### PR TITLE
Inline verse picker warnings

### DIFF
--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -178,9 +178,9 @@
               <td class="td-reference">
                 <div class="reference-cell">
                   <button
+                    *ngIf="editingCardId !== card.card_id"
                     class="reference-button"
                     (click)="toggleCardEdit(card.card_id)"
-                    [class.active]="editingCardId === card.card_id"
                   >
                     <span class="reference-text">{{ card.reference }}</span>
                     <svg
@@ -188,7 +188,6 @@
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
-                      [class.rotated]="editingCardId === card.card_id"
                     >
                       <path
                         stroke-linecap="round"
@@ -207,6 +206,7 @@
                     [pageType]="'flashcard'"
                     [maximumVerses]="7"
                     [warningMessage]="pickerWarnings[card.card_id]"
+                    [initialSelection]="getCardSelection(card)"
                     (selectionApplied)="applyVerseSelection(card, $event)"
                   >
                   </app-verse-picker>
@@ -368,9 +368,7 @@
               d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
             />
           </svg>
-          {{ selectedCards.size }} card{{
-            selectedCards.size !== 1 ? "s" : ""
-          }}
+          {{ selectedCards.size }} card{{ selectedCards.size !== 1 ? "s" : "" }}
           selected
         </div>
         <button class="bulk-action-button" (click)="removeSelectedCards()">

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -94,10 +94,7 @@
 
   <!-- Cards Tab with Table Design -->
   <div *ngIf="!isLoading && editMode === 'verses'" class="tab-content">
-    <div
-      class="cards-table-section"
-      [class.has-open-dropdown]="editingCardId !== null"
-    >
+    <div class="cards-table-section">
       <div class="section-header">
         <h2>Deck Cards</h2>
         <div class="header-stats">
@@ -164,7 +161,6 @@
             <tr
               *ngFor="let card of deckCards; let i = index"
               [class.selected]="selectedCards.has(card.card_id)"
-              [class.editing]="editingCardId === card.card_id"
             >
               <td class="td-checkbox">
                 <input
@@ -177,29 +173,7 @@
 
               <td class="td-reference">
                 <div class="reference-cell">
-                  <button
-                    *ngIf="editingCardId !== card.card_id"
-                    class="reference-button"
-                    (click)="toggleCardEdit(card.card_id)"
-                  >
-                    <span class="reference-text">{{ card.reference }}</span>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </button>
-
                   <app-verse-picker
-                    *ngIf="editingCardId === card.card_id"
                     class="inline-picker"
                     [theme]="'minimal'"
                     [disabledModes]="['chapter']"

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -3,16 +3,31 @@
   <!-- Header -->
   <div class="editor-header">
     <button class="back-button" (click)="goBack()">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M10 19l-7-7m0 0l7-7m-7 7h18"
+        />
       </svg>
       Back to Decks
     </button>
-    
+
     <h1 class="editor-title">Edit Deck: {{ deck?.name }}</h1>
-    
+
     <div class="header-actions">
-      <button class="save-button" (click)="updateDeckInfo()" *ngIf="editMode === 'info'" [disabled]="isSaving">
+      <button
+        class="save-button"
+        (click)="updateDeckInfo()"
+        *ngIf="editMode === 'info'"
+        [disabled]="isSaving"
+      >
         <span *ngIf="!isSaving">Save Info</span>
         <span *ngIf="isSaving">Saving...</span>
       </button>
@@ -21,16 +36,18 @@
 
   <!-- Tab Navigation -->
   <div class="tab-navigation">
-    <button 
-      class="tab-button" 
+    <button
+      class="tab-button"
       [class.active]="editMode === 'verses'"
-      (click)="editMode = 'verses'">
+      (click)="editMode = 'verses'"
+    >
       Manage Cards
     </button>
-    <button 
+    <button
       class="tab-button"
       [class.active]="editMode === 'info'"
-      (click)="editMode = 'info'">
+      (click)="editMode = 'info'"
+    >
       Deck Settings
     </button>
   </div>
@@ -46,29 +63,29 @@
     <div class="form-section">
       <div class="form-group">
         <label for="deck-name">Deck Name</label>
-        <input 
+        <input
           id="deck-name"
-          type="text" 
-          [(ngModel)]="deckName" 
+          type="text"
+          [(ngModel)]="deckName"
           placeholder="Enter deck name..."
-          class="form-control">
+          class="form-control"
+        />
       </div>
 
       <div class="form-group">
         <label for="deck-description">Description</label>
-        <textarea 
+        <textarea
           id="deck-description"
-          [(ngModel)]="deckDescription" 
+          [(ngModel)]="deckDescription"
           placeholder="Enter deck description..."
           rows="4"
-          class="form-control"></textarea>
+          class="form-control"
+        ></textarea>
       </div>
 
       <div class="form-group">
         <label class="checkbox-label">
-          <input 
-            type="checkbox" 
-            [(ngModel)]="isDeckPublic">
+          <input type="checkbox" [(ngModel)]="isDeckPublic" />
           <span>Make this deck public</span>
         </label>
       </div>
@@ -77,19 +94,42 @@
 
   <!-- Cards Tab with Table Design -->
   <div *ngIf="!isLoading && editMode === 'verses'" class="tab-content">
-    <div class="cards-table-section" [class.has-open-dropdown]="editingCardId !== null">
+    <div
+      class="cards-table-section"
+      [class.has-open-dropdown]="editingCardId !== null"
+    >
       <div class="section-header">
         <h2>Deck Cards</h2>
         <div class="header-stats">
           <span class="stat-badge">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+              />
             </svg>
             {{ deckCards.length }} cards
           </span>
           <span class="stat-badge">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
             </svg>
             {{ getTotalVerseCount() }} verses
           </span>
@@ -102,11 +142,15 @@
           <thead>
             <tr>
               <th class="th-checkbox">
-                <input 
-                  type="checkbox" 
-                  [checked]="selectedCards.size === deckCards.length && deckCards.length > 0"
+                <input
+                  type="checkbox"
+                  [checked]="
+                    selectedCards.size === deckCards.length &&
+                    deckCards.length > 0
+                  "
                   (change)="toggleAllCards($event)"
-                  class="table-checkbox">
+                  class="table-checkbox"
+                />
               </th>
               <th class="th-reference">Reference</th>
               <th class="th-book">Book</th>
