### PR TITLE
Improve deck row drag preview

### DIFF
--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.html
@@ -157,10 +157,12 @@
             <tr
               *ngFor="let card of deckCards; let i = index"
               [class.selected]="selectedCards.has(card.card_id)"
+              [class.dragging]="draggedIndex === i"
               draggable="true"
-              (dragstart)="onDragStart(i, $event)"
-              (dragover)="onDragOver($event)"
+              (dragstart)="onDragStart(i)"
+              (dragover)="onDragOver(i, $event)"
               (drop)="onDrop(i)"
+              (dragend)="onDragEnd()"
             >
               <td class="td-checkbox">
                 <span class="drag-handle" title="Drag to reorder"></span>

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.scss
@@ -295,6 +295,10 @@ textarea.form-control {
   tbody tr[draggable="true"] {
     cursor: move;
   }
+
+  tbody tr.dragging {
+    opacity: 0.5;
+  }
 }
 
 // Table column widths

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
@@ -47,6 +47,8 @@ export class DeckEditorComponent implements OnInit {
 
   // Drag and drop
   draggedIndex: number | null = null;
+  private originalDeckCards: CardWithVerses[] | null = null;
+  private dropHandled = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -426,25 +428,33 @@ export class DeckEditorComponent implements OnInit {
     }
   }
 
-  onDragStart(index: number, event: DragEvent) {
+  onDragStart(index: number) {
     this.draggedIndex = index;
-    if (event.dataTransfer) {
-      const img = new Image();
-      img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/AcAAwUB/WM8JAgAAAAASUVORK5CYII=';
-      event.dataTransfer.setDragImage(img, 0, 0);
-    }
+    this.originalDeckCards = [...this.deckCards];
+    this.dropHandled = false;
   }
-
-  onDragOver(event: DragEvent) {
+  onDragOver(index: number, event: DragEvent) {
     event.preventDefault();
+    if (this.draggedIndex === null || index === this.draggedIndex) return;
+    const [moved] = this.deckCards.splice(this.draggedIndex, 1);
+    this.deckCards.splice(index, 0, moved);
+    this.draggedIndex = index;
   }
 
   onDrop(index: number) {
-    if (this.draggedIndex === null || this.draggedIndex === index) return;
-    const [moved] = this.deckCards.splice(this.draggedIndex, 1);
-    this.deckCards.splice(index, 0, moved);
+    if (this.draggedIndex === null) return;
+    this.dropHandled = true;
     this.draggedIndex = null;
+    this.originalDeckCards = null;
     this.saveCardOrder();
+  }
+
+  onDragEnd() {
+    if (!this.dropHandled && this.originalDeckCards) {
+      this.deckCards = this.originalDeckCards;
+    }
+    this.draggedIndex = null;
+    this.originalDeckCards = null;
   }
 
   saveCardOrder() {


### PR DESCRIPTION
## Summary
- show ghost style during drag
- reposition rows as they're dragged for a preview
- keep order if drag is cancelled

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684329aab5448331abfc401f3a35b771