### PR TITLE
Add quiz flashcard selection to workflow builder

### DIFF
--- a/frontend/src/app/core/models/workflow.model.ts
+++ b/frontend/src/app/core/models/workflow.model.ts
@@ -30,8 +30,6 @@ export interface Lesson {
   youtube_url?: string;
   article_text?: string;
   external_url?: string;
-  content_data?: LessonContent;
-  external_title?: string;
   audio_url?: string;
   flashcards_required: number;
   position: number;

--- a/frontend/src/app/features/workflows/workflow-builder.component.html
+++ b/frontend/src/app/features/workflows/workflow-builder.component.html
@@ -2,28 +2,40 @@
 <div class="workflow-builder">
   <!-- Header -->
   <div class="builder-header">
-    <h1>{{ isEditMode ? 'Edit Workflow' : 'Create New Workflow' }}</h1>
+    <h1>{{ isEditMode ? "Edit Workflow" : "Create New Workflow" }}</h1>
     <div class="header-actions">
       <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
-      <button class="btn btn-primary" (click)="saveWorkflow()" [disabled]="saving">
-        {{ saving ? 'Saving...' : 'Save Workflow' }}
+      <button
+        class="btn btn-primary"
+        (click)="saveWorkflow()"
+        [disabled]="saving"
+      >
+        {{ saving ? "Saving..." : "Save Workflow" }}
       </button>
     </div>
   </div>
 
   <!-- Step Navigation -->
   <div class="step-navigation">
-    <div 
-      *ngFor="let step of steps" 
+    <div
+      *ngFor="let step of steps"
       class="step-item"
       [class.completed]="getStepStatus(step.number) === 'completed'"
       [class.active]="getStepStatus(step.number) === 'active'"
       (click)="goToStep(step.number)"
     >
       <div class="step-number">
-        <span *ngIf="getStepStatus(step.number) !== 'completed'">{{ step.number }}</span>
-        <svg *ngIf="getStepStatus(step.number) === 'completed'" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+        <span *ngIf="getStepStatus(step.number) !== 'completed'">{{
+          step.number
+        }}</span>
+        <svg
+          *ngIf="getStepStatus(step.number) === 'completed'"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" />
         </svg>
       </div>
       <div class="step-info">
@@ -34,29 +46,45 @@
   </div>
 
   <!-- Step 1: Workflow Info -->
-  <div class="workflow-info" [formGroup]="workflowForm" *ngIf="currentStep === 1">
+  <div
+    class="workflow-info"
+    [formGroup]="workflowForm"
+    *ngIf="currentStep === 1"
+  >
     <div class="form-group">
       <label>Workflow Title <span class="required">*</span></label>
-      <input 
-        type="text" 
-        class="form-control" 
+      <input
+        type="text"
+        class="form-control"
         formControlName="title"
         placeholder="Enter a title for your workflow"
+      />
+      <div
+        class="error-message"
+        *ngIf="
+          workflowForm.get('title')?.touched &&
+          workflowForm.get('title')?.errors?.['required']
+        "
       >
-      <div class="error-message" *ngIf="workflowForm.get('title')?.touched && workflowForm.get('title')?.errors?.['required']">
         Title is required
       </div>
     </div>
 
     <div class="form-group">
       <label>Description <span class="required">*</span></label>
-      <textarea 
-        class="form-control" 
+      <textarea
+        class="form-control"
         formControlName="description"
         rows="3"
         placeholder="Describe what learners will gain from this workflow"
       ></textarea>
-      <div class="error-message" *ngIf="workflowForm.get('description')?.touched && workflowForm.get('description')?.errors?.['required']">
+      <div
+        class="error-message"
+        *ngIf="
+          workflowForm.get('description')?.touched &&
+          workflowForm.get('description')?.errors?.['required']
+        "
+      >
         Description is required
       </div>
     </div>
@@ -66,8 +94,8 @@
         <label>Tags</label>
         <div class="tags-container">
           <div class="selected-tags">
-            <span 
-              *ngFor="let tag of selectedTags" 
+            <span
+              *ngFor="let tag of selectedTags"
               class="tag-chip"
               (click)="removeTag(tag)"
             >
@@ -75,14 +103,14 @@
               <span class="remove-icon">×</span>
             </span>
           </div>
-          <select 
-            class="form-control tag-select" 
+          <select
+            class="form-control tag-select"
             #tagSelect
             (change)="addTag(tagSelect.value); tagSelect.value = ''"
           >
             <option value="">Add a tag...</option>
-            <option 
-              *ngFor="let tag of availableTags" 
+            <option
+              *ngFor="let tag of availableTags"
               [value]="tag"
               [disabled]="selectedTags.includes(tag)"
             >
@@ -94,15 +122,21 @@
 
       <div class="form-group">
         <label class="checkbox-label">
-          <input type="checkbox" formControlName="is_public">
+          <input type="checkbox" formControlName="is_public" />
           Make this workflow public
         </label>
-        <p class="help-text">Public workflows can be discovered by other users</p>
+        <p class="help-text">
+          Public workflows can be discovered by other users
+        </p>
       </div>
     </div>
 
     <div class="step-footer">
-      <button class="btn btn-primary" (click)="nextStep()" [disabled]="!canProceed()">
+      <button
+        class="btn btn-primary"
+        (click)="nextStep()"
+        [disabled]="!canProceed()"
+      >
         Next Step
       </button>
     </div>
@@ -118,7 +152,7 @@
       </div>
 
       <div class="lesson-list">
-        <div 
+        <div
           *ngFor="let lesson of lessons; let i = index"
           class="lesson-card"
           [class.active]="selectedLessonIndex === i"
@@ -126,24 +160,34 @@
         >
           <div class="lesson-handle">
             <div class="reorder-buttons">
-              <button 
+              <button
                 class="reorder-btn"
                 (click)="moveLesson(i, 'up'); $event.stopPropagation()"
                 [disabled]="i === 0"
                 title="Move up"
               >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M7 14l5-5 5 5z"/>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M7 14l5-5 5 5z" />
                 </svg>
               </button>
-              <button 
+              <button
                 class="reorder-btn"
                 (click)="moveLesson(i, 'down'); $event.stopPropagation()"
                 [disabled]="i === lessons.length - 1"
                 title="Move down"
               >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M7 10l5 5 5-5z"/>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M7 10l5 5 5-5z" />
                 </svg>
               </button>
             </div>
@@ -151,24 +195,43 @@
             <div class="lesson-info">
               <div class="lesson-title">{{ lesson.title }}</div>
               <div class="lesson-type">
-                {{ getLessonIcon(lesson.content_type) }} {{ getLessonTypeLabel(lesson.content_type) }}
+                {{ getLessonIcon(lesson.content_type) }}
+                {{ getLessonTypeLabel(lesson.content_type) }}
               </div>
             </div>
-            <button 
+            <button
               class="delete-btn"
               (click)="deleteLesson(i); $event.stopPropagation()"
               title="Delete lesson"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                />
               </svg>
             </button>
           </div>
         </div>
 
         <button class="add-lesson-btn" (click)="addLesson()">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 4v16m8-8H4"
+            />
           </svg>
           <span>Add New Lesson</span>
         </button>
@@ -178,12 +241,26 @@
     <!-- Right Panel: Lesson Editor -->
     <div class="editor-panel content-panel">
       <div class="panel-header" *ngIf="selectedLessonIndex !== null">
-        <h3>Lesson {{ selectedLessonIndex + 1 }}: {{ lessons[selectedLessonIndex].title }}</h3>
+        <h3>
+          Lesson {{ selectedLessonIndex + 1 }}:
+          {{ lessons[selectedLessonIndex].title }}
+        </h3>
       </div>
 
       <div class="empty-state" *ngIf="selectedLessonIndex === null">
-        <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        <svg
+          width="64"
+          height="64"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+          />
         </svg>
         <p>Select a lesson to edit or create a new one</p>
       </div>
@@ -191,18 +268,18 @@
       <form [formGroup]="lessonForm" *ngIf="selectedLessonIndex !== null">
         <div class="form-group">
           <label>Lesson Title <span class="required">*</span></label>
-          <input 
-            type="text" 
-            class="form-control" 
+          <input
+            type="text"
+            class="form-control"
             formControlName="title"
             placeholder="Enter lesson title"
-          >
+          />
         </div>
 
         <div class="form-group">
           <label>Description</label>
-          <textarea 
-            class="form-control" 
+          <textarea
+            class="form-control"
             formControlName="description"
             rows="2"
             placeholder="Brief description of the lesson (optional)"
@@ -212,34 +289,42 @@
         <div class="form-group">
           <label>Content Type <span class="required">*</span></label>
           <div class="content-type-selector">
-            <div 
+            <div
               class="type-option"
-              [class.selected]="lessonForm.get('content_type')?.value === 'video'"
-              (click)="lessonForm.patchValue({content_type: 'video'})"
+              [class.selected]="
+                lessonForm.get('content_type')?.value === 'video'
+              "
+              (click)="lessonForm.patchValue({ content_type: 'video' })"
             >
               <div class="type-icon">📹</div>
               <div>Video</div>
             </div>
-            <div 
+            <div
               class="type-option"
-              [class.selected]="lessonForm.get('content_type')?.value === 'article'"
-              (click)="lessonForm.patchValue({content_type: 'article'})"
+              [class.selected]="
+                lessonForm.get('content_type')?.value === 'article'
+              "
+              (click)="lessonForm.patchValue({ content_type: 'article' })"
             >
               <div class="type-icon">📄</div>
               <div>Article</div>
             </div>
             <div
               class="type-option"
-              [class.selected]="lessonForm.get('content_type')?.value === 'external_link'"
-              (click)="lessonForm.patchValue({content_type: 'external_link'})"
+              [class.selected]="
+                lessonForm.get('content_type')?.value === 'external_link'
+              "
+              (click)="lessonForm.patchValue({ content_type: 'external_link' })"
             >
               <div class="type-icon">🔗</div>
               <div>External</div>
             </div>
             <div
               class="type-option"
-              [class.selected]="lessonForm.get('content_type')?.value === 'quiz'"
-              (click)="lessonForm.patchValue({content_type: 'quiz'})"
+              [class.selected]="
+                lessonForm.get('content_type')?.value === 'quiz'
+              "
+              (click)="lessonForm.patchValue({ content_type: 'quiz' })"
             >
               <div class="type-icon">❓</div>
               <div>Quiz</div>
@@ -248,32 +333,44 @@
         </div>
 
         <!-- Video Content -->
-        <div class="content-fields" *ngIf="lessonForm.get('content_type')?.value === 'video'">
+        <div
+          class="content-fields"
+          *ngIf="lessonForm.get('content_type')?.value === 'video'"
+        >
           <div class="form-group">
             <label>YouTube URL <span class="required">*</span></label>
-            <input 
-              type="url" 
-              class="form-control" 
+            <input
+              type="url"
+              class="form-control"
               formControlName="youtube_url"
               placeholder="https://www.youtube.com/watch?v=..."
-            >
+            />
             <p class="help-text">Paste the full YouTube video URL</p>
           </div>
         </div>
 
         <!-- Article Content -->
-        <div class="content-fields" *ngIf="lessonForm.get('content_type')?.value === 'article'">
+        <div
+          class="content-fields"
+          *ngIf="lessonForm.get('content_type')?.value === 'article'"
+        >
           <div class="form-group">
             <label>Article Content <span class="required">*</span></label>
-            <textarea 
-              class="form-control article-textarea" 
+            <textarea
+              class="form-control article-textarea"
               formControlName="article_text"
               rows="10"
               placeholder="Write your article content here..."
             ></textarea>
             <div class="char-count">
-              {{ lessonForm.get('article_text')?.value?.length || 0 }} characters
-              <span *ngIf="lessonForm.get('article_text')?.errors?.['minLength']" class="error">
+              {{
+                lessonForm.get("article_text")?.value?.length || 0
+              }}
+              characters
+              <span
+                *ngIf="lessonForm.get('article_text')?.errors?.['minLength']"
+                class="error"
+              >
                 (minimum 100)
               </span>
             </div>
@@ -281,41 +378,35 @@
         </div>
 
         <!-- External Link Content -->
-        <div class="content-fields" *ngIf="lessonForm.get('content_type')?.value === 'external_link'">
+        <div
+          class="content-fields"
+          *ngIf="lessonForm.get('content_type')?.value === 'external_link'"
+        >
           <div class="form-group">
             <label>External URL <span class="required">*</span></label>
-            <input 
-              type="url" 
-              class="form-control" 
+            <input
+              type="url"
+              class="form-control"
               formControlName="external_url"
               placeholder="https://example.com/resource"
-            >
+            />
           </div>
           <div class="form-group">
             <label>Link Title</label>
-            <input 
-              type="text" 
-              class="form-control" 
+            <input
+              type="text"
+              class="form-control"
               formControlName="external_title"
               placeholder="Title for the external resource"
-            >
+            />
           </div>
         </div>
 
         <!-- Quiz Content -->
-        <div class="content-fields" *ngIf="lessonForm.get('content_type')?.value === 'quiz'">
-          <div class="form-group">
-            <label>Number of Verses <span class="required">*</span></label>
-            <input
-              type="number"
-              class="form-control"
-              formControlName="quiz_verse_count"
-              min="2"
-              max="7"
-              placeholder="5"
-            >
-            <p class="help-text">How many verses to include (2-7)</p>
-          </div>
+        <div
+          class="content-fields"
+          *ngIf="lessonForm.get('content_type')?.value === 'quiz'"
+        >
           <div class="form-group">
             <label>Pass Threshold (%)</label>
             <input
@@ -325,52 +416,116 @@
               min="50"
               max="100"
               placeholder="85"
-            >
+            />
             <p class="help-text">Minimum average confidence to pass</p>
           </div>
           <div class="form-group">
             <label class="checkbox-label">
-              <input type="checkbox" formControlName="quiz_randomize">
-              Randomize verse selection
+              <input type="checkbox" formControlName="quiz_randomize" />
+              Randomize question order
             </label>
           </div>
-          <div class="quiz-warning" *ngIf="selectedLessonIndex === 0">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
-            </svg>
-            <span>First lesson cannot be a quiz as there are no previous lessons.</span>
+
+          <div class="quiz-cards-table">
+            <table class="cards-table" formArrayName="quiz_cards">
+              <thead>
+                <tr>
+                  <th class="th-reference">Reference</th>
+                  <th class="th-verses">Verses</th>
+                  <th class="th-actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let card of quizCards.controls; let i = index"
+                  [formGroupName]="i"
+                >
+                  <td class="td-reference">
+                    <app-verse-picker
+                      class="inline-picker"
+                      [theme]="'minimal'"
+                      [disabledModes]="['chapter']"
+                      [pageType]="'flashcard'"
+                      [maximumVerses]="getMaxVersesForCard(i)"
+                      (selectionApplied)="applyQuizSelection(i, $event)"
+                    ></app-verse-picker>
+                  </td>
+                  <td class="td-verses">{{ card.get("verseCount")?.value }}</td>
+                  <td class="td-actions">
+                    <button
+                      type="button"
+                      class="action-btn delete"
+                      (click)="removeQuizCard(i)"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                </tr>
+                <tr *ngIf="quizCards.length === 0" class="empty-row">
+                  <td class="empty-cell" colspan="3">No cards added.</td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              class="add-card-section"
+              *ngIf="quizCards.length < 3 && getTotalQuizVerses() < 5"
+            >
+              <button
+                type="button"
+                class="add-card-button"
+                (click)="addQuizCard()"
+              >
+                Add Card
+              </button>
+            </div>
+            <p class="help-text">Up to 3 cards or 5 verses total.</p>
           </div>
         </div>
 
         <!-- Common Fields -->
         <div class="form-group">
           <label>Audio Narration (Optional)</label>
-          <input 
-            type="url" 
-            class="form-control" 
+          <input
+            type="url"
+            class="form-control"
             formControlName="audio_url"
             placeholder="https://example.com/audio.mp3"
-          >
+          />
           <p class="help-text">Add an audio file URL for narration</p>
         </div>
 
         <div class="form-group">
           <label>Required Flashcards</label>
-          <input 
-            type="number" 
-            class="form-control" 
+          <input
+            type="number"
+            class="form-control"
             formControlName="flashcards_required"
             min="1"
             max="20"
-            style="width: 100px;"
-          >
-          <p class="help-text">Number of flashcards students must complete to unlock the next lesson</p>
+            style="width: 100px"
+          />
+          <p class="help-text">
+            Number of flashcards students must complete to unlock the next
+            lesson
+          </p>
         </div>
 
         <div class="lesson-actions">
-          <button 
-            type="button" 
-            class="btn btn-primary" 
+          <button
+            type="button"
+            class="btn btn-primary"
             (click)="saveLessonToMemory()"
             [disabled]="!lessonForm.valid"
           >
@@ -385,33 +540,41 @@
   <div class="review-section" *ngIf="currentStep === 3">
     <div class="review-content">
       <h2>Review Your Workflow</h2>
-      
+
       <div class="review-card">
-        <h3>{{ workflowForm.get('title')?.value }}</h3>
-        <p>{{ workflowForm.get('description')?.value }}</p>
-        
+        <h3>{{ workflowForm.get("title")?.value }}</h3>
+        <p>{{ workflowForm.get("description")?.value }}</p>
+
         <div class="review-meta">
           <div class="meta-item">
-            <strong>Visibility:</strong> 
-            {{ workflowForm.get('is_public')?.value ? 'Public' : 'Private' }}
+            <strong>Visibility:</strong>
+            {{ workflowForm.get("is_public")?.value ? "Public" : "Private" }}
           </div>
           <div class="meta-item">
             <strong>Total Lessons:</strong> {{ lessons.length }}
           </div>
           <div class="meta-item" *ngIf="selectedTags.length > 0">
-            <strong>Tags:</strong> 
-            <span class="tag-chip" *ngFor="let tag of selectedTags">{{ formatTag(tag) }}</span>
+            <strong>Tags:</strong>
+            <span class="tag-chip" *ngFor="let tag of selectedTags">{{
+              formatTag(tag)
+            }}</span>
           </div>
         </div>
       </div>
 
       <div class="lessons-review">
         <h3>Lessons</h3>
-        <div class="review-lesson" *ngFor="let lesson of lessons; let i = index">
+        <div
+          class="review-lesson"
+          *ngFor="let lesson of lessons; let i = index"
+        >
           <div class="lesson-number">{{ i + 1 }}</div>
           <div class="lesson-details">
             <strong>{{ lesson.title }}</strong>
-            <span class="lesson-type">{{ getLessonIcon(lesson.content_type) }} {{ getLessonTypeLabel(lesson.content_type) }}</span>
+            <span class="lesson-type"
+              >{{ getLessonIcon(lesson.content_type) }}
+              {{ getLessonTypeLabel(lesson.content_type) }}</span
+            >
           </div>
         </div>
       </div>
@@ -423,9 +586,9 @@
     <button class="btn btn-secondary" (click)="previousStep()">
       Previous Step
     </button>
-    <button 
-      class="btn btn-primary" 
-      (click)="nextStep()" 
+    <button
+      class="btn btn-primary"
+      (click)="nextStep()"
       [disabled]="!canProceed()"
       *ngIf="currentStep < 3"
     >

--- a/frontend/src/app/features/workflows/workflow-builder.component.html
+++ b/frontend/src/app/features/workflows/workflow-builder.component.html
@@ -534,44 +534,156 @@
     </div>
   </div>
 
-  <!-- Step 3: Review (Minimal Version) -->
-  <div class="review-section minimal" *ngIf="currentStep === 3">
+  <!-- Step 3: Review (Enhanced) -->
+  <div class="review-section enhanced" *ngIf="currentStep === 3">
     <div class="review-header">
-      <h2 class="review-title">{{ workflowForm.get("title")?.value }}</h2>
-      <p class="review-subtitle">
-        {{
-          workflowForm.get("is_public")?.value ? "Public" : "Private"
-        }}
-        workflow
-        <span class="separator">&bull;</span>
-        {{ lessons.length }} {{ lessons.length === 1 ? "lesson" : "lessons" }}
-        <span class="separator">&bull;</span>
-        ~{{ estimatedDuration }}
-        {{ estimatedDuration === 1 ? "hour" : "hours" }}
+      <h1 class="workflow-title">{{ workflowForm.get("title")?.value }}</h1>
+      <p class="workflow-description">
+        {{ workflowForm.get("description")?.value }}
       </p>
-    </div>
-
-    <div class="lesson-summary">
-      <div
-        *ngFor="let lesson of lessons; let i = index"
-        class="lesson-row"
-        [class.first]="i === 0"
-        [class.last]="i === lessons.length - 1"
-      >
-        <span class="lesson-number">{{
-          (i + 1).toString().padStart(2, "0")
-        }}</span>
-        <span class="lesson-name">{{ lesson.title }}</span>
-        <span class="lesson-icon">{{
-          getLessonIcon(lesson.content_type)
-        }}</span>
+      <div class="header-badges">
+        <div class="badge public" *ngIf="workflowForm.get('is_public')?.value">
+          <span class="badge-icon">🌍</span>
+          <span>Public Workflow</span>
+        </div>
+        <div class="badge public" *ngIf="!workflowForm.get('is_public')?.value">
+          <span class="badge-icon">🔒</span>
+          <span>Private Workflow</span>
+        </div>
+        <div class="badge duration">
+          <span class="badge-icon">⏱️</span>
+          <span>
+            ~{{ estimatedDuration }}
+            {{ estimatedDuration === 1 ? "hour" : "hours" }}
+          </span>
+        </div>
+        <div class="badge lessons">
+          <span class="badge-icon">📚</span>
+          <span>
+            {{ lessons.length }}
+            {{ lessons.length === 1 ? "Lesson" : "Lessons" }}
+          </span>
+        </div>
       </div>
     </div>
 
-    <div class="review-tags" *ngIf="selectedTags.length > 0">
-      <span class="tag" *ngFor="let tag of selectedTags">{{
-        formatTag(tag)
-      }}</span>
+    <div class="review-grid">
+      <div class="details-panel">
+        <h3 class="panel-title">
+          <span class="panel-title-icon">✨</span>
+          Workflow Details
+        </h3>
+
+        <div class="detail-item">
+          <div class="detail-label">
+            <span class="detail-icon">📝</span>
+            <span>Title</span>
+          </div>
+          <div class="detail-value">
+            {{ workflowForm.get("title")?.value }}
+          </div>
+        </div>
+
+        <div class="detail-item">
+          <div class="detail-label">
+            <span class="detail-icon">👁️</span>
+            <span>Visibility</span>
+          </div>
+          <div class="detail-value">
+            {{ workflowForm.get("is_public")?.value ? "Public" : "Private" }}
+          </div>
+        </div>
+
+        <div class="detail-item">
+          <div class="detail-label">
+            <span class="detail-icon">📊</span>
+            <span>Total Lessons</span>
+          </div>
+          <div class="detail-value">{{ lessons.length }}</div>
+        </div>
+
+        <div class="detail-item">
+          <div class="detail-label">
+            <span class="detail-icon">⏰</span>
+            <span>Est. Duration</span>
+          </div>
+          <div class="detail-value">
+            {{ estimatedDuration }}
+            {{ estimatedDuration === 1 ? "hour" : "hours" }}
+          </div>
+        </div>
+
+        <div class="detail-item" *ngIf="selectedTags.length > 0">
+          <div class="detail-label">
+            <span class="detail-icon">🏷️</span>
+            <span>Tags</span>
+          </div>
+          <div class="tags-display">
+            <span class="tag" *ngFor="let tag of selectedTags">
+              {{ formatTag(tag) }}
+            </span>
+          </div>
+        </div>
+
+        <div class="chart-section" *ngIf="pieSlices.length">
+          <h4>Content Distribution</h4>
+          <div class="chart-container">
+            <div class="pie-chart">
+              <svg width="150" height="150">
+                <circle cx="75" cy="75" r="60" fill="#f3f4f6"></circle>
+                <ng-container *ngFor="let slice of pieSlices">
+                  <path [attr.d]="slice.path" [attr.fill]="slice.color"></path>
+                </ng-container>
+              </svg>
+            </div>
+            <div class="chart-legend">
+              <div class="legend-item" *ngFor="let slice of pieSlices">
+                <div
+                  class="legend-color"
+                  [style.background]="slice.color"
+                ></div>
+                <span>
+                  {{ slice.icon }} {{ slice.label }} ({{ slice.count }})
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="lessons-panel" style="position: relative">
+        <span class="ready-badge">Ready!</span>
+        <h3 class="panel-title">
+          <span class="panel-title-icon">📖</span>
+          Lesson Structure
+        </h3>
+        <div class="lesson-list">
+          <div
+            class="lesson-card"
+            *ngFor="let lesson of lessons; let i = index"
+          >
+            <div class="lesson-number">{{ i + 1 }}</div>
+            <div class="lesson-content">
+              <div class="lesson-title">{{ lesson.title }}</div>
+              <div class="lesson-type">
+                {{ getLessonTypeLabel(lesson.content_type) }}
+              </div>
+            </div>
+            <div class="lesson-emoji">
+              {{ getLessonIcon(lesson.content_type) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-actions">
+      <button class="btn btn-secondary" (click)="previousStep()">
+        ← Edit Lessons
+      </button>
+      <button class="btn btn-primary" (click)="saveWorkflow()">
+        Publish Workflow 🚀
+      </button>
     </div>
   </div>
 

--- a/frontend/src/app/features/workflows/workflow-builder.component.html
+++ b/frontend/src/app/features/workflows/workflow-builder.component.html
@@ -534,48 +534,44 @@
     </div>
   </div>
 
-  <!-- Step 3: Review -->
-  <div class="review-section" *ngIf="currentStep === 3">
-    <div class="review-content">
-      <h2>Review Your Workflow</h2>
+  <!-- Step 3: Review (Minimal Version) -->
+  <div class="review-section minimal" *ngIf="currentStep === 3">
+    <div class="review-header">
+      <h2 class="review-title">{{ workflowForm.get("title")?.value }}</h2>
+      <p class="review-subtitle">
+        {{
+          workflowForm.get("is_public")?.value ? "Public" : "Private"
+        }}
+        workflow
+        <span class="separator">&bull;</span>
+        {{ lessons.length }} {{ lessons.length === 1 ? "lesson" : "lessons" }}
+        <span class="separator">&bull;</span>
+        ~{{ estimatedDuration }}
+        {{ estimatedDuration === 1 ? "hour" : "hours" }}
+      </p>
+    </div>
 
-      <div class="review-card">
-        <h3>{{ workflowForm.get("title")?.value }}</h3>
-        <p>{{ workflowForm.get("description")?.value }}</p>
-
-        <div class="review-meta">
-          <div class="meta-item">
-            <strong>Visibility:</strong>
-            {{ workflowForm.get("is_public")?.value ? "Public" : "Private" }}
-          </div>
-          <div class="meta-item">
-            <strong>Total Lessons:</strong> {{ lessons.length }}
-          </div>
-          <div class="meta-item" *ngIf="selectedTags.length > 0">
-            <strong>Tags:</strong>
-            <span class="tag-chip" *ngFor="let tag of selectedTags">{{
-              formatTag(tag)
-            }}</span>
-          </div>
-        </div>
+    <div class="lesson-summary">
+      <div
+        *ngFor="let lesson of lessons; let i = index"
+        class="lesson-row"
+        [class.first]="i === 0"
+        [class.last]="i === lessons.length - 1"
+      >
+        <span class="lesson-number">{{
+          (i + 1).toString().padStart(2, "0")
+        }}</span>
+        <span class="lesson-name">{{ lesson.title }}</span>
+        <span class="lesson-icon">{{
+          getLessonIcon(lesson.content_type)
+        }}</span>
       </div>
+    </div>
 
-      <div class="lessons-review">
-        <h3>Lessons</h3>
-        <div
-          class="review-lesson"
-          *ngFor="let lesson of lessons; let i = index"
-        >
-          <div class="lesson-number">{{ i + 1 }}</div>
-          <div class="lesson-details">
-            <strong>{{ lesson.title }}</strong>
-            <span class="lesson-type"
-              >{{ getLessonIcon(lesson.content_type) }}
-              {{ getLessonTypeLabel(lesson.content_type) }}</span
-            >
-          </div>
-        </div>
-      </div>
+    <div class="review-tags" *ngIf="selectedTags.length > 0">
+      <span class="tag" *ngFor="let tag of selectedTags">{{
+        formatTag(tag)
+      }}</span>
     </div>
   </div>
 

--- a/frontend/src/app/features/workflows/workflow-builder.component.html
+++ b/frontend/src/app/features/workflows/workflow-builder.component.html
@@ -363,9 +363,7 @@
               placeholder="Write your article content here..."
             ></textarea>
             <div class="char-count">
-              {{
-                lessonForm.get("article_text")?.value?.length || 0
-              }}
+              {{ lessonForm.get("article_text")?.value?.length || 0 }}
               characters
               <span
                 *ngIf="lessonForm.get('article_text')?.errors?.['minLength']"

--- a/frontend/src/app/features/workflows/workflow-builder.component.scss
+++ b/frontend/src/app/features/workflows/workflow-builder.component.scss
@@ -760,3 +760,92 @@ textarea.form-control {
     }
   }
 }
+
+// Review (Minimal) Styles
+.review-section.minimal {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.review-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.review-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 0.5rem;
+}
+
+.review-subtitle {
+  color: #6b7280;
+  font-size: 0.875rem;
+
+  .separator {
+    margin: 0 0.5rem;
+    color: #d1d5db;
+  }
+}
+
+.lesson-summary {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.lesson-row {
+  display: flex;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #f3f4f6;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #f9fafb;
+  }
+
+  &.last {
+    border-bottom: none;
+  }
+}
+
+.lesson-number {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #9ca3af;
+  width: 2rem;
+  flex-shrink: 0;
+}
+
+.lesson-name {
+  flex: 1;
+  font-size: 0.875rem;
+  color: #374151;
+  padding-right: 1rem;
+}
+
+.lesson-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.review-tags {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+
+  .tag {
+    padding: 0.375rem 0.875rem;
+    background: #e0e7ff;
+    color: #4338ca;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+}

--- a/frontend/src/app/features/workflows/workflow-builder.component.scss
+++ b/frontend/src/app/features/workflows/workflow-builder.component.scss
@@ -387,7 +387,7 @@ textarea.form-control {
   cursor: pointer;
   border-radius: 0.25rem;
   transition: all 0.2s;
-  
+
   &:hover {
     background: #fee2e2;
     color: #ef4444;
@@ -671,5 +671,92 @@ textarea.form-control {
 
   .content-type-selector {
     grid-template-columns: 1fr;
+  }
+}
+
+// Quiz cards table styles
+.quiz-cards-table {
+  margin-top: 1rem;
+}
+
+.cards-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  thead {
+    background: #f9fafb;
+    border-bottom: 2px solid #e5e7eb;
+  }
+
+  th {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+  }
+
+  td {
+    padding: 1rem;
+    vertical-align: middle;
+  }
+
+  .td-actions {
+    text-align: center;
+  }
+}
+
+.add-card-section {
+  padding: 1rem;
+  background: #f9fafb;
+  border-top: 1px solid #e5e7eb;
+  border-bottom-left-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.add-card-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: white;
+  border: 2px dashed #d1d5db;
+  border-radius: 0.5rem;
+  color: #6b7280;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: #3b82f6;
+    color: #3b82f6;
+    background: #eff6ff;
+  }
+}
+
+.action-btn.delete {
+  padding: 0.375rem;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    color: #6b7280;
+  }
+
+  &:hover {
+    border-color: #dc2626;
+    background: #fef2f2;
+    svg {
+      color: #dc2626;
+    }
   }
 }

--- a/frontend/src/app/features/workflows/workflow-builder.component.scss
+++ b/frontend/src/app/features/workflows/workflow-builder.component.scss
@@ -849,3 +849,345 @@ textarea.form-control {
     font-weight: 500;
   }
 }
+
+// Enhanced Review Styles
+.review-section.enhanced {
+  max-width: 1200px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+
+  .review-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    position: relative;
+    padding-bottom: 2rem;
+
+    &::after {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 100px;
+      height: 3px;
+      background: linear-gradient(to right, #3b82f6, #8b5cf6);
+      border-radius: 2px;
+    }
+  }
+
+  .workflow-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 0.75rem;
+  }
+
+  .workflow-description {
+    font-size: 1.125rem;
+    color: #6b7280;
+    max-width: 600px;
+    margin: 0 auto 1.5rem;
+    line-height: 1.75;
+  }
+
+  .header-badges {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: #f3f4f6;
+      border-radius: 9999px;
+      font-size: 0.875rem;
+      font-weight: 500;
+
+      &.public {
+        background: #dbeafe;
+        color: #1e40af;
+      }
+
+      &.duration {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      &.lessons {
+        background: #d1fae5;
+        color: #065f46;
+      }
+
+      .badge-icon {
+        font-size: 1.125rem;
+      }
+    }
+  }
+
+  .review-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .details-panel,
+  .lessons-panel {
+    background: #f9fafb;
+    border-radius: 0.75rem;
+    padding: 2rem;
+    border: 1px solid #e5e7eb;
+  }
+
+  .panel-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .panel-title-icon {
+      font-size: 1.5rem;
+    }
+  }
+
+  .detail-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.875rem 0;
+    border-bottom: 1px solid #e5e7eb;
+    transition: all 0.2s;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      padding-left: 0.5rem;
+    }
+
+    .detail-label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #6b7280;
+      font-size: 0.875rem;
+
+      .detail-icon {
+        font-size: 1.125rem;
+      }
+    }
+
+    .detail-value {
+      font-weight: 600;
+      color: #1f2937;
+    }
+  }
+
+  .tags-display {
+    display: flex;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+
+    .tag {
+      padding: 0.25rem 0.625rem;
+      background: #e0e7ff;
+      color: #4338ca;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+  }
+
+  .chart-section {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e5e7eb;
+
+    .chart-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+      gap: 2rem;
+
+      .pie-chart {
+        position: relative;
+        width: 150px;
+        height: 150px;
+
+        svg {
+          transform: rotate(-90deg);
+        }
+      }
+
+      .chart-legend {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+
+        .legend-item {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          font-size: 0.875rem;
+
+          .legend-color {
+            width: 16px;
+            height: 16px;
+            border-radius: 0.25rem;
+          }
+        }
+      }
+    }
+  }
+
+  .lesson-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .lesson-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background: white;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    transition: all 0.2s;
+    cursor: pointer;
+
+    &:hover {
+      border-color: #3b82f6;
+      transform: translateX(4px);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .lesson-number {
+      width: 36px;
+      height: 36px;
+      background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+      color: white;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      font-size: 0.875rem;
+      flex-shrink: 0;
+    }
+
+    .lesson-content {
+      flex: 1;
+
+      .lesson-title {
+        font-weight: 500;
+        color: #1f2937;
+        margin-bottom: 0.125rem;
+      }
+
+      .lesson-type {
+        font-size: 0.75rem;
+        color: #6b7280;
+      }
+    }
+
+    .lesson-emoji {
+      font-size: 1.75rem;
+      flex-shrink: 0;
+    }
+  }
+
+  .review-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid #e5e7eb;
+
+    .btn {
+      padding: 0.875rem 2rem;
+      border: none;
+      border-radius: 0.5rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      &.btn-secondary {
+        background: #f3f4f6;
+        color: #374151;
+
+        &:hover {
+          background: #e5e7eb;
+          transform: translateX(-2px);
+        }
+      }
+
+      &.btn-primary {
+        background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+        color: white;
+        box-shadow: 0 4px 14px rgba(59, 130, 246, 0.3);
+
+        &:hover {
+          transform: translateY(-2px);
+          box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+        }
+      }
+    }
+  }
+
+  .ready-badge {
+    position: absolute;
+    top: -0.5rem;
+    right: -0.5rem;
+    background: #10b981;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    animation: pulse 2s infinite;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+@media (max-width: 768px) {
+  .review-section.enhanced {
+    .review-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .workflow-title {
+      font-size: 2rem;
+    }
+
+    .chart-container {
+      flex-direction: column;
+      gap: 1rem;
+    }
+  }
+}

