### PR TITLE
Consolidate confidence sliders

### DIFF
--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.html
@@ -6,19 +6,29 @@
       <div class="hero-gradient"></div>
       <div class="hero-pattern"></div>
     </div>
-    
+
     <div class="hero-content">
       <button class="back-button" (click)="exitStudy()">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M10 19l-7-7m0 0l7-7m-7 7h18"
+          />
         </svg>
         Back to Decks
       </button>
-      
+
       <h1 class="hero-title">
         <span class="gradient-text">{{ deckName }}</span>
       </h1>
-      
+
       <div class="study-stats">
         <div class="stat-item">
           <span class="stat-value">{{ currentIndex + 1 }}</span>
@@ -27,7 +37,8 @@
         </div>
         <div class="progress-ring">
           <svg viewBox="0 0 36 36">
-            <path class="progress-bg"
+            <path
+              class="progress-bg"
               d="M18 2.0845
                 a 15.9155 15.9155 0 0 1 0 31.831
                 a 15.9155 15.9155 0 0 1 0 -31.831"
@@ -35,7 +46,8 @@
               stroke="#e5e7eb"
               stroke-width="3"
             />
-            <path class="progress-fill"
+            <path
+              class="progress-fill"
               d="M18 2.0845
                 a 15.9155 15.9155 0 0 1 0 31.831
                 a 15.9155 15.9155 0 0 1 0 -31.831"
@@ -46,13 +58,25 @@
               [style.stroke-dashoffset]="100 - progress"
             />
             <defs>
-              <linearGradient id="progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
-                <stop offset="100%" style="stop-color:#10b981;stop-opacity:1" />
+              <linearGradient
+                id="progress-gradient"
+                x1="0%"
+                y1="0%"
+                x2="100%"
+                y2="100%"
+              >
+                <stop
+                  offset="0%"
+                  style="stop-color: #3b82f6; stop-opacity: 1"
+                />
+                <stop
+                  offset="100%"
+                  style="stop-color: #10b981; stop-opacity: 1"
+                />
               </linearGradient>
             </defs>
           </svg>
-          <span class="progress-text">{{ progress | number:'1.0-0' }}%</span>
+          <span class="progress-text">{{ progress | number: "1.0-0" }}%</span>
         </div>
       </div>
     </div>
@@ -71,13 +95,34 @@
 
   <!-- Error State -->
   <div *ngIf="error && !isLoading" class="error-container">
-    <svg class="error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+    <svg
+      class="error-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+      />
     </svg>
     <p class="error-message">{{ error }}</p>
     <button class="btn btn-primary" (click)="loadDeckVerses()">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
       </svg>
       Try Again
     </button>
@@ -93,8 +138,18 @@
         </div>
         <button class="reveal-hint">
           Click to reveal verse
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
           </svg>
         </button>
       </div>
@@ -104,74 +159,136 @@
         <div class="verse-text">
           {{ currentVerse.text }}
         </div>
-        
+
         <!-- Confidence Slider -->
-        <div class="confidence-container">
-          <label class="confidence-label">How well do you know this verse?</label>
-          <div class="confidence-slider-wrapper">
-            <div class="confidence-emoji">😟</div>
-            <input 
-              type="range" 
-              class="confidence-slider"
-              min="0" 
-              max="100" 
-              [(ngModel)]="currentVerse.confidence_score"
-              (change)="onConfidenceChange()">
-            <div class="confidence-emoji">😄</div>
-          </div>
-          <div class="confidence-value">
-            <span class="confidence-score">{{ currentVerse.confidence_score }}%</span>
-            <span class="confidence-label-text">Confidence</span>
-          </div>
-        </div>
+        <app-confidence-slider
+          [label]="'How well do you know this verse?'"
+          [(value)]="currentVerse.confidence_score"
+          (valueChange)="onConfidenceChange()"
+        >
+        </app-confidence-slider>
       </div>
 
       <!-- Click handler for flipping -->
