### PR TITLE
Fix lesson interface compile errors

### DIFF
--- a/frontend/src/app/core/models/workflow.model.ts
+++ b/frontend/src/app/core/models/workflow.model.ts
@@ -20,6 +20,13 @@ export interface Lesson {
   title: string;
   description?: string;
   content_type: 'video' | 'article' | 'external_link' | 'quiz' | '';
+  /**
+   * The API returns lesson content nested under a `content_data` field.
+   * Including this optional property allows frontend code to map the
+   * response directly while still supporting the flattened structure
+   * used when creating new lessons.
+   */
+  content_data?: LessonContent;
   youtube_url?: string;
   article_text?: string;
   external_url?: string;
@@ -33,14 +40,14 @@ export interface LessonContent {
   // For video lessons
   youtube_url?: string;
   video_duration?: number;
-  
+
   // For article lessons
   article_text?: string;
-  
+
   // For external link lessons
   external_url?: string;
   external_title?: string;
-  
+
   // For quiz lessons
   quiz_config?: {
     source_lessons: number[]; // IDs of lessons to pull verses from

--- a/frontend/src/app/features/workflows/workflow-builder.component.html
+++ b/frontend/src/app/features/workflows/workflow-builder.component.html
@@ -228,13 +228,21 @@
               <div class="type-icon">📄</div>
               <div>Article</div>
             </div>
-            <div 
+            <div
               class="type-option"
               [class.selected]="lessonForm.get('content_type')?.value === 'external_link'"
               (click)="lessonForm.patchValue({content_type: 'external_link'})"
             >
               <div class="type-icon">🔗</div>
               <div>External</div>
+            </div>
+            <div
+              class="type-option"
+              [class.selected]="lessonForm.get('content_type')?.value === 'quiz'"
+              (click)="lessonForm.patchValue({content_type: 'quiz'})"
+            >
+              <div class="type-icon">❓</div>
+              <div>Quiz</div>
             </div>
           </div>
         </div>
@@ -291,6 +299,46 @@
               formControlName="external_title"
               placeholder="Title for the external resource"
             >
+          </div>
+        </div>
+
+        <!-- Quiz Content -->
+        <div class="content-fields" *ngIf="lessonForm.get('content_type')?.value === 'quiz'">
+          <div class="form-group">
+            <label>Number of Verses <span class="required">*</span></label>
+            <input
+              type="number"
+              class="form-control"
+              formControlName="quiz_verse_count"
+              min="2"
+              max="7"
+              placeholder="5"
+            >
+            <p class="help-text">How many verses to include (2-7)</p>
+          </div>
+          <div class="form-group">
+            <label>Pass Threshold (%)</label>
+            <input
+              type="number"
+              class="form-control"
+              formControlName="quiz_pass_threshold"
+              min="50"
+              max="100"
+              placeholder="85"
+            >
+            <p class="help-text">Minimum average confidence to pass</p>
+          </div>
+          <div class="form-group">
+            <label class="checkbox-label">
+              <input type="checkbox" formControlName="quiz_randomize">
+              Randomize verse selection
+            </label>
+          </div>
+          <div class="quiz-warning" *ngIf="selectedLessonIndex === 0">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+            </svg>
+            <span>First lesson cannot be a quiz as there are no previous lessons.</span>
           </div>
         </div>
 

--- a/frontend/src/app/features/workflows/workflow-builder.component.scss
+++ b/frontend/src/app/features/workflows/workflow-builder.component.scss
@@ -445,7 +445,7 @@ textarea.form-control {
 
 .content-type-selector {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
 }
 
@@ -495,6 +495,19 @@ textarea.form-control {
 
   .error {
     color: #ef4444;
+  }
+}
+
+.quiz-warning {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #b45309;
+  margin-top: 0.5rem;
+
+  svg {
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- include quiz in lesson type and allow optional content_data
- add quiz-specific lesson fields and UI elements

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684183687ec48331a69b2a2d17dfc4a5