### PR TITLE
Implement downvote and UI improvements

### DIFF
--- a/frontend/src/app/features/feature-request/feature-request.component.html
+++ b/frontend/src/app/features/feature-request/feature-request.component.html
@@ -140,13 +140,22 @@
     <div class="request-card" *ngFor="let request of requests" [class.voted]="request.has_voted">
       <!-- Vote Section -->
       <div class="vote-section">
-        <button 
+        <button
           class="vote-btn upvote"
           [class.active]="request.user_vote === 'up'"
           (click)="vote(request)"
           [disabled]="!currentUser">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+          </svg>
+        </button>
+        <button
+          class="vote-btn downvote"
+          title="Remove Vote"
+          (click)="downvote(request)"
+          [disabled]="!currentUser || request.user_vote !== 'up'">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
         <span class="vote-count">{{ request.upvotes }}</span>

--- a/frontend/src/app/features/feature-request/feature-request.component.scss
+++ b/frontend/src/app/features/feature-request/feature-request.component.scss
@@ -336,6 +336,12 @@
     }
   }
 
+  &.downvote {
+    svg {
+      transform: translateY(2px);
+    }
+  }
+
 }
 
 .vote-count {

--- a/frontend/src/app/features/feature-request/feature-request.component.ts
+++ b/frontend/src/app/features/feature-request/feature-request.component.ts
@@ -196,6 +196,22 @@ export class FeatureRequestComponent implements OnInit, OnDestroy {
     }
   }
 
+  downvote(request: FeatureRequest): void {
+    if (!this.currentUser || request.user_vote !== 'up') return;
+
+    this.featureRequestService.removeVote(request.id, this.currentUser.id as number).subscribe({
+      next: () => {
+        request.upvotes--;
+        request.user_vote = null;
+        request.has_voted = false;
+      },
+      error: (error) => {
+        console.error('Error removing vote:', error);
+        this.modalService.alert('Error', 'Failed to remove vote', 'danger');
+      }
+    });
+  }
+
   onSearchChange(): void {
     this.searchSubject.next(this.searchQuery);
   }

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -158,7 +158,7 @@
               *ngFor="let card of deckCards; let i = index"
               [class.selected]="selectedCards.has(card.card_id)"
               draggable="true"
-              (dragstart)="onDragStart(i)"
+              (dragstart)="onDragStart(i, $event)"
               (dragover)="onDragOver($event)"
               (drop)="onDrop(i)"
             >

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
@@ -300,12 +300,12 @@ textarea.form-control {
 // Table column widths
 .th-checkbox,
 .td-checkbox {
-  width: 60px;
+  width: 70px;
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
 .drag-handle {
@@ -330,8 +330,9 @@ textarea.form-control {
 
 .th-added,
 .td-added {
-  width: 8%;
+  width: 12%;
   text-align: center;
+  white-space: nowrap;
 }
 
 .th-added-date,

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
@@ -426,8 +426,13 @@ export class DeckEditorComponent implements OnInit {
     }
   }
 
-  onDragStart(index: number) {
+  onDragStart(index: number, event: DragEvent) {
     this.draggedIndex = index;
+    if (event.dataTransfer) {
+      const img = new Image();
+      img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/AcAAwUB/WM8JAgAAAAASUVORK5CYII=';
+      event.dataTransfer.setDragImage(img, 0, 0);
+    }
   }
 
   onDragOver(event: DragEvent) {


### PR DESCRIPTION
## Summary
- enable removing votes via new downvote button
- space deck editor row checkbox from drag handle
- increase Added By column width
- hide drag ghost image during deck editor row drag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f91b45b4833183c82ba651190f29