-      <div class="card-click-area" (click)="toggleReveal()" *ngIf="!currentVerse.isRevealed"></div>
+      <div
+        class="card-click-area"
+        (click)="toggleReveal()"
+        *ngIf="!currentVerse.isRevealed"
+      ></div>
     </div>
   </div>
 
   <!-- Navigation Controls -->
   <div *ngIf="!isLoading && !error && currentVerse" class="navigation-controls">
-    <button class="nav-button secondary" (click)="previousVerse()" [disabled]="currentIndex === 0">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+    <button
+      class="nav-button secondary"
+      (click)="previousVerse()"
+      [disabled]="currentIndex === 0"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
       </svg>
       <span class="button-text">Previous</span>
     </button>
 
-    <button class="nav-button skip" (click)="skipVerse()" [disabled]="currentIndex === verses.length - 1">
+    <button
+      class="nav-button skip"
+      (click)="skipVerse()"
+      [disabled]="currentIndex === verses.length - 1"
+    >
       <span class="button-text">Skip</span>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M13 5l7 7-7 7M5 5l7 7-7 7"
+        />
       </svg>
     </button>
 
-    <button class="nav-button primary" (click)="nextVerse()" [disabled]="currentIndex === verses.length - 1">
+    <button
+      class="nav-button primary"
+      (click)="nextVerse()"
+      [disabled]="currentIndex === verses.length - 1"
+    >
       <span class="button-text">Next</span>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9 5l7 7-7 7"
+        />
       </svg>
     </button>
   </div>
 
   <!-- Complete State -->
-  <div *ngIf="!isLoading && !error && verses.length > 0 && currentIndex === verses.length - 1 && currentVerse?.isRevealed" 
-       class="complete-container">
+  <div
+    *ngIf="
+      !isLoading &&
+      !error &&
+      verses.length > 0 &&
+      currentIndex === verses.length - 1 &&
+      currentVerse?.isRevealed
+    "
+    class="complete-container"
+  >
     <div class="complete-content">
       <div class="complete-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
+          />
         </svg>
       </div>
       <h2>Study Session Complete!</h2>
       <p>You've reviewed all {{ verses.length }} verses in this deck.</p>
-      
+
       <div class="session-stats">
         <div class="stat-card">
           <div class="stat-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           </div>
           <div class="stat-info">
@@ -179,11 +296,21 @@
             <span class="stat-value">{{ getSessionTime() }}</span>
           </div>
         </div>
-        
+
         <div class="stat-card">
           <div class="stat-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
             </svg>
           </div>
           <div class="stat-info">
@@ -191,11 +318,21 @@
             <span class="stat-value">{{ verses.length }}</span>
           </div>
         </div>
-        
+
         <div class="stat-card">
           <div class="stat-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+              />
             </svg>
           </div>
           <div class="stat-info">
@@ -204,10 +341,20 @@
           </div>
         </div>
       </div>
-      
+
       <button class="btn btn-primary large" (click)="exitStudy()">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
         </svg>
         Back to Decks
       </button>

--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.scss
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.scss
@@ -1,6 +1,6 @@
 // frontend/src/app/features/memorize/decks/deck-study/deck-study.component.scss
-@use '../shared/styles/variables' as *;
-@use '../shared/styles/animations' as *;
+@use "../shared/styles/variables" as *;
+@use "../shared/styles/animations" as *;
 
 .study-container {
   min-height: 100vh;
@@ -15,7 +15,7 @@
   padding: 2rem 2rem 3rem;
   text-align: center;
   overflow: hidden;
-  
+
   @media (max-width: 768px) {
     padding: 1.5rem 1rem 2rem;
   }
@@ -36,8 +36,17 @@
   left: -50%;
   width: 200%;
   height: 200%;
-  background: radial-gradient(circle at 30% 50%, rgba(59, 130, 246, 0.1) 0%, transparent 50%),
-              radial-gradient(circle at 70% 50%, rgba(16, 185, 129, 0.1) 0%, transparent 50%);
+  background:
+    radial-gradient(
+      circle at 30% 50%,
+      rgba(59, 130, 246, 0.1) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 70% 50%,
+      rgba(16, 185, 129, 0.1) 0%,
+      transparent 50%
+    );
   animation: heroFadeIn 1.5s ease-out forwards;
 }
 