@@ -117,115 +161,191 @@
             </tr>
           </thead>
           <tbody>
-            <tr *ngFor="let card of deckCards; let i = index" 
-                [class.selected]="selectedCards.has(card.card_id)"
-                [class.editing]="editingCardId === card.card_id">
+            <tr
+              *ngFor="let card of deckCards; let i = index"
+              [class.selected]="selectedCards.has(card.card_id)"
+              [class.editing]="editingCardId === card.card_id"
+            >
               <td class="td-checkbox">
-                <input 
-                  type="checkbox" 
+                <input
+                  type="checkbox"
                   [checked]="selectedCards.has(card.card_id)"
                   (change)="toggleCardSelection(card.card_id)"
-                  class="table-checkbox">
+                  class="table-checkbox"
+                />
               </td>
-              
+
               <td class="td-reference">
                 <div class="reference-cell">
-                  <button 
+                  <button
                     class="reference-button"
                     (click)="toggleCardEdit(card.card_id)"
-                    [class.active]="editingCardId === card.card_id">
+                    [class.active]="editingCardId === card.card_id"
+                  >
                     <span class="reference-text">{{ card.reference }}</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" 
-                         [class.rotated]="editingCardId === card.card_id">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      [class.rotated]="editingCardId === card.card_id"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 9l-7 7-7-7"
+                      />
                     </svg>
                   </button>
-                  
-                  <!-- Dropdown Verse Picker -->
-                  <div class="dropdown-wrapper" *ngIf="editingCardId === card.card_id">
-                    <!-- Click backdrop to close -->
-                    <div class="dropdown-backdrop" (click)="editingCardId = null"></div>
-                    <div class="dropdown-container" (click)="$event.stopPropagation()" [attr.data-card-index]="i">
-                      <app-verse-picker 
-                        [theme]="'minimal'"
-                        [disabledModes]="['chapter']"
-                        [pageType]="'flashcard'"
-                        [maximumVerses]="7"
-                        (selectionChanged)="updateCardVerses(card, $event)">
-                      </app-verse-picker>
-                    </div>
-                  </div>
+
+                  <app-verse-picker
+                    *ngIf="editingCardId === card.card_id"
+                    class="inline-picker"
+                    [theme]="'minimal'"
+                    [disabledModes]="['chapter']"
+                    [pageType]="'flashcard'"
+                    [maximumVerses]="7"
+                    [warningMessage]="pickerWarnings[card.card_id]"
+                    (selectionApplied)="applyVerseSelection(card, $event)"
+                  >
+                  </app-verse-picker>
                 </div>
               </td>
-              
+
               <td class="td-book">
                 <span class="book-name">{{ getCardBook(card) }}</span>
               </td>
-              
+
               <td class="td-type">
                 <span class="type-badge" [class]="card.card_type">
-                  {{ card.card_type === 'single_verse' ? 'Single' : 'Range' }}
+                  {{ card.card_type === "single_verse" ? "Single" : "Range" }}
                 </span>
               </td>
-              
+
               <td class="td-verses">
                 <span class="verse-count">{{ card.verses.length }}</span>
               </td>
-              
+
               <td class="td-confidence">
                 <div class="confidence-display">
                   <div class="confidence-bar">
-                    <div class="confidence-fill" [style.width.%]="card.confidence_score || 0"></div>
+                    <div
+                      class="confidence-fill"
+                      [style.width.%]="card.confidence_score || 0"
+                    ></div>
                   </div>
-                  <span class="confidence-value">{{ card.confidence_score || 0 }}%</span>
+                  <span class="confidence-value"
+                    >{{ card.confidence_score || 0 }}%</span
+                  >
                 </div>
               </td>
-              
+
               <td class="td-actions">
                 <div class="action-buttons">
-                  <button 
+                  <button
                     class="action-btn duplicate"
                     (click)="duplicateCard(card)"
-                    title="Duplicate card">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    title="Duplicate card"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
                     </svg>
                   </button>
-                  <button 
+                  <button
                     class="action-btn delete"
                     (click)="removeCardFromDeck(card.card_id)"
-                    title="Delete card">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    title="Delete card"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
                     </svg>
                   </button>
                 </div>
               </td>
             </tr>
-            
+
             <!-- Empty State Row -->
             <tr *ngIf="deckCards.length === 0" class="empty-row">
               <td colspan="7" class="empty-cell">
                 <div class="empty-state-inline">
-                  <svg class="empty-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <rect x="5" y="3" width="14" height="18" rx="2" stroke="currentColor" stroke-width="2"/>
-                    <line x1="9" y1="8" x2="15" y2="8" stroke="currentColor" stroke-width="2"/>
-                    <line x1="9" y1="12" x2="15" y2="12" stroke="currentColor" stroke-width="2"/>
+                  <svg
+                    class="empty-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect
+                      x="5"
+                      y="3"
+                      width="14"
+                      height="18"
+                      rx="2"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    />
+                    <line
+                      x1="9"
+                      y1="8"
+                      x2="15"
+                      y2="8"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    />
+                    <line
+                      x1="9"
+                      y1="12"
+                      x2="15"
+                      y2="12"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    />
                   </svg>
-                  <p>No cards in this deck yet. Click the button below to add your first card.</p>
+                  <p>
+                    No cards in this deck yet. Click the button below to add
+                    your first card.
+                  </p>
                 </div>
               </td>
             </tr>
           </tbody>
         </table>
-        
+
         <!-- Add New Card Row -->
         <div class="add-card-section">
-          <button 
-            class="add-card-button"
-            (click)="addNewCard()">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          <button class="add-card-button" (click)="addNewCard()">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+              />
             </svg>
             Add New Card
           </button>
@@ -235,16 +355,37 @@
       <!-- Bulk Actions -->
       <div class="bulk-actions" *ngIf="selectedCards.size > 0">
         <div class="selection-info">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
           </svg>
-          {{ selectedCards.size }} card{{ selectedCards.size !== 1 ? 's' : '' }} selected
+          {{ selectedCards.size }} card{{
+            selectedCards.size !== 1 ? "s" : ""
+          }}
+          selected
         </div>