--- a/frontend/src/app/features/workflows/workflow-builder.component.ts
+++ b/frontend/src/app/features/workflows/workflow-builder.component.ts
@@ -16,7 +16,10 @@ import { UserService } from '../../core/services/user.service';
 import { ModalService } from '../../core/services/modal.service';
 
 import { LessonContent } from '../../core/models/workflow.model';
-import { VerseSelection } from '../shared/components/verse-range-picker/verse-range-picker.component';
+import {
+  VersePickerComponent,
+  VerseSelection,
+} from '../../shared/components/verse-range-picker/verse-range-picker.component';
 
 interface Lesson {
   id?: number;
@@ -47,7 +50,12 @@ interface Lesson {
 @Component({
   selector: 'app-workflow-builder',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    VersePickerComponent,
+  ],
   templateUrl: './workflow-builder.component.html',
   styleUrls: ['./workflow-builder.component.scss'],
 })

--- a/frontend/src/app/features/workflows/workflow-builder.component.ts
+++ b/frontend/src/app/features/workflows/workflow-builder.component.ts
@@ -2,13 +2,21 @@
 
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+  FormArray,
+} from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { WorkflowService } from '../../core/services/workflow.service';
 import { UserService } from '../../core/services/user.service';
 import { ModalService } from '../../core/services/modal.service';
 
 import { LessonContent } from '../../core/models/workflow.model';