@@ -88,7 +97,7 @@
   font-size: 2.5rem;
   font-weight: 800;
   margin-bottom: 1.5rem;
-  
+
   @media (max-width: 768px) {
     font-size: 2rem;
   }
@@ -167,7 +176,8 @@
 }
 
 // Loading & Error states
-.loading-container, .error-container {
+.loading-container,
+.error-container {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -296,95 +306,7 @@
   margin-bottom: 2rem;
 }
 
-// Confidence slider with emojis
-.confidence-container {
-  width: 100%;
-  max-width: 400px;
-  padding: 1.5rem;
-  background: #f8fafc;
-  border-radius: 1rem;
-  border: 1px solid #e2e8f0;
-}
-
-.confidence-label {
-  display: block;
-  text-align: center;
-  font-size: 0.875rem;
-  color: #64748b;
-  margin-bottom: 1rem;
-  font-weight: 600;
-}
-
-.confidence-slider-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.confidence-emoji {
-  font-size: 1.5rem;
-}
-
-.confidence-slider {
-  flex: 1;
-  height: 8px;
-  background: linear-gradient(90deg, #ef4444 0%, #f59e0b 25%, #fbbf24 50%, #84cc16 75%, #10b981 100%);
-  border-radius: 4px;
-  outline: none;
-  -webkit-appearance: none;
-  
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: 24px;
-    height: 24px;
-    background: white;
-    border: 3px solid #3b82f6;
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s;
-    
-    &:hover {
-      transform: scale(1.2);
-      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-    }
-  }
-  
-  &::-moz-range-thumb {
-    width: 24px;
-    height: 24px;
-    background: white;
-    border: 3px solid #3b82f6;
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s;
-    
-    &:hover {
-      transform: scale(1.2);
-      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-    }
-  }
-}
-
-.confidence-value {
-  text-align: center;
-  
-  .confidence-score {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #3b82f6;
-    display: block;
-  }
-  
-  .confidence-label-text {
-    font-size: 0.75rem;
-    color: #94a3b8;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-}
+// Confidence slider styles moved to shared component
 
 // Navigation controls
 .navigation-controls {
@@ -510,7 +432,7 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   margin-bottom: 2rem;
-  
+
   @media (max-width: 640px) {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DeckService } from '../../../../core/services/deck.service';
 import { BibleService } from '../../../../core/services/bible.service';
 import { UserService } from '../../../../core/services/user.service';
+import { ConfidenceSliderComponent } from '../../../../shared/components/confidence-slider/confidence-slider.component';
 
 interface StudyVerse {
   verse_id: number;
@@ -22,7 +23,7 @@ interface StudyVerse {
   templateUrl: './deck-study.component.html',
   styleUrls: ['./deck-study.component.scss'],
   standalone: true,
-  imports: [CommonModule, FormsModule]
+  imports: [CommonModule, FormsModule, ConfidenceSliderComponent],
 })
 export class DeckStudyComponent implements OnInit {
   deckId: number = 0;
@@ -40,12 +41,12 @@ export class DeckStudyComponent implements OnInit {
     private router: Router,
     private deckService: DeckService,
     private bibleService: BibleService,
-    private userService: UserService
+    private userService: UserService,
   ) {}
 
   ngOnInit() {
     // Get user preferences first
-    this.userService.currentUser$.subscribe(user => {
+    this.userService.currentUser$.subscribe((user) => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
         // Map preferred Bible to API Bible ID if needed
@@ -54,7 +55,7 @@ export class DeckStudyComponent implements OnInit {
       }
     });
 
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       this.deckId = +params['deckId'];
       this.loadDeckVerses();
     });
@@ -63,37 +64,44 @@ export class DeckStudyComponent implements OnInit {
   loadDeckVerses() {
     this.isLoading = true;
     this.error = '';
-    
-    this.deckService.getDeckCards(this.deckId, this.userId, this.preferredBibleId).subscribe({
-      next: (response: any) => {
-        this.deckName = response.deck_name;
-        
-        // Flatten cards to verses for study mode
-        this.verses = response.cards.flatMap((card: any) => 
-          card.verses.map((verse: any) => ({
-            ...verse,
-            confidence_score: card.confidence_score || 50,
-            isRevealed: false,
-            // Ensure we have text or a fallback
-            text: verse.text || `Unable to load text for ${verse.reference}`
-          }))
-        );
-        
-        // Check if any verses failed to load
-        const failedVerses = this.verses.filter(v => v.text.startsWith('Unable to load'));
-        if (failedVerses.length > 0) {
-          console.warn(`${failedVerses.length} verses failed to load properly`);
-        }
-        
-        this.orderVersesBySpacedRepetition();
-        this.isLoading = false;
-      },
-      error: (error: any) => {
-        console.error('Error loading deck cards:', error);
-        this.error = 'Failed to load deck cards. Please check your internet connection and try again.';
-        this.isLoading = false;
-      }
-    });
+
+    this.deckService
+      .getDeckCards(this.deckId, this.userId, this.preferredBibleId)
+      .subscribe({
+        next: (response: any) => {
+          this.deckName = response.deck_name;
+
+          // Flatten cards to verses for study mode
+          this.verses = response.cards.flatMap((card: any) =>
+            card.verses.map((verse: any) => ({
+              ...verse,
+              confidence_score: card.confidence_score || 50,
+              isRevealed: false,
+              // Ensure we have text or a fallback
+              text: verse.text || `Unable to load text for ${verse.reference}`,
+            })),
+          );
+
+          // Check if any verses failed to load
+          const failedVerses = this.verses.filter((v) =>
+            v.text.startsWith('Unable to load'),
+          );
+          if (failedVerses.length > 0) {
+            console.warn(
+              `${failedVerses.length} verses failed to load properly`,
+            );
+          }
+
+          this.orderVersesBySpacedRepetition();
+          this.isLoading = false;
+        },
+        error: (error: any) => {
+          console.error('Error loading deck cards:', error);
+          this.error =
+            'Failed to load deck cards. Please check your internet connection and try again.';
+          this.isLoading = false;
+        },
+      });
   }
 
   orderVersesBySpacedRepetition() {
@@ -102,24 +110,24 @@ export class DeckStudyComponent implements OnInit {
     this.verses.sort((a, b) => {
       const scoreA = a.confidence_score || 50;
       const scoreB = b.confidence_score || 50;
-      
+
       // If neither has been reviewed, sort by confidence
       if (!a.last_reviewed && !b.last_reviewed) {
         return scoreA - scoreB;
       }
-      
+
       // Prioritize unreviewed verses
       if (!a.last_reviewed) return -1;
       if (!b.last_reviewed) return 1;
-      
+
       // Calculate days since last review
       const daysA = this.daysSinceReview(a.last_reviewed);
       const daysB = this.daysSinceReview(b.last_reviewed);
-      
+
       // Priority score: lower confidence + more days = higher priority
-      const priorityA = (100 - scoreA) + (daysA * 2);
-      const priorityB = (100 - scoreB) + (daysB * 2);
-      
+      const priorityA = 100 - scoreA + daysA * 2;
+      const priorityB = 100 - scoreB + daysB * 2;
+
       return priorityB - priorityA;
     });
   }
@@ -136,7 +144,9 @@ export class DeckStudyComponent implements OnInit {
   }
 
   get progress(): number {
-    return this.verses.length > 0 ? ((this.currentIndex + 1) / this.verses.length) * 100 : 0;
+    return this.verses.length > 0
+      ? ((this.currentIndex + 1) / this.verses.length) * 100
+      : 0;
   }
 
   toggleReveal() {
@@ -185,7 +195,7 @@ export class DeckStudyComponent implements OnInit {
     const diff = now.getTime() - this.sessionStartTime.getTime();
     const minutes = Math.floor(diff / 60000);
     const seconds = Math.floor((diff % 60000) / 1000);
-    
+
     if (minutes === 0) {
       return `${seconds}s`;
     } else if (minutes < 60) {
@@ -199,11 +209,11 @@ export class DeckStudyComponent implements OnInit {
 
   getAverageConfidence(): number {
     if (this.verses.length === 0) return 0;
-    
+
     const totalConfidence = this.verses.reduce((sum, verse) => {
       return sum + (verse.confidence_score || 50);
     }, 0);
-    
+
     return Math.round(totalConfidence / this.verses.length);
   }
 }

--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -132,22 +132,14 @@
       {{ verses.length === 1 ? "this verse" : "these verses" }}?
     </p>
 
-    <div class="slider-container">
-      <span class="slider-label">0%</span>
-      <input
-        type="range"
-        class="confidence-slider"
-        [(ngModel)]="confidenceLevel"
-        min="0"
-        max="100"
-        step="1"
-      />
-      <span class="slider-label">100%</span>
-    </div>
-
-    <div class="confidence-value">
-      Current confidence: <strong>{{ confidenceLevel }}%</strong>
-    </div>
+    <app-confidence-slider
+      [label]="
+        'How well do you know ' +
+        (verses.length === 1 ? 'this verse?' : 'these verses?')
+      "
+      [(value)]="confidenceLevel"
+    >
+    </app-confidence-slider>
 
     <div class="action-buttons">
       <button

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -243,63 +243,7 @@
     margin-bottom: 2rem;
   }
 
-  .slider-container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
-    max-width: 500px;
-    margin-left: auto;
-    margin-right: auto;
-
-    .slider-label {
-      font-size: 0.875rem;
-      color: #6b7280;
-      min-width: 35px;
-    }
-
-    .confidence-slider {
-      flex: 1;
-      height: 8px;
-      -webkit-appearance: none;
-      appearance: none;
-      background: #e5e7eb;
-      border-radius: 4px;
-      outline: none;
-
-      &::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 20px;
-        height: 20px;
-        background: #3b82f6;
-        border-radius: 50%;
-        cursor: pointer;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-        transition: all 0.2s;
-
-        &:hover {
-          transform: scale(1.1);
-        }
-      }
-
-      &::-moz-range-thumb {
-        width: 20px;
-        height: 20px;
-        background: #3b82f6;
-        border-radius: 50%;
-        cursor: pointer;
-        border: none;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-        transition: all 0.2s;
-
-        &:hover {
-          transform: scale(1.1);
-        }
-      }
-    }
-  }
+  // Slider styles moved to shared component
 
   .saved-indicator {
     position: fixed;
@@ -330,16 +274,7 @@
     }
   }
 
-  .confidence-value {
-    font-size: 1.125rem;
-    color: #4b5563;
-    margin-bottom: 2rem;
-
-    strong {
-      color: #3b82f6;
-      font-size: 1.25rem;
-    }
-  }
+  // confidence-value styles moved to shared component
 
   .action-buttons {
     display: flex;

--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -11,6 +11,7 @@ import { UserService } from '../../../core/services/user.service';
 import { User } from '../../../core/models/user';
 import { UserVerseDetail } from '../../../core/models/bible';
 import { Subject, takeUntil } from 'rxjs';
+import { ConfidenceSliderComponent } from '../../../shared/components/confidence-slider/confidence-slider.component';
 
 interface FlowVerse {
   verseCode: string;
@@ -27,7 +28,12 @@ interface FlowVerse {
 @Component({
   selector: 'app-flow',
   standalone: true,
-  imports: [CommonModule, FormsModule, VersePickerComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    VersePickerComponent,
+    ConfidenceSliderComponent,
+  ],
   templateUrl: './flow.component.html',
   styleUrls: ['./flow.component.scss'],
 })

--- a/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.html
+++ b/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.html
@@ -1,0 +1,19 @@
+<div class="confidence-container">
+  <label *ngIf="label" class="confidence-label">{{ label }}</label>
+  <div class="confidence-slider-wrapper">
+    <div *ngIf="showEmojis" class="confidence-emoji">😟</div>
+    <input
+      type="range"
+      class="confidence-slider"
+      [min]="min"
+      [max]="max"
+      [(ngModel)]="value"
+      (ngModelChange)="onChange($event)"
+    />
+    <div *ngIf="showEmojis" class="confidence-emoji">😄</div>
+  </div>
+  <div class="confidence-value">
+    <span class="confidence-score">{{ value }}%</span>
+    <span class="confidence-label-text">Confidence</span>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.scss
+++ b/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.scss
@@ -1,0 +1,99 @@
+:host {
+  display: block;
+}
+
+.confidence-container {
+  width: 100%;
+  max-width: 400px;
+  padding: 1.5rem;
+  background: #f8fafc;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+}
+
+.confidence-label {
+  display: block;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.confidence-slider-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.confidence-emoji {
+  font-size: 1.5rem;
+}
+
+.confidence-slider {
+  flex: 1;
+  height: 8px;
+  background: linear-gradient(
+    90deg,
+    #ef4444 0%,
+    #f59e0b 25%,
+    #fbbf24 50%,
+    #84cc16 75%,
+    #10b981 100%
+  );
+  border-radius: 4px;
+  outline: none;
+  -webkit-appearance: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 24px;
+    height: 24px;
+    background: white;
+    border: 3px solid #3b82f6;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s;
+
+    &:hover {
+      transform: scale(1.2);
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    }
+  }
+
+  &::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    background: white;
+    border: 3px solid #3b82f6;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s;
+
+    &:hover {
+      transform: scale(1.2);
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    }
+  }
+}
+
+.confidence-value {
+  text-align: center;
+
+  .confidence-score {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #3b82f6;
+    display: block;
+  }
+
+  .confidence-label-text {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}

--- a/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.ts
+++ b/frontend/src/app/shared/components/confidence-slider/confidence-slider.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-confidence-slider',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './confidence-slider.component.html',
+  styleUrls: ['./confidence-slider.component.scss'],
+})
+export class ConfidenceSliderComponent {
+  @Input() label = '';
+  @Input() value = 50;
+  @Input() min = 0;
+  @Input() max = 100;
+  @Input() showEmojis = true;
+
+  @Output() valueChange = new EventEmitter<number>();
+
+  onChange(val: number) {
+    this.valueChange.emit(val);
+  }
+}


### PR DESCRIPTION
## Summary
- create a reusable `ConfidenceSliderComponent`
- swap deck study confidence UI to shared component
- swap FLOW confidence UI to shared component

## Testing
- `npx prettier --write frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts frontend/src/app/features/memorize/decks/deck-study/deck-study.component.html frontend/src/app/features/memorize/decks/deck-study/deck-study.component.scss frontend/src/app/features/memorize/flow/flow.component.ts frontend/src/app/features/memorize/flow/flow.component.html frontend/src/app/features/memorize/flow/flow.component.scss frontend/src/app/shared/components/confidence-slider/confidence-slider.component.ts frontend/src/app/shared/components/confidence-slider/confidence-slider.component.html frontend/src/app/shared/components/confidence-slider/confidence-slider.component.scss`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684188ef8f108331a9344201de263a79