-        <button 
-          class="bulk-action-button"
-          (click)="removeSelectedCards()">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        <button class="bulk-action-button" (click)="removeSelectedCards()">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
           </svg>
           Remove Selected
         </button>

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
@@ -1,32 +1,8 @@
-// When editing a card, ensure proper layering
-.cards-table tbody tr.editing {
-  position: relative;
-  z-index: 500 !important; // High z-index for the editing row
-  
-  .reference-cell {
-    position: relative;
-    z-index: 501 !important; // Even higher for the cell with dropdown
-  }
-}// Global style to prevent clipping when dropdown is open
-body:has(.dropdown-container) {
-  overflow-x: hidden; // Prevent horizontal scroll
-  
-  // Ensure all parent containers allow overflow
-  .deck-editor-container,
-  .tab-content,
-  .cards-table-section,
-  .cards-table-container {
-    overflow: visible !important;
-  }
-}.td-reference {
-  position: relative;
-  overflow: visible !important; // Force overflow visible
-}// frontend/src/app/deck-editor/deck-editor.component.scss
 .deck-editor-container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 1rem;
-  padding-bottom: 300px; // Extra space for dropdown at bottom of page
+  padding-bottom: 300px; // Extra space for picker overlays at bottom of page
   min-height: 100vh;
 }
 