+import { VerseSelection } from '../shared/components/verse-range-picker/verse-range-picker.component';
 
 interface Lesson {
   id?: number;
@@ -31,6 +39,7 @@ interface Lesson {
   quiz_verse_count?: number;
   quiz_pass_threshold?: number;
   quiz_randomize?: boolean;
+  quiz_cards?: { verseCodes: string[]; reference: string }[];
   flashcards_required: number;
   position: number;
 }
@@ -40,31 +49,31 @@ interface Lesson {
   standalone: true,
   imports: [CommonModule, FormsModule, ReactiveFormsModule],
   templateUrl: './workflow-builder.component.html',
-  styleUrls: ['./workflow-builder.component.scss']
+  styleUrls: ['./workflow-builder.component.scss'],
 })
 export class WorkflowBuilderComponent implements OnInit {
   workflowForm!: FormGroup;
   lessonForm!: FormGroup;
-  
+
   isEditMode = false;
   workflowId?: number;
   saving = false;
   savingLesson = false;
-  
+
   lessons: Lesson[] = [];
   selectedLessonIndex: number | null = null;
-  
+
   availableTags: string[] = [];
   selectedTags: string[] = [];
-  
+
   userId!: number;
-  
+
   // Step navigation
   currentStep = 1;
   steps = [
     { number: 1, title: 'Basic Info', description: 'Title & description' },
     { number: 2, title: 'Add Lessons', description: 'Create content' },
-    { number: 3, title: 'Review', description: 'Preview & settings' }
+    { number: 3, title: 'Review', description: 'Preview & settings' },
   ];
 
   constructor(
@@ -73,15 +82,15 @@ export class WorkflowBuilderComponent implements OnInit {
     private router: Router,
     private workflowService: WorkflowService,
     private userService: UserService,
-    private modalService: ModalService
+    private modalService: ModalService,
   ) {
     this.initializeForms();
   }
 
   ngOnInit() {
     this.availableTags = this.workflowService.getSuggestedTags();
-    
-    this.userService.currentUser$.subscribe(user => {
+
+    this.userService.currentUser$.subscribe((user) => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
       } else {
@@ -89,7 +98,7 @@ export class WorkflowBuilderComponent implements OnInit {
       }
     });
 
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       if (params['id']) {
         this.workflowId = +params['id'];
         this.isEditMode = true;
@@ -103,7 +112,7 @@ export class WorkflowBuilderComponent implements OnInit {
       title: ['', Validators.required],
       description: ['', Validators.required],
       thumbnail_url: [''],
-      is_public: [true]
+      is_public: [true],
     });
 
     this.lessonForm = this.fb.group({
@@ -118,43 +127,123 @@ export class WorkflowBuilderComponent implements OnInit {
       quiz_verse_count: [5],
       quiz_pass_threshold: [85],
       quiz_randomize: [true],
-      flashcards_required: [3, [Validators.required, Validators.min(1), Validators.max(20)]]
+      quiz_cards: this.fb.array([]),
+      flashcards_required: [
+        3,
+        [Validators.required, Validators.min(1), Validators.max(20)],
+      ],
     });
 
     this.setupContentTypeValidation();
   }
 
   setupContentTypeValidation() {
-    this.lessonForm.get('content_type')?.valueChanges.subscribe(type => {
+    this.lessonForm.get('content_type')?.valueChanges.subscribe((type) => {
       const controls = {
         youtube_url: this.lessonForm.get('youtube_url'),
         article_text: this.lessonForm.get('article_text'),
         external_url: this.lessonForm.get('external_url'),
         quiz_verse_count: this.lessonForm.get('quiz_verse_count'),
-        quiz_pass_threshold: this.lessonForm.get('quiz_pass_threshold')
+        quiz_pass_threshold: this.lessonForm.get('quiz_pass_threshold'),
       };
 
       // Clear all validators
-      Object.values(controls).forEach(control => control?.clearValidators());
+      Object.values(controls).forEach((control) => control?.clearValidators());
 
       // Set validators based on type
-      switch(type) {
+      switch (type) {
         case 'video':
           controls.youtube_url?.setValidators([Validators.required]);
           break;
         case 'article':
-          controls.article_text?.setValidators([Validators.required, Validators.minLength(100)]);
+          controls.article_text?.setValidators([
+            Validators.required,
+            Validators.minLength(100),
+          ]);
           break;
         case 'external_link':
           controls.external_url?.setValidators([Validators.required]);
           break;
         case 'quiz':
-          controls.quiz_verse_count?.setValidators([Validators.required, Validators.min(2), Validators.max(7)]);
-          controls.quiz_pass_threshold?.setValidators([Validators.required, Validators.min(50), Validators.max(100)]);
+          controls.quiz_verse_count?.setValidators([
+            Validators.required,
+            Validators.min(2),
+            Validators.max(7),
+          ]);
+          controls.quiz_pass_threshold?.setValidators([
+            Validators.required,
+            Validators.min(50),
+            Validators.max(100),
+          ]);
+          if (this.quizCards.length === 0) {
+            this.addQuizCard();
+          }
           break;
       }
 
-      Object.values(controls).forEach(control => control?.updateValueAndValidity());
+      Object.values(controls).forEach((control) =>
+        control?.updateValueAndValidity(),
+      );
+
+      if (type !== 'quiz') {
+        while (this.quizCards.length) {
+          this.quizCards.removeAt(0);
+        }
+      }
+    });
+  }
+
+  get quizCards(): FormArray {
+    return this.lessonForm.get('quiz_cards') as FormArray;
+  }
+
+  createQuizCardGroup(): FormGroup {
+    return this.fb.group({
+      reference: ['Select verses...'],
+      verseCodes: [[]],
+      verseCount: [0],
+    });
+  }
+
+  addQuizCard() {
+    if (this.quizCards.length >= 3 || this.getTotalQuizVerses() >= 5) return;
+    this.quizCards.push(this.createQuizCardGroup());
+  }
+
+  removeQuizCard(index: number) {
+    this.quizCards.removeAt(index);
+  }
+
+  getTotalQuizVerses(): number {
+    return this.quizCards.controls.reduce(
+      (sum, c) => sum + (c.get('verseCount')?.value || 0),
+      0,
+    );
+  }
+
+  getMaxVersesForCard(index: number): number {
+    const current = this.quizCards.at(index);
+    const remaining =
+      5 - (this.getTotalQuizVerses() - (current.get('verseCount')?.value || 0));
+    return remaining > 0 ? remaining : 1;
+  }
+
+  applyQuizSelection(index: number, sel: VerseSelection) {
+    const current = this.quizCards.at(index);
+    const totalExcl =
+      this.getTotalQuizVerses() - (current.get('verseCount')?.value || 0);
+    if (totalExcl + sel.verseCodes.length > 5) {
+      this.modalService.alert(
+        'Limit Reached',
+        'You can only select up to 5 verses across all cards.',
+        'warning',
+      );
+      return;
+    }
+    current.patchValue({
+      reference: sel.reference,
+      verseCodes: sel.verseCodes,
+      verseCount: sel.verseCount,
     });
   }
 
@@ -172,7 +261,7 @@ export class WorkflowBuilderComponent implements OnInit {
           title: workflow.title,
           description: workflow.description,
           thumbnail_url: workflow.thumbnail_url,
-          is_public: workflow.is_public
+          is_public: workflow.is_public,
         });
 
         this.selectedTags = [...workflow.tags];
@@ -186,14 +275,15 @@ export class WorkflowBuilderComponent implements OnInit {
           quiz_verse_count: lesson.content_data?.quiz_config?.verse_count,
           quiz_pass_threshold: lesson.content_data?.quiz_config?.pass_threshold,
           quiz_randomize: lesson.content_data?.quiz_config?.randomize,
+          quiz_cards: [],
           flashcards_required: 3, // Default value, as it's not in the API response
-          position: index + 1
+          position: index + 1,
         }));
 
         if (this.lessons.length > 0) {
           this.selectLesson(0);
         }
-      }
+      },
     });
   }
 
