### PR TITLE
Add Amazon Cognito integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -71,3 +71,19 @@ Use with main docker-compose.yml in project root.
 ## Files
 - `backend/services/api_bible.py` - API Bible service
 - `backend/routers/user_verses.py` - Includes `/verses/texts` endpoint
+
+# Amazon Cognito Integration
+
+## Setup
+1. Create a User Pool and App Client in the AWS console.
+2. Add the following variables to your `.env`:
+   ```
+   AWS_REGION=us-east-1
+   COGNITO_USER_POOL_ID=your_pool_id
+   COGNITO_APP_CLIENT_ID=your_client_id
+   ```
+3. Restart the backend after setting these values.
+
+## Files
+- `backend/services/aws_cognito.py` - Cognito helper class
+- `backend/routers/auth.py` - Signup and login endpoints

--- a/backend/config.py
+++ b/backend/config.py
@@ -28,6 +28,11 @@ class Config:
     API_BIBLE_KEY = os.getenv('API_BIBLE_KEY')
     DEFAULT_BIBLE_ID = os.getenv('DEFAULT_BIBLE_ID', 'de4e12af7f28f599-02')  # KJV
 
+    # Amazon Cognito
+    AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
+    COGNITO_USER_POOL_ID = os.getenv('COGNITO_USER_POOL_ID')
+    COGNITO_APP_CLIENT_ID = os.getenv('COGNITO_APP_CLIENT_ID')
+
     @classmethod
     def get_database_url(cls):
         return f"postgresql://{cls.DATABASE_USER}:{cls.DATABASE_PASSWORD}@{cls.DATABASE_HOST}:{cls.DATABASE_PORT}/{cls.DATABASE_NAME}"
@@ -38,3 +43,5 @@ class Config:
         logger.info(f"Database: {cls.DATABASE_HOST}:{cls.DATABASE_PORT}/{cls.DATABASE_NAME}")
         logger.info(f"API: {cls.API_HOST}:{cls.API_PORT}")
         logger.info(f"Frontend URL: {cls.FRONTEND_URL}")
+        logger.info(f"AWS Region: {cls.AWS_REGION}")
+        logger.info(f"Cognito User Pool: {cls.COGNITO_USER_POOL_ID}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,16 +60,17 @@ app.add_middleware(
 )
 
 # Import routers after app creation to avoid circular imports
-from routers import users, user_verses, decks, feature_requests, workflows
+from routers import users, user_verses, decks, feature_requests, workflows, auth
 
 # Include routers
 app.include_router(users.router, prefix="/api/users", tags=["users"])
-app.include_router(user_verses.router, prefix="/api/user-verses", tags=["verses"])
+app.include_router(user_verses.router, prefix="/api/user-verses", tags=["verses"]) 
 app.include_router(decks.router, prefix="/api/decks", tags=["decks"])
 app.include_router(
     feature_requests.router, prefix="/api/feature-requests", tags=["feature_requests"]
 )
 app.include_router(workflows.router, prefix="/api/workflows", tags=["workflows"])
+app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 
 
 @app.get("/api/health")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary==2.9.9
 pydantic==2.5.0
 python-dotenv==1.0.0
 requests==2.31.0
+boto3==1.34.113

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -7,3 +7,4 @@ from . import user_verses
 from . import decks
 from . import feature_requests
 from . import workflows
+from . import auth

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,36 @@
+# backend/routers/auth.py
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, EmailStr
+import logging
+from services.aws_cognito import CognitoService
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+cognito = CognitoService()
+
+class SignUpRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+@router.post("/signup")
+async def sign_up(req: SignUpRequest):
+    try:
+        resp = cognito.sign_up(req.email, req.password)
+        return {"user_sub": resp["UserSub"]}
+    except Exception as e:
+        logger.error(f"Sign up failed: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+@router.post("/login")
+async def login(req: LoginRequest):
+    try:
+        tokens = cognito.sign_in(req.email, req.password)
+        return tokens
+    except Exception as e:
+        logger.error(f"Login failed: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+

--- a/backend/services/aws_cognito.py
+++ b/backend/services/aws_cognito.py
@@ -1,0 +1,38 @@
+import boto3
+import logging
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+class CognitoService:
+    """Helper for interacting with Amazon Cognito"""
+
+    def __init__(self):
+        self.client = boto3.client("cognito-idp", region_name=Config.AWS_REGION)
+
+    def sign_up(self, email: str, password: str):
+        """Register a new user"""
+        return self.client.sign_up(
+            ClientId=Config.COGNITO_APP_CLIENT_ID,
+            Username=email,
+            Password=password,
+            UserAttributes=[{"Name": "email", "Value": email}],
+        )
+
+    def confirm_sign_up(self, email: str, code: str):
+        """Confirm a new user's email"""
+        return self.client.confirm_sign_up(
+            ClientId=Config.COGNITO_APP_CLIENT_ID,
+            Username=email,
+            ConfirmationCode=code,
+        )
+
+    def sign_in(self, email: str, password: str):
+        """Authenticate a user and return tokens"""
+        resp = self.client.initiate_auth(
+            AuthFlow="USER_PASSWORD_AUTH",
+            AuthParameters={"USERNAME": email, "PASSWORD": password},
+            ClientId=Config.COGNITO_APP_CLIENT_ID,
+        )
+        return resp.get("AuthenticationResult", {})
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       DATABASE_USER: ${DATABASE_USER}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       FRONTEND_URL: ${FRONTEND_URL}
+      AWS_REGION: ${AWS_REGION}
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID}
+      COGNITO_APP_CLIENT_ID: ${COGNITO_APP_CLIENT_ID}
     volumes:
       - ./backend:/app
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- integrate Amazon Cognito authentication with a new `auth` router
- add helper `CognitoService`
- configure AWS Cognito settings in `Config`
- document usage in the backend README
- include Cognito environment vars in Docker Compose and requirements

## Testing
- `python3 -m py_compile backend/services/aws_cognito.py backend/routers/auth.py backend/main.py backend/config.py`
- `python3 backend/services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: ng not found)*
- `python3 -m pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*

------
https://chatgpt.com/codex/tasks/task_e_6842491554f4833197323e55cff07ce0