### PR TITLE
Add grand total display on tracker page

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -6,6 +6,15 @@
     <p>Loading Bible data...</p>
   </div>
 
+  <!-- Grand Total -->
+  <div class="grand-total-card section bg-white p-4 rounded shadow mb-6 text-center">
+    <h3 class="text-lg font-semibold mb-2">Grand Total Memorized</h3>
+    <div class="text-2xl font-bold">
+      {{ memorizedVerses | number }} / {{ totalVerses | number }}
+    </div>
+    <div class="text-sm text-gray-500">{{ percentComplete }}% complete</div>
+  </div>
+
   <!-- Testament Selection -->
   <div class="section bg-white p-4 rounded shadow mb-6">
     <div class="flex justify-between items-center mb-3">

--- a/frontend/src/app/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.scss
@@ -354,3 +354,13 @@
     gap: 0.5rem;
   }
 }
+
+/* Grand Total Card */
+.grand-total-card {
+  text-align: center;
+}
+
+.grand-total-card .text-2xl {
+  font-size: 1.5rem;
+  font-weight: 600;
+}

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -422,4 +422,12 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
   get percentComplete(): number {
     return this.bibleData.percentComplete;
   }
+
+  get totalVerses(): number {
+    return this.bibleData.totalVerses;
+  }
+
+  get memorizedVerses(): number {
+    return this.bibleData.memorizedVerses;
+  }
 }


### PR DESCRIPTION
## Summary
- show a grand total card at the top of the tracker
- expose helper getters to return total/memorized verses
- style the new grand total card

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f9730f7c8331968a65b648d8728a