@@ -214,11 +304,27 @@ export class WorkflowBuilderComponent implements OnInit {
       external_url: lesson.external_url || '',
       external_title: lesson.external_title || '',
       audio_url: lesson.audio_url || '',
-      quiz_verse_count: lesson.quiz_verse_count || 5,
+      quiz_verse_count: lesson.quiz_cards
+        ? lesson.quiz_cards.reduce((t, c) => t + c.verseCodes.length, 0)
+        : lesson.quiz_verse_count || 5,
       quiz_pass_threshold: lesson.quiz_pass_threshold || 85,
       quiz_randomize: lesson.quiz_randomize ?? true,
-      flashcards_required: lesson.flashcards_required
+      flashcards_required: lesson.flashcards_required,
     });
+
+    const cards = lesson.quiz_cards || [];
+    const arr = this.fb.array(cards.map(() => this.createQuizCardGroup()));
+    arr.controls.forEach((ctrl, idx) => {
+      const c = cards[idx];
+      if (c) {
+        ctrl.patchValue({
+          reference: c.reference,
+          verseCodes: c.verseCodes,
+          verseCount: c.verseCodes.length,
+        });
+      }
+    });
+    this.lessonForm.setControl('quiz_cards', arr);
 
     this.lessonForm.markAsPristine();
   }
@@ -230,8 +336,9 @@ export class WorkflowBuilderComponent implements OnInit {
       quiz_verse_count: 5,
       quiz_pass_threshold: 85,
       quiz_randomize: true,
+      quiz_cards: [],
       flashcards_required: 3,
-      position: this.lessons.length + 1
+      position: this.lessons.length + 1,
     };
 
     this.lessons.push(newLesson);
@@ -244,41 +351,48 @@ export class WorkflowBuilderComponent implements OnInit {
     const formValue = this.lessonForm.value;
     this.lessons[this.selectedLessonIndex] = {
       ...this.lessons[this.selectedLessonIndex],
-      ...formValue
+      ...formValue,
+      quiz_cards: this.quizCards.value,
+      quiz_verse_count: this.getTotalQuizVerses(),
     };
   }
 
   deleteLesson(index: number) {
-    this.modalService.danger(
-      'Delete Lesson',
-      'Are you sure you want to delete this lesson? This action cannot be undone.',
-      'Delete'
-    ).then(confirmed => {
-      if (confirmed) {
-        this.lessons.splice(index, 1);
-        this.updatePositions();
-        
-        if (this.selectedLessonIndex === index) {
-          this.selectedLessonIndex = null;
-          this.lessonForm.reset();
-        } else if (this.selectedLessonIndex && this.selectedLessonIndex > index) {
-          this.selectedLessonIndex--;
+    this.modalService
+      .danger(
+        'Delete Lesson',
+        'Are you sure you want to delete this lesson? This action cannot be undone.',
+        'Delete',
+      )
+      .then((confirmed) => {
+        if (confirmed) {
+          this.lessons.splice(index, 1);
+          this.updatePositions();
+
+          if (this.selectedLessonIndex === index) {
+            this.selectedLessonIndex = null;
+            this.lessonForm.reset();
+          } else if (
+            this.selectedLessonIndex &&
+            this.selectedLessonIndex > index
+          ) {
+            this.selectedLessonIndex--;
+          }
         }
-      }
-    });
+      });
   }
 
   moveLesson(fromIndex: number, direction: 'up' | 'down') {
     const toIndex = direction === 'up' ? fromIndex - 1 : fromIndex + 1;
-    
+
     if (toIndex < 0 || toIndex >= this.lessons.length) return;
-    
+
     const temp = this.lessons[fromIndex];
     this.lessons[fromIndex] = this.lessons[toIndex];
     this.lessons[toIndex] = temp;
-    
+
     this.updatePositions();
-    
+
     // Update selected index if needed
     if (this.selectedLessonIndex === fromIndex) {
       this.selectedLessonIndex = toIndex;
@@ -294,22 +408,32 @@ export class WorkflowBuilderComponent implements OnInit {
   }
 
   getLessonIcon(type: string): string {
-    switch(type) {
-      case 'video': return '📹';
-      case 'article': return '📄';
-      case 'external_link': return '🔗';
-      case 'quiz': return '❓';
-      default: return '📝';
+    switch (type) {
+      case 'video':
+        return '📹';
+      case 'article':
+        return '📄';
+      case 'external_link':
+        return '🔗';
+      case 'quiz':
+        return '❓';
+      default:
+        return '📝';
     }
   }
 
   getLessonTypeLabel(type: string): string {
-    switch(type) {
-      case 'video': return 'Video lesson';
-      case 'article': return 'Article';
-      case 'external_link': return 'External link';
-      case 'quiz': return 'Quiz';
-      default: return 'No type selected';
+    switch (type) {
+      case 'video':
+        return 'Video lesson';
+      case 'article':
+        return 'Article';
+      case 'external_link':
+        return 'External link';
+      case 'quiz':
+        return 'Quiz';
+      default:
+        return 'No type selected';
     }
   }
 
@@ -320,30 +444,30 @@ export class WorkflowBuilderComponent implements OnInit {
   }
 
   removeTag(tag: string) {
-    this.selectedTags = this.selectedTags.filter(t => t !== tag);
+    this.selectedTags = this.selectedTags.filter((t) => t !== tag);
   }
 
   formatTag(tag: string): string {
     return tag
       .split('-')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
   }
 
   // Step navigation methods
   goToStep(step: number) {
     if (step === this.currentStep) return;
-    
+
     // Validate current step before moving
     if (step > this.currentStep && !this.canProceed()) {
       return;
     }
-    
+
     // Save lesson changes if on step 2
     if (this.currentStep === 2 && this.selectedLessonIndex !== null) {
       this.saveLessonToMemory();
     }
-    
+
     this.currentStep = step;
   }
 
@@ -387,7 +511,11 @@ export class WorkflowBuilderComponent implements OnInit {
     }
 
     if (this.lessons.length === 0) {
-      this.modalService.alert('No Lessons', 'Please add at least one lesson to your workflow.', 'warning');
+      this.modalService.alert(
+        'No Lessons',
+        'Please add at least one lesson to your workflow.',
+        'warning',
+      );
       return;
     }
 
@@ -396,33 +524,43 @@ export class WorkflowBuilderComponent implements OnInit {
     try {
       const workflowData = {
         ...this.workflowForm.value,
-        tags: this.selectedTags
+        tags: this.selectedTags,
       };
 
       if (this.isEditMode && this.workflowId) {
-        await this.workflowService.updateWorkflow(this.workflowId, workflowData).toPromise();
+        await this.workflowService
+          .updateWorkflow(this.workflowId, workflowData)
+          .toPromise();
         // Update lessons would go here
         this.modalService.success('Success', 'Workflow updated successfully!');
       } else {
-        const workflow = await this.workflowService.createWorkflow(workflowData, this.userId).toPromise();
-        
+        const workflow = await this.workflowService
+          .createWorkflow(workflowData, this.userId)
+          .toPromise();
+
         for (const lesson of this.lessons) {
-          await this.workflowService.createLesson({
-            workflow_id: workflow!.id,
-            title: lesson.title,
-            description: lesson.description,
-            content_type: lesson.content_type as any,
-            content_data: this.buildContentData(lesson),
-            audio_url: lesson.audio_url,
-            position: lesson.position
-          }).toPromise();
+          await this.workflowService
+            .createLesson({
+              workflow_id: workflow!.id,
+              title: lesson.title,
+              description: lesson.description,
+              content_type: lesson.content_type as any,
+              content_data: this.buildContentData(lesson),
+              audio_url: lesson.audio_url,
+              position: lesson.position,
+            })
+            .toPromise();
         }
 
         this.modalService.success('Success', 'Workflow created successfully!');
         this.router.navigate(['/workflows', workflow!.id]);
       }
     } catch (error) {
-      this.modalService.alert('Error', 'Failed to save workflow. Please try again.', 'danger');
+      this.modalService.alert(
+        'Error',
+        'Failed to save workflow. Please try again.',
+        'danger',
+      );
     } finally {
       this.saving = false;
     }
@@ -435,15 +573,21 @@ export class WorkflowBuilderComponent implements OnInit {
       case 'article':
         return { article_text: lesson.article_text };
       case 'external_link':
-        return { external_url: lesson.external_url, external_title: lesson.external_title };
+        return {
+          external_url: lesson.external_url,
+          external_title: lesson.external_title,
+        };
       case 'quiz':
         return {
           quiz_config: {
             source_lessons: [],
-            verse_count: lesson.quiz_verse_count,
+            verse_count: lesson.quiz_cards
+              ? lesson.quiz_cards.reduce((t, c) => t + c.verseCodes.length, 0)
+              : lesson.quiz_verse_count,
             pass_threshold: lesson.quiz_pass_threshold,
-            randomize: lesson.quiz_randomize
-          }
+            randomize: lesson.quiz_randomize,
+            flashcards: lesson.quiz_cards || [],
+          },
         };
       default:
         return {};
@@ -452,17 +596,19 @@ export class WorkflowBuilderComponent implements OnInit {
 
   cancel() {
     if (this.workflowForm.dirty || this.lessonForm.dirty) {
-      this.modalService.confirm({
-        title: 'Unsaved Changes',
-        message: 'You have unsaved changes. Are you sure you want to leave?',
-        type: 'warning',
-        confirmText: 'Leave',
-        showCancel: true
-      }).then(result => {
-        if (result.confirmed) {
-          this.navigateBack();
-        }
-      });
+      this.modalService
+        .confirm({
+          title: 'Unsaved Changes',
+          message: 'You have unsaved changes. Are you sure you want to leave?',
+          type: 'warning',
+          confirmText: 'Leave',
+          showCancel: true,
+        })
+        .then((result) => {
+          if (result.confirmed) {
+            this.navigateBack();
+          }
+        });
     } else {
       this.navigateBack();
     }

--- a/frontend/src/app/features/workflows/workflow-builder.component.ts
+++ b/frontend/src/app/features/workflows/workflow-builder.component.ts
@@ -415,6 +415,11 @@ export class WorkflowBuilderComponent implements OnInit {
     });
   }
 
+  get estimatedDuration(): number {
+    // Estimate ~30 minutes per lesson
+    return Math.ceil(this.lessons.length * 0.5);
+  }
+
   getLessonIcon(type: string): string {
     switch (type) {
       case 'video':

--- a/frontend/src/app/features/workflows/workflow-builder.component.ts
+++ b/frontend/src/app/features/workflows/workflow-builder.component.ts
@@ -420,6 +420,75 @@ export class WorkflowBuilderComponent implements OnInit {
     return Math.ceil(this.lessons.length * 0.5);
   }
 
+  get pieSlices() {
+    const counts = {
+      video: 0,
+      article: 0,
+      external_link: 0,
+      quiz: 0,
+    } as Record<string, number>;
+    for (const lesson of this.lessons) {
+      counts[lesson.content_type] = (counts[lesson.content_type] || 0) + 1;
+    }
+    const total = this.lessons.length || 1;
+    const colors: Record<string, string> = {
+      video: '#3b82f6',
+      article: '#8b5cf6',
+      external_link: '#10b981',
+      quiz: '#f59e0b',
+    };
+    const icons: Record<string, string> = {
+      video: '📹',
+      article: '📄',
+      external_link: '🔗',
+      quiz: '❓',
+    };
+    const slices: {
+      path: string;
+      color: string;
+      icon: string;
+      label: string;
+      count: number;
+    }[] = [];
+    let start = 0;
+    for (const type of Object.keys(counts)) {
+      const count = counts[type];
+      if (!count) continue;
+      const pct = count / total;
+      const end = start + pct;
+      slices.push({
+        path: this.describeArc(75, 75, 60, start * 360, end * 360),
+        color: colors[type],
+        icon: icons[type],
+        label: this.getLessonTypeLabel(type),
+        count,
+      });
+      start = end;
+    }
+    return slices;
+  }
+
+  polarToCartesian(cx: number, cy: number, r: number, angle: number) {
+    const rad = ((angle - 90) * Math.PI) / 180.0;
+    return {
+      x: cx + r * Math.cos(rad),
+      y: cy + r * Math.sin(rad),
+    };
+  }
+
+  describeArc(
+    cx: number,
+    cy: number,
+    r: number,
+    startAngle: number,
+    endAngle: number,
+  ) {
+    const start = this.polarToCartesian(cx, cy, r, endAngle);
+    const end = this.polarToCartesian(cx, cy, r, startAngle);
+    const large = endAngle - startAngle <= 180 ? '0' : '1';
+    return `M ${cx},${cy} L ${start.x},${start.y} A ${r},${r} 0 ${large} 0 ${end.x},${end.y} Z`;
+  }
+
   getLessonIcon(type: string): string {
     switch (type) {
       case 'video':


### PR DESCRIPTION
## Summary
- enable quiz lessons to select specific flashcards
- compute verse count from selected cards
- style and display a cards table similar to deck editor

## Testing
- `npx prettier frontend/src/app/features/workflows/workflow-builder.component.ts frontend/src/app/features/workflows/workflow-builder.component.html frontend/src/app/features/workflows/workflow-builder.component.scss -w`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb4dec84833184d72a119a89f2e0