@@ -123,7 +99,7 @@ body:has(.dropdown-container) {
     font-weight: 600;
 
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       bottom: -2px;
       left: 0;
@@ -153,7 +129,9 @@ body:has(.dropdown-container) {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 // Tab Content
@@ -162,7 +140,7 @@ body:has(.dropdown-container) {
   border-radius: 0.5rem;
   padding: 2rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  overflow: visible; // Ensure dropdowns can overflow
+  overflow: visible; // Allow pickers to overflow
 }
 
 // Form Section
@@ -219,15 +197,8 @@ textarea.form-control {
 // Cards Table Section
 .cards-table-section {
   margin-bottom: 2rem;
-  position: relative; // For dropdown positioning context
-  
-  // Ensure dropdowns can overflow
+  position: relative;
   overflow: visible;
-  
-  // When dropdown is open, ensure proper z-index layering
-  &.has-open-dropdown {
-    z-index: 100;
-  }
 }
 
 .section-header {
@@ -272,7 +243,7 @@ textarea.form-control {
   background: white;
   border-radius: 0.75rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  // Removed overflow: hidden to allow dropdown to show outside container
+  // Allow pickers to overflow
 }
 
 // Table Styles
@@ -320,27 +291,18 @@ textarea.form-control {
   }
 }
 
-// When editing a card, ensure proper layering
-.cards-table tbody tr.editing {
-  position: relative;
-  z-index: 500 !important; // High z-index for the editing row
-  
-  .reference-cell {
-    position: relative;
-    z-index: 501 !important; // Even higher for the cell with dropdown
-  }
-}
-
 // Table column widths
-.th-checkbox, .td-checkbox {
+.th-checkbox,
+.td-checkbox {
   width: 40px;
   text-align: center;
 }
 
-.th-reference, .td-reference {
+.th-reference,
+.td-reference {
   width: 30%;
   position: relative;
-  overflow: visible; // Allow dropdown to overflow
+  overflow: visible; // Allow picker overlay to escape
 }
 
 .th-book {
@@ -371,107 +333,6 @@ textarea.form-control {
   cursor: pointer;
   width: 16px;
   height: 16px;
-}
-
-// Reference cell with dropdown
-.reference-cell {
-  position: relative;
-  z-index: auto;
-  
-  // When dropdown is open, increase z-index
-  &:has(.dropdown-wrapper) {
-    z-index: 1001;
-  }
-}
-
-.reference-button {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0.5rem;
-  margin: -0.5rem;
-  border-radius: 0.375rem;
-  transition: all 0.2s;
-  width: 100%;
-  text-align: left;
-
-  &:hover {
-    background-color: #f3f4f6;
-  }
-
-  &.active {
-    background-color: #eff6ff;
-    color: #3b82f6;
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
-    color: #6b7280;
-    transition: transform 0.2s;
-
-    &.rotated {
-      transform: rotate(180deg);
-    }
-  }
-}
-
-.reference-text {
-  font-weight: 500;
-  color: #1f2937;
-}
-
-// Dropdown wrapper and container
-.dropdown-wrapper {
-  position: static; // Important: don't create a new positioning context
-}
-
-.dropdown-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 999;
-  background: rgba(0, 0, 0, 0.1);
-}
-
-.dropdown-container {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  left: 0;
-  z-index: 1000;
-  min-width: 400px;
-  max-width: min(90vw, 600px);
-  
-  // Add max height and scroll if needed
-  max-height: min(500px, calc(100vh - 200px));
-  overflow-y: auto;
-  overflow-x: hidden;
-  
-  // Style the verse picker within
-  app-verse-picker {
-    display: block;
-    position: relative;
-    z-index: 1002;
-    
-    // Override the verse picker's minimal theme to add proper styling
-    ::ng-deep .verse-picker {
-      background: white !important;
-      border-radius: 0.5rem !important;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15) !important;
-      border: 1px solid #e5e7eb !important;
-      padding: 1rem !important;
-      position: relative !important;
-      z-index: 1003 !important;
-    }
-  }
-  
-  // If near bottom of viewport, open upwards
-  &.dropup {
-    top: auto;
-    bottom: calc(100% + 0.5rem);
-  }
 }
 
 // Book name
@@ -675,7 +536,7 @@ textarea.form-control {
   align-items: center;
   justify-content: space-between;
   box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1);
-  z-index: 50; // Lower than dropdown z-index (1000)
+  z-index: 50; // Keep bulk actions above table rows
 }
 
 .selection-info {
@@ -736,26 +597,5 @@ textarea.form-control {
 
   .cards-table {
     min-width: 700px;
-  }
-
-  .dropdown-container {
-    position: fixed;
-    left: 1rem !important;
-    right: 1rem !important;
-    top: 50% !important;
-    transform: translateY(-50%);
-    max-width: none;
-    min-width: auto;
-    width: auto;
-  }
-}
-
-// Global style to prevent clipping when dropdown is open
-:host-context(body):has(.dropdown-container) {
-  .deck-editor-container,
-  .tab-content,
-  .cards-table-section,
-  .cards-table-container {
-    overflow: visible !important;
   }
 }

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
@@ -39,9 +39,6 @@ export class DeckEditorComponent implements OnInit {
   deckDescription = '';
   isDeckPublic = false;
 
-  // Card editing state
-  editingCardId: number | null = null;
-
   // Selected cards for bulk operations
   selectedCards: Set<number> = new Set();
 
@@ -141,23 +138,7 @@ export class DeckEditorComponent implements OnInit {
     });
   }
 
-  // Card editing methods
-  toggleCardEdit(cardId: number) {
-    this.editingCardId = this.editingCardId === cardId ? null : cardId;
-    this.pickerWarnings[cardId] = '';
-
-    // If opening, calculate dropdown position after DOM update
-    if (this.editingCardId === cardId) {
-      setTimeout(() => {
-        this.calculateDropdownPosition(cardId);
-      }, 0);
-    }
-  }
-
-  calculateDropdownPosition(cardId: number) {
-    // This method can be used to calculate if dropdown should open up or down
-    // based on available space. For now, we'll rely on CSS positioning.
-  }
+  // Card selection helpers
 
   getCardSelection(card: CardWithVerses): VerseSelection | null {
     if (!card.verses || card.verses.length === 0) return null;
@@ -223,7 +204,6 @@ export class DeckEditorComponent implements OnInit {
         .subscribe({
           next: () => {
             this.loadDeckCards();
-            this.editingCardId = null;
             this.modalService.success(
               'Card Added',
               'The card has been added successfully.',
@@ -267,7 +247,6 @@ export class DeckEditorComponent implements OnInit {
           .subscribe({
             next: () => {
               this.loadDeckCards();
-              this.editingCardId = null;
               this.modalService.success(
                 'Card Updated',
                 'The card has been updated successfully.',
@@ -328,7 +307,6 @@ export class DeckEditorComponent implements OnInit {
     };
 
     this.deckCards.push(newCard);
-    this.editingCardId = tempCardId;
   }
 
   // Duplicate card
@@ -390,9 +368,6 @@ export class DeckEditorComponent implements OnInit {
     // If it's a temporary card (negative ID), just remove from array
     if (cardId < 0) {
       this.deckCards = this.deckCards.filter((c) => c.card_id !== cardId);
-      if (this.editingCardId === cardId) {
-        this.editingCardId = null;
-      }
       return;
     }
 
@@ -400,9 +375,6 @@ export class DeckEditorComponent implements OnInit {
       next: () => {
         this.deckCards = this.deckCards.filter((c) => c.card_id !== cardId);
         this.selectedCards.delete(cardId);
-        if (this.editingCardId === cardId) {
-          this.editingCardId = null;
-        }
         this.modalService.success(
           'Card Removed',
           'The card has been removed from the deck.',

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
@@ -159,7 +159,6 @@ export class DeckEditorComponent implements OnInit {
     // based on available space. For now, we'll rely on CSS positioning.
   }
 
-  // Note: This method is for future use when VersePickerComponent supports initialSelection
   getCardSelection(card: CardWithVerses): VerseSelection | null {
     if (!card.verses || card.verses.length === 0) return null;
 

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
@@ -46,7 +46,11 @@
       </div>
 
       <!-- Expanded Content -->
-      <div class="expanded-content" [ngClass]="{ show: isOpen }">
+      <div
+        class="expanded-content"
+        [ngClass]="{ show: isOpen }"
+        (click)="$event.stopPropagation()"
+      >
         <div class="content-divider"></div>
         <div class="controls-container">
           <!-- Mode Selection -->

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
@@ -1,49 +1,73 @@
 <!-- frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html -->
 <div class="verse-picker hover-reveal" [ngClass]="'theme-' + theme">
-  <div 
-    class="hover-container"
-    (mouseenter)="handleMouseEnter()"
-    (mouseleave)="handleMouseLeave()">
-    
+  <div class="hover-container">
     <!-- Compact Preview -->
-    <div class="compact-preview" [ngClass]="{'hovered': isHovered, 'expanded': isHovered}">
+    <div
+      class="compact-preview"
+      [ngClass]="{ hovered: isOpen, expanded: isOpen }"
+      (click)="toggleOpen()"
+    >
       <div class="preview-content">
-        <svg class="icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        <svg
+          class="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+          />
         </svg>
         <div class="preview-info">
           <div class="reference-text">{{ getDisplayReference() }}</div>
-          <div class="verse-meta">{{ verseCount }} verses • {{ getModeLabel() }} mode</div>
+          <div class="verse-meta">
+            {{ verseCount }} verses • {{ getModeLabel() }} mode
+          </div>
         </div>
-        <div class="expand-indicator" [ngClass]="{'visible': isHovered}">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        <div class="expand-indicator" [ngClass]="{ visible: isOpen }">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
           </svg>
         </div>
       </div>
 
       <!-- Expanded Content -->
-      <div class="expanded-content" [ngClass]="{'show': isHovered}">
+      <div class="expanded-content" [ngClass]="{ show: isOpen }">
         <div class="content-divider"></div>
         <div class="controls-container">
-          
           <!-- Mode Selection -->
           <div class="mode-selector-inline">
-            <button 
+            <button
               *ngFor="let modeOption of availableModes"
               [ngClass]="getModeButtonClass(modeOption)"
               (click)="onModeChange(modeOption)"
-              [disabled]="isModeDisabled(modeOption)">
+              [disabled]="isModeDisabled(modeOption)"
+            >
               {{ getModeLabel(modeOption) }}
             </button>
           </div>
 
           <!-- Book Selector -->
           <div class="book-selector">
-            <select 
-              [(ngModel)]="selectedBook" 
+            <select
+              [(ngModel)]="selectedBook"
               (ngModelChange)="onBookChange()"
-              class="select-control book-select">
+              class="select-control book-select"
+            >
               <option *ngFor="let book of books" [ngValue]="book">
                 {{ book.name }}
               </option>
@@ -54,24 +78,28 @@
           <div class="verse-inputs">
             <!-- Start/Single Selection -->
             <div class="input-group">
-              <label class="input-label">{{ mode === 'range' ? 'Start' : 'Select' }}</label>
+              <label class="input-label">{{
+                mode === "range" ? "Start" : "Select"
+              }}</label>
               <div class="input-row">
-                <input 
-                  type="number" 
+                <input
+                  type="number"
                   [(ngModel)]="selectedChapter"
                   (ngModelChange)="onChapterChange()"
                   class="number-input"
                   [min]="1"
-                  [max]="chapters.length">
+                  [max]="chapters.length"
+                />
                 <span class="separator" *ngIf="mode !== 'chapter'">:</span>
-                <input 
+                <input
                   *ngIf="mode !== 'chapter'"
-                  type="number" 
+                  type="number"
                   [(ngModel)]="selectedVerse"
                   (ngModelChange)="onVerseChange()"
                   class="number-input"
                   [min]="1"
-                  [max]="verses.length">
+                  [max]="verses.length"
+                />
               </div>
             </div>
 
@@ -79,21 +107,27 @@
             <div class="input-group" *ngIf="mode === 'range'">
               <label class="input-label">End</label>
               <div class="input-row">
-                <input 
-                  type="number" 
+                <input
+                  type="number"
                   [(ngModel)]="selectedEndChapter"
                   (ngModelChange)="onEndChapterChange()"
                   class="number-input"
                   [min]="selectedChapter"
-                  [max]="chapters.length">
+                  [max]="chapters.length"
+                />
                 <span class="separator">:</span>
-                <input 
-                  type="number" 
+                <input
+                  type="number"
                   [(ngModel)]="selectedEndVerse"
                   (ngModelChange)="onEndVerseChange()"
                   class="number-input"
-                  [min]="mode === 'range' && selectedEndChapter === selectedChapter ? selectedVerse : 1"
-                  [max]="endVerses.length">
+                  [min]="
+                    mode === 'range' && selectedEndChapter === selectedChapter
+                      ? selectedVerse
+                      : 1
+                  "
+                  [max]="endVerses.length"
+                />
               </div>
             </div>
           </div>
@@ -104,17 +138,61 @@
           </button>
 
           <!-- Validation Message -->
-          <div class="validation-message" *ngIf="!isValidSelection && validationMessage">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          <div
+            class="validation-message"
+            *ngIf="!isValidSelection && validationMessage"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
             </svg>
             {{ validationMessage }}
           </div>
 
+          <!-- External Warning Message -->
+          <div class="validation-message" *ngIf="warningMessage">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            {{ warningMessage }}
+          </div>
+
           <!-- Page-specific message for FLOW -->
-          <div class="page-message flow-message" *ngIf="pageType === 'FLOW' && mode === 'range'">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          <div
+            class="page-message flow-message"
+            *ngIf="pageType === 'FLOW' && mode === 'range'"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
             FLOW method works best with 10-80 verses
           </div>

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
@@ -1,11 +1,13 @@
 // frontend/src/app/components/verse-range-picker/verse-picker.component.scss
 
 .verse-picker.hover-reveal {
-  display: inline-block;
+  display: block;
+  width: 100%;
 }
 
 .hover-container {
-  display: inline-block;
+  display: block;
+  position: relative;
 }
 
 // Compact Preview
@@ -14,10 +16,12 @@
   border: 2px solid #e5e7eb;
   border-radius: 0.5rem;
   transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-  
+
   &.hovered {
     border-color: #3b82f6;
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow:
+      0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
 }
 
@@ -55,11 +59,11 @@
   margin-left: 1rem;
   transition: opacity 300ms;
   opacity: 0.5;
-  
+
   &.visible {
     opacity: 1;
   }
-  
+
   svg {
     width: 1rem;
     height: 1rem;
@@ -69,14 +73,24 @@
 
 // Expanded Content
 .expanded-content {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.5rem);
+  z-index: 1000;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
   overflow: hidden;
-  transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-  max-height: 0;
+  transition:
+    opacity 300ms,
+    transform 300ms;
   opacity: 0;
-  
+  transform: translateY(-10px);
+
   &.show {
-    max-height: 24rem;
     opacity: 1;
+    transform: translateY(0);
   }
 }
 
@@ -107,16 +121,16 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 200ms;
-  
+
   &:hover:not(:disabled) {
     background-color: #e5e7eb;
   }
-  
+
   &.active {
     background-color: #dbeafe;
     color: #1e40af;
   }
-  
+
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -138,11 +152,11 @@
   color: #111827;
   cursor: pointer;
   transition: all 200ms;
-  
+
   &:hover {
     border-color: #9ca3af;
   }
-  
+
   &:focus {
     outline: none;
     border-color: #3b82f6;
@@ -186,19 +200,19 @@
   text-align: center;
   font-size: 0.875rem;
   background-color: white;
-  
+
   &:focus {
     outline: none;
     border-color: #3b82f6;
   }
-  
+
   // Hide number input arrows
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
-  
+
   -moz-appearance: textfield;
 }
 
@@ -219,11 +233,11 @@
   font-weight: 500;
   cursor: pointer;
   transition: background-color 200ms;
-  
+
   &:hover {
     background-color: #2563eb;
   }
-  
+
   &:active {
     background-color: #1d4ed8;
   }
@@ -241,7 +255,7 @@
   border: 1px solid #fbbf24;
   border-radius: 0.375rem;
   font-size: 0.75rem;
-  
+
   svg {
     width: 1rem;
     height: 1rem;
@@ -258,13 +272,13 @@
   padding: 0.5rem 0.75rem;
   border-radius: 0.375rem;
   font-size: 0.75rem;
-  
+
   svg {
     width: 1rem;
     height: 1rem;
     flex-shrink: 0;
   }
-  
+
   &.flow-message {
     background-color: #dbeafe;
     color: #1e40af;
@@ -276,25 +290,27 @@
 .theme-minimal {
   .compact-preview {
     border: 1px solid #e5e7eb;
-    
+
     &.hovered {
       border-color: #6b7280;
-      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+      box-shadow:
+        0 4px 6px -1px rgba(0, 0, 0, 0.1),
+        0 2px 4px -1px rgba(0, 0, 0, 0.06);
     }
   }
-  
+
   .icon {
     color: #6b7280;
   }
-  
+
   .mode-button.active {
     background-color: #374151;
     color: white;
   }
-  
+
   .apply-button {
     background-color: #374151;
-    
+
     &:hover {
       background-color: #1f2937;
     }
@@ -306,82 +322,82 @@
     background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 100%);
     border: 2px solid #00ff41;
     color: #00ff41;
-    
+
     &.hovered {
       border-color: #00ff41;
       box-shadow: 0 0 20px rgba(0, 255, 65, 0.5);
     }
   }
-  
+
   .reference-text {
     color: #00ff41;
   }
-  
+
   .verse-meta {
     color: #00ff41;
     opacity: 0.7;
   }
-  
+
   .icon {
     color: #00ff41;
   }
-  
+
   .expand-indicator svg {
     color: #00ff41;
   }
-  
+
   .expanded-content {
     background: #0f0f23;
   }
-  
+
   .content-divider {
     background-color: rgba(0, 255, 65, 0.3);
   }
-  
+
   .mode-button {
     background-color: rgba(0, 255, 65, 0.1);
     color: #00ff41;
     border: 1px solid rgba(0, 255, 65, 0.3);
-    
+
     &:hover:not(:disabled) {
       background-color: rgba(0, 255, 65, 0.2);
     }
-    
+
     &.active {
       background-color: #00ff41;
       color: #0f0f23;
     }
   }
-  
+
   .select-control,
   .number-input {
     background-color: rgba(0, 255, 65, 0.05);
     border-color: rgba(0, 255, 65, 0.3);
     color: #00ff41;
-    
+
     &:focus {
       border-color: #00ff41;
       box-shadow: 0 0 0 3px rgba(0, 255, 65, 0.1);
     }
   }
-  
+
   .input-group {
     background-color: rgba(0, 255, 65, 0.05);
   }
-  
+
   .input-label {
     color: #00ff41;
     opacity: 0.7;
   }
-  
+
   .separator {
     color: #00ff41;
   }
-  
+
   .apply-button {
     background-color: #00ff41;
     color: #0f0f23;
-    
+
     &:hover {
       background-color: #00cc33;
     }
@@ -393,7 +409,7 @@
   .verse-inputs {
     grid-template-columns: 1fr;
   }
-  
+
   .expanded-content.show {
     max-height: 32rem;
   }

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -41,6 +41,9 @@ export class VersePickerComponent implements OnInit {
   @Output() selectionApplied = new EventEmitter<VerseSelection>();
 
   @Input() warningMessage: string | null = null;
+  @Input() initialSelection: VerseSelection | null = null;
+
+  private appliedInitial = false;
 
   mode: 'single' | 'range' | 'chapter' = 'range';
 
@@ -168,8 +171,16 @@ export class VersePickerComponent implements OnInit {
     this.books = bibleData.books;
 
     if (this.books.length > 0) {
-      this.selectedBook = this.books[0];
+      if (this.initialSelection) {
+        const book = this.books.find(
+          (b) => b.id === this.initialSelection!.startVerse.bookId,
+        );
+        this.selectedBook = book || this.books[0];
+      } else {
+        this.selectedBook = this.books[0];
+      }
       this.loadChapters();
+      this.applyInitialSelection();
     }
   }
 
@@ -269,6 +280,25 @@ export class VersePickerComponent implements OnInit {
   }
 
   onEndVerseChange() {
+    this.emitSelection();
+  }
+
+  private applyInitialSelection() {
+    if (!this.initialSelection || this.appliedInitial) return;
+
+    const sel = this.initialSelection;
+    this.mode = sel.mode;
+    this.selectedChapter = sel.startVerse.chapter;
+    this.selectedVerse = sel.startVerse.verse;
+    this.selectedEndChapter = sel.endVerse
+      ? sel.endVerse.chapter
+      : sel.startVerse.chapter;
+    this.selectedEndVerse = sel.endVerse
+      ? sel.endVerse.verse
+      : sel.startVerse.verse;
+
+    this.loadVerses();
+    this.appliedInitial = true;
     this.emitSelection();
   }
 

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -27,7 +27,7 @@ export interface VerseSelection {
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './verse-picker.component.html',
-  styleUrls: ['./verse-picker.component.scss']
+  styleUrls: ['./verse-picker.component.scss'],
 })
 export class VersePickerComponent implements OnInit {
   @Input() theme: 'enhanced' | 'minimal' | 'cyberpunk' = 'enhanced';
@@ -36,24 +36,30 @@ export class VersePickerComponent implements OnInit {
   @Input() maximumVerses = 0; // 0 means no maximum
   @Input() disabledModes: ('single' | 'range' | 'chapter')[] = [];
   @Input() pageType: 'FLOW' | 'flashcard' | 'general' = 'general';
-  
+
   @Output() selectionChanged = new EventEmitter<VerseSelection>();
+  @Output() selectionApplied = new EventEmitter<VerseSelection>();
+
+  @Input() warningMessage: string | null = null;
 
   mode: 'single' | 'range' | 'chapter' = 'range';
-  
+
   userId = 1;
-  
-  // Hover state
-  isHovered = false;
-  hoverTimeout: any;
-  
+
+  // Open state
+  isOpen = false;
+
   // Available options
   books: any[] = [];
   chapters: number[] = [];
   verses: number[] = [];
   endChapters: number[] = [];
   endVerses: number[] = [];
-  availableModes: ('single' | 'range' | 'chapter')[] = ['single', 'range', 'chapter'];
+  availableModes: ('single' | 'range' | 'chapter')[] = [
+    'single',
+    'range',
+    'chapter',
+  ];
 
   // Selected values
   selectedBook: any = null;
@@ -69,15 +75,17 @@ export class VersePickerComponent implements OnInit {
 
   constructor(
     private bibleService: BibleService,
-    private userService: UserService
+    private userService: UserService,
   ) {}
 
   ngOnInit() {
     this.loadBooks();
-    
+
     // Filter available modes
-    this.availableModes = this.availableModes.filter(m => !this.disabledModes.includes(m));
-    
+    this.availableModes = this.availableModes.filter(
+      (m) => !this.disabledModes.includes(m),
+    );
+
     // Set default mode based on disabled modes
     if (this.disabledModes.includes(this.mode)) {
       // Find first available mode
@@ -86,43 +94,39 @@ export class VersePickerComponent implements OnInit {
         this.mode = availableMode;
       }
     }
-    
+
     // Get user ID
-    this.userService.currentUser$.subscribe(user => {
+    this.userService.currentUser$.subscribe((user) => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
       }
     });
-    
+
     // Emit initial selection
     setTimeout(() => {
       this.emitSelection();
     }, 100);
   }
 
-  // Hover handling
-  handleMouseEnter() {
-    clearTimeout(this.hoverTimeout);
-    this.isHovered = true;
-  }
-
-  handleMouseLeave() {
-    this.hoverTimeout = setTimeout(() => {
-      this.isHovered = false;
-    }, 300);
+  // Open handling
+  toggleOpen() {
+    this.isOpen = !this.isOpen;
   }
 
   // Display helpers
   getDisplayReference(): string {
     if (!this.selectedBook) return 'Select verses';
-    
+
     let reference = `${this.selectedBook.name} ${this.selectedChapter}`;
-    
+
     if (this.mode === 'single') {
       reference += `:${this.selectedVerse}`;
     } else if (this.mode === 'range') {
       reference += `:${this.selectedVerse}`;
-      if (this.selectedEndChapter !== this.selectedChapter || this.selectedEndVerse !== this.selectedVerse) {
+      if (
+        this.selectedEndChapter !== this.selectedChapter ||
+        this.selectedEndVerse !== this.selectedVerse
+      ) {
         if (this.selectedEndChapter === this.selectedChapter) {
           reference += `-${this.selectedEndVerse}`;
         } else {
@@ -130,17 +134,21 @@ export class VersePickerComponent implements OnInit {
         }
       }
     }
-    
+
     return reference;
   }
 
   getModeLabel(mode?: 'single' | 'range' | 'chapter'): string {
     const modeToCheck = mode || this.mode;
     switch (modeToCheck) {
-      case 'single': return 'Single';
-      case 'range': return 'Range';
-      case 'chapter': return 'Chapter';
-      default: return '';
+      case 'single':
+        return 'Single';
+      case 'range':
+        return 'Range';
+      case 'chapter':
+        return 'Chapter';
+      default:
+        return '';
     }
   }
 
@@ -158,7 +166,7 @@ export class VersePickerComponent implements OnInit {
   loadBooks() {
     const bibleData = this.bibleService.getBibleData();
     this.books = bibleData.books;
-    
+
     if (this.books.length > 0) {
       this.selectedBook = this.books[0];
       this.loadChapters();
@@ -176,7 +184,10 @@ export class VersePickerComponent implements OnInit {
 
   loadChapters() {
     if (this.selectedBook) {
-      this.chapters = Array.from({length: this.selectedBook.chapters.length}, (_, i) => i + 1);
+      this.chapters = Array.from(
+        { length: this.selectedBook.chapters.length },
+        (_, i) => i + 1,
+      );
       this.endChapters = [...this.chapters];
       this.loadVerses();
     }
@@ -185,28 +196,34 @@ export class VersePickerComponent implements OnInit {
   onChapterChange() {
     this.loadVerses();
     this.selectedVerse = 1;
-    
+
     if (this.mode === 'range') {
       // Auto-adjust if end chapter is before start chapter
       if (this.selectedEndChapter < this.selectedChapter) {
         this.selectedEndChapter = this.selectedChapter;
         this.selectedEndVerse = this.selectedVerse;
-      } else if (this.selectedEndChapter === this.selectedChapter && this.selectedEndVerse < this.selectedVerse) {
+      } else if (
+        this.selectedEndChapter === this.selectedChapter &&
+        this.selectedEndVerse < this.selectedVerse
+      ) {
         this.selectedEndVerse = this.selectedVerse;
       }
-      
+
       this.loadEndVerses();
       this.autoAdjustForMinimumVerses();
     }
-    
+
     this.emitSelection();
   }
 
   loadVerses() {
     if (this.selectedBook && this.selectedChapter) {
       const chapterData = this.selectedBook.chapters[this.selectedChapter - 1];
-      this.verses = Array.from({length: chapterData.verses.length}, (_, i) => i + 1);
-      
+      this.verses = Array.from(
+        { length: chapterData.verses.length },
+        (_, i) => i + 1,
+      );
+
       if (this.mode === 'range') {
         this.loadEndVerses();
       }
@@ -214,8 +231,14 @@ export class VersePickerComponent implements OnInit {
   }
 
   onVerseChange() {
-    if (this.mode === 'range' && this.selectedEndChapter === this.selectedChapter) {
-      this.selectedEndVerse = Math.max(this.selectedVerse, this.selectedEndVerse);
+    if (
+      this.mode === 'range' &&
+      this.selectedEndChapter === this.selectedChapter
+    ) {
+      this.selectedEndVerse = Math.max(
+        this.selectedVerse,
+        this.selectedEndVerse,
+      );
     }
     this.emitSelection();
   }
@@ -228,12 +251,16 @@ export class VersePickerComponent implements OnInit {
 
   loadEndVerses() {
     if (this.selectedBook && this.selectedEndChapter) {
-      const chapterData = this.selectedBook.chapters[this.selectedEndChapter - 1];
-      this.endVerses = Array.from({length: chapterData.verses.length}, (_, i) => i + 1);
-      
+      const chapterData =
+        this.selectedBook.chapters[this.selectedEndChapter - 1];
+      this.endVerses = Array.from(
+        { length: chapterData.verses.length },
+        (_, i) => i + 1,
+      );
+
       // If same chapter, ensure end verse is >= start verse
       if (this.selectedEndChapter === this.selectedChapter) {
-        this.endVerses = this.endVerses.filter(v => v >= this.selectedVerse);
+        this.endVerses = this.endVerses.filter((v) => v >= this.selectedVerse);
         if (this.selectedEndVerse < this.selectedVerse) {
           this.selectedEndVerse = this.selectedVerse;
         }
@@ -250,14 +277,14 @@ export class VersePickerComponent implements OnInit {
     if (this.disabledModes.includes(newMode)) {
       return;
     }
-    
+
     this.mode = newMode;
-    
+
     // Auto-adjust for minimum verses if in range mode
     if (newMode === 'range' && this.minimumVerses > 0) {
       this.autoAdjustForMinimumVerses();
     }
-    
+
     this.emitSelection();
   }
 
@@ -266,30 +293,32 @@ export class VersePickerComponent implements OnInit {
   }
 
   applySelection() {
-    // Close the hover panel
-    this.isHovered = false;
-    
-    // Emit the final selection
-    this.emitSelection();
+    const selection = this.emitSelection();
+    this.selectionApplied.emit(selection as VerseSelection);
+    this.isOpen = false;
   }
 
   private autoAdjustForMinimumVerses() {
-    if (this.mode !== 'range' || this.minimumVerses === 0 || !this.selectedBook) return;
-    
+    if (this.mode !== 'range' || this.minimumVerses === 0 || !this.selectedBook)
+      return;
+
     // Calculate current verse count
     let currentCount = this.calculateVerseCount();
-    
+
     // If we already meet the minimum, don't adjust
     if (currentCount >= this.minimumVerses) return;
-    
+
     // Try to extend to meet minimum
     const bookChapters = this.selectedBook.chapters;
     let endChapter = this.selectedEndChapter;
     let endVerse = this.selectedEndVerse;
-    
-    while (currentCount < this.minimumVerses && endChapter <= bookChapters.length) {
+
+    while (
+      currentCount < this.minimumVerses &&
+      endChapter <= bookChapters.length
+    ) {
       const chapterData = bookChapters[endChapter - 1];
-      
+
       if (endChapter === this.selectedEndChapter) {
         // Extend within current chapter
         if (endVerse < chapterData.verses.length) {
@@ -312,10 +341,10 @@ export class VersePickerComponent implements OnInit {
           break;
         }
       }
-      
+
       currentCount++;
     }
-    
+
     // Update the selections
     this.selectedEndChapter = endChapter;
     this.selectedEndVerse = endVerse;
@@ -324,7 +353,7 @@ export class VersePickerComponent implements OnInit {
 
   private calculateVerseCount(): number {
     if (!this.selectedBook) return 0;
-    
+
     if (this.mode === 'single') {
       return 1;
     } else if (this.mode === 'chapter') {
@@ -336,8 +365,11 @@ export class VersePickerComponent implements OnInit {
       for (let ch = this.selectedChapter; ch <= this.selectedEndChapter; ch++) {
         const startV = ch === this.selectedChapter ? this.selectedVerse : 1;
         const chapterData = this.selectedBook.chapters[ch - 1];
-        const endV = ch === this.selectedEndChapter ? this.selectedEndVerse : chapterData.verses.length;
-        count += (endV - startV + 1);
+        const endV =
+          ch === this.selectedEndChapter
+            ? this.selectedEndVerse
+            : chapterData.verses.length;
+        count += endV - startV + 1;
       }
       return count;
     }
@@ -345,31 +377,31 @@ export class VersePickerComponent implements OnInit {
 
   private validateSelection(): boolean {
     const count = this.calculateVerseCount();
-    
+
     // Check minimum
     if (this.minimumVerses > 0 && count < this.minimumVerses) {
       this.validationMessage = `Please select at least ${this.minimumVerses} verses`;
       return false;
     }
-    
+
     // Check maximum
     if (this.maximumVerses > 0 && count > this.maximumVerses) {
       this.validationMessage = `Please select no more than ${this.maximumVerses} verses`;
       return false;
     }
-    
+
     this.validationMessage = '';
     return true;
   }
 
-  private emitSelection() {
+  private emitSelection(): VerseSelection | undefined {
     if (!this.selectedBook) return;
 
     const startVerse = {
       book: this.selectedBook.name,
       bookId: this.selectedBook.id,
       chapter: this.selectedChapter,
-      verse: this.selectedVerse
+      verse: this.selectedVerse,
     };
 
     let verseCodes: string[] = [];
@@ -377,27 +409,32 @@ export class VersePickerComponent implements OnInit {
     let reference = `${this.selectedBook.name} ${this.selectedChapter}:${this.selectedVerse}`;
 
     if (this.mode === 'single') {
-      verseCodes = [`${this.selectedBook.id}-${this.selectedChapter}-${this.selectedVerse}`];
+      verseCodes = [
+        `${this.selectedBook.id}-${this.selectedChapter}-${this.selectedVerse}`,
+      ];
       verseCount = 1;
     } else if (this.mode === 'chapter') {
       // Chapter mode - all verses in the chapter
       const chapterData = this.selectedBook.chapters[this.selectedChapter - 1];
       reference = `${this.selectedBook.name} ${this.selectedChapter}`;
-      
+
       for (let v = 1; v <= chapterData.verses.length; v++) {
         const verseCode = `${this.selectedBook.id}-${this.selectedChapter}-${v}`;
         verseCodes.push(verseCode);
       }
-      
+
       verseCount = verseCodes.length;
     } else {
       // Range mode
       const endChapter = this.selectedEndChapter;
       const endVerse = this.selectedEndVerse;
-      
+
       reference = `${this.selectedBook.name} ${this.selectedChapter}:${this.selectedVerse}`;
-      
-      if (endChapter !== this.selectedChapter || endVerse !== this.selectedVerse) {
+
+      if (
+        endChapter !== this.selectedChapter ||
+        endVerse !== this.selectedVerse
+      ) {
         if (endChapter === this.selectedChapter) {
           reference += `-${endVerse}`;
         } else {
@@ -411,13 +448,13 @@ export class VersePickerComponent implements OnInit {
         const startV = ch === this.selectedChapter ? this.selectedVerse : 1;
         const chapterData = this.selectedBook.chapters[ch - 1];
         const endV = ch === endChapter ? endVerse : chapterData.verses.length;
-        
+
         for (let v = startV; v <= endV; v++) {
           const verseCode = `${this.selectedBook.id}-${ch}-${v}`;
           verseCodes.push(verseCode);
         }
       }
-      
+
       verseCount = verseCodes.length;
     }
 
@@ -428,15 +465,19 @@ export class VersePickerComponent implements OnInit {
     const selection: VerseSelection = {
       mode: this.mode,
       startVerse,
-      endVerse: this.mode === 'range' ? {
-        chapter: this.selectedEndChapter,
-        verse: this.selectedEndVerse
-      } : undefined,
+      endVerse:
+        this.mode === 'range'
+          ? {
+              chapter: this.selectedEndChapter,
+              verse: this.selectedEndVerse,
+            }
+          : undefined,
       verseCodes,
       verseCount,
-      reference
+      reference,
     };
 
     this.selectionChanged.emit(selection);
+    return selection;
   }
 }


### PR DESCRIPTION
## Summary
- integrate verse picker directly inside deck card rows
- toggle verse picker open/close with click instead of hover
- emit a `selectionApplied` event on apply button click
- show duplicate warnings inline in the verse picker

## Testing
- `npx prettier -w frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8e0b1bc833185e0b8b3a2e78cc2