### PR TITLE
UI tweaks and confidence tracking updates

### DIFF
--- a/frontend/src/app/core/services/bible.service.ts
+++ b/frontend/src/app/core/services/bible.service.ts
@@ -183,4 +183,15 @@ export class BibleService {
       })
     );
   }
+
+  updateVerseConfidence(userId: number, verseId: number, confidence: number) {
+    const payload = {
+      confidence_score: confidence,
+      last_reviewed: new Date().toISOString(),
+    };
+    return this.http.put(
+      `${this.apiUrl}/user-verses/confidence/${userId}/${verseId}`,
+      payload,
+    );
+  }
 }

--- a/frontend/src/app/features/feature-request/feature-request.component.html
+++ b/frontend/src/app/features/feature-request/feature-request.component.html
@@ -141,24 +141,15 @@
       <!-- Vote Section -->
       <div class="vote-section">
         <button 
-          class="vote-btn upvote" 
+          class="vote-btn upvote"
           [class.active]="request.user_vote === 'up'"
-          (click)="vote(request, 'up')"
+          (click)="vote(request)"
           [disabled]="!currentUser">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
           </svg>
         </button>
-        <span class="vote-count">{{ request.upvotes - request.downvotes }}</span>
-        <button 
-          class="vote-btn downvote" 
-          [class.active]="request.user_vote === 'down'"
-          (click)="vote(request, 'down')"
-          [disabled]="!currentUser">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
+        <span class="vote-count">{{ request.upvotes }}</span>
       </div>
 
       <!-- Content Section -->

--- a/frontend/src/app/features/feature-request/feature-request.component.scss
+++ b/frontend/src/app/features/feature-request/feature-request.component.scss
@@ -336,14 +336,6 @@
     }
   }
 
-  &.downvote.active {
-    background: #fee2e2;
-    border-color: #ef4444;
-    
-    svg {
-      color: #ef4444;
-    }
-  }
 }
 
 .vote-count {

--- a/frontend/src/app/features/feature-request/feature-request.component.ts
+++ b/frontend/src/app/features/feature-request/feature-request.component.ts
@@ -155,23 +155,18 @@ export class FeatureRequestComponent implements OnInit, OnDestroy {
     });
   }
 
-  vote(request: FeatureRequest, voteType: 'up' | 'down'): void {
+  vote(request: FeatureRequest): void {
     if (!this.currentUser) {
       this.modalService.alert('Login Required', 'Please log in to vote on feature requests', 'info');
       return;
     }
 
-    // If user is changing their vote
-    if (request.user_vote === voteType) {
+    if (request.user_vote === 'up') {
       // Remove vote
       this.featureRequestService.removeVote(request.id, this.currentUser.id as number).subscribe({
         next: () => {
           // Update local state
-          if (voteType === 'up') {
-            request.upvotes--;
-          } else {
-            request.downvotes--;
-          }
+          request.upvotes--;
           request.user_vote = null;
           request.has_voted = false;
         },
@@ -182,22 +177,15 @@ export class FeatureRequestComponent implements OnInit, OnDestroy {
       });
     } else {
       // Add or change vote
-      this.featureRequestService.voteOnRequest(request.id, voteType, this.currentUser.id as number).subscribe({
+      this.featureRequestService.voteOnRequest(request.id, 'up', this.currentUser.id as number).subscribe({
         next: () => {
           // Update local state
           if (request.user_vote === 'up') {
             request.upvotes--;
-          } else if (request.user_vote === 'down') {
-            request.downvotes--;
           }
+          request.upvotes++;
 
-          if (voteType === 'up') {
-            request.upvotes++;
-          } else {
-            request.downvotes++;
-          }
-
-          request.user_vote = voteType;
+          request.user_vote = 'up';
           request.has_voted = true;
         },
         error: (error) => {

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -21,17 +21,7 @@
 
     <h1 class="editor-title">Edit Deck: {{ deck?.name }}</h1>
 
-    <div class="header-actions">
-      <button
-        class="save-button"
-        (click)="updateDeckInfo()"
-        *ngIf="editMode === 'info'"
-        [disabled]="isSaving"
-      >
-        <span *ngIf="!isSaving">Save Info</span>
-        <span *ngIf="isSaving">Saving...</span>
-      </button>
-    </div>
+    <div class="header-actions"></div>
   </div>
 
   <!-- Tab Navigation -->
@@ -88,6 +78,12 @@
           <input type="checkbox" [(ngModel)]="isDeckPublic" />
           <span>Make this deck public</span>
         </label>
+      </div>
+      <div class="form-actions">
+        <button class="save-button" (click)="updateDeckInfo()" [disabled]="isSaving">
+          <span *ngIf="!isSaving">Save Settings</span>
+          <span *ngIf="isSaving">Saving...</span>
+        </button>
       </div>
     </div>
   </div>
@@ -150,7 +146,7 @@
                 />
               </th>
               <th class="th-reference">Reference</th>
-              <th class="th-added">Added</th>
+              <th class="th-added">Added By</th>
               <th class="th-added-date">Added Date</th>
               <th class="th-verses">Verses</th>
               <th class="th-confidence">Confidence</th>
@@ -167,6 +163,7 @@
               (drop)="onDrop(i)"
             >
               <td class="td-checkbox">
+                <span class="drag-handle" title="Drag to reorder"></span>
                 <input
                   type="checkbox"
                   [checked]="selectedCards.has(card.card_id)"
@@ -192,7 +189,7 @@
               </td>
 
               <td class="td-added">
-                <span>{{ card.position }}</span>
+                <span>{{ deck?.creator_name || 'You' }}</span>
               </td>
 
               <td class="td-added-date">

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
@@ -78,6 +78,9 @@
   gap: 1rem;
   margin-bottom: 2rem;
   border-bottom: 2px solid #e5e7eb;
+  background: #f3f4f6;
+  padding: 0.5rem;
+  border-radius: 0.5rem 0.5rem 0 0;
 }
 
 .tab-button {
@@ -97,16 +100,10 @@
   &.active {
     color: #3b82f6;
     font-weight: 600;
-
-    &::after {
-      content: "";
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background-color: #3b82f6;
-    }
+    background: white;
+    border: 1px solid #3b82f6;
+    border-bottom: none;
+    border-radius: 0.5rem 0.5rem 0 0;
   }
 }
 
@@ -192,6 +189,11 @@ textarea.form-control {
   span {
     color: #374151;
   }
+}
+
+.form-actions {
+  margin-top: 1rem;
+  text-align: right;
 }
 
 // Cards Table Section
@@ -298,8 +300,25 @@ textarea.form-control {
 // Table column widths
 .th-checkbox,
 .td-checkbox {
-  width: 40px;
+  width: 60px;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.drag-handle {
+  width: 10px;
+  height: 16px;
+  cursor: move;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    #9ca3af 0,
+    #9ca3af 2px,
+    transparent 2px,
+    transparent 4px
+  );
 }
 
 .th-reference,

--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
@@ -169,12 +169,14 @@ export class DeckStudyComponent implements OnInit {
   }
 
   onConfidenceChange() {
-    // Save confidence score immediately when changed
     if (this.currentVerse) {
-      console.log(`Confidence changed to ${this.currentVerse.confidence_score}%`);
-      // TODO: Save confidence to backend using a new endpoint
-      // This would require creating a new endpoint to save confidence scores
-      // for individual verses or cards
+      this.bibleService
+        .updateVerseConfidence(
+          this.userId,
+          this.currentVerse.verse_id,
+          this.currentVerse.confidence_score || 0,
+        )
+        .subscribe();
     }
   }
 

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
@@ -75,7 +75,7 @@
 .expanded-content {
   position: absolute;
   left: 0;
-  top: calc(100% + 0.5rem);
+  top: 100%;
   z-index: 1000;
   background: white;
   border: 1px solid #e5e7eb;
@@ -83,15 +83,10 @@
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
   overflow: hidden;
   pointer-events: none;
-  transition:
-    opacity 300ms,
-    transform 300ms;
   opacity: 0;
-  transform: translateY(-10px);
 
   &.show {
     opacity: 1;
-    transform: translateY(0);
     pointer-events: auto;
   }
 }

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -1,5 +1,5 @@
 // frontend/src/app/shared/components/verse-range-picker/verse-picker.component.ts
-import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { UserService } from '../../../core/services/user.service';
@@ -114,6 +114,15 @@ export class VersePickerComponent implements OnInit {
   // Open handling
   toggleOpen() {
     this.isOpen = !this.isOpen;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent) {
+    if (!this.isOpen) return;
+    const target = event.target as HTMLElement;
+    if (!target.closest('.hover-container')) {
+      this.isOpen = false;
+    }
   }
 
   // Display helpers


### PR DESCRIPTION
## Summary
- add API route for updating verse confidence
- sync deck study confidence with backend
- show deck creator in card table and add drag handle
- reposition deck settings save button and style tabs
- clean verse picker animation and close on outside click
- restrict feature requests to upvotes only

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f4e92f1c8331bf4bdef6263bca02