### PR TITLE
Add OT/NT filter and enforce range minimum

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -12,6 +12,7 @@
       [theme]="'minimal'"
       [disabledModes]="['single']"
       [pageType]="'FLOW'"
+      [showFlowTip]="false"
       [minimumVerses]="10"
       [maximumVerses]="80"
       [warningMessage]="warningMessage"

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html
@@ -65,17 +65,42 @@
             </button>
           </div>
 
-          <!-- Book Selector -->
-          <div class="book-selector">
-            <select
-              [(ngModel)]="selectedBook"
-              (ngModelChange)="onBookChange()"
-              class="select-control book-select"
-            >
-              <option *ngFor="let book of books" [ngValue]="book">
-                {{ book.name }}
-              </option>
-            </select>
+          <!-- Book Row -->
+          <div class="book-row">
+            <!-- Testament Filter -->
+            <div class="testament-filter">
+              <label>
+                <input
+                  type="radio"
+                  name="testament"
+                  [value]="'old'"
+                  [(ngModel)]="testamentFilter"
+                  (change)="onTestamentChange()"
+                />
+                OT
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="testament"
+                  [value]="'new'"
+                  [(ngModel)]="testamentFilter"
+                  (change)="onTestamentChange()"
+                />
+                NT
+              </label>
+            </div>
+            <div class="book-selector">
+              <select
+                [(ngModel)]="selectedBook"
+                (ngModelChange)="onBookChange()"
+                class="select-control book-select"
+              >
+                <option *ngFor="let book of books" [ngValue]="book">
+                  {{ book.name }}
+                </option>
+              </select>
+            </div>
           </div>
 
           <!-- Chapter/Verse Inputs -->
@@ -86,24 +111,26 @@
                 mode === "range" ? "Start" : "Select"
               }}</label>
               <div class="input-row">
-                <input
-                  type="number"
+                <select
                   [(ngModel)]="selectedChapter"
                   (ngModelChange)="onChapterChange()"
-                  class="number-input"
-                  [min]="1"
-                  [max]="chapters.length"
-                />
+                  class="select-control chapter-select"
+                >
+                  <option *ngFor="let ch of chapters" [ngValue]="ch">
+                    {{ ch }}
+                  </option>
+                </select>
                 <span class="separator" *ngIf="mode !== 'chapter'">:</span>
-                <input
+                <select
                   *ngIf="mode !== 'chapter'"
-                  type="number"
                   [(ngModel)]="selectedVerse"
                   (ngModelChange)="onVerseChange()"
-                  class="number-input"
-                  [min]="1"
-                  [max]="verses.length"
-                />
+                  class="select-control verse-select"
+                >
+                  <option *ngFor="let v of verses" [ngValue]="v">
+                    {{ v }}
+                  </option>
+                </select>
               </div>
             </div>
 
@@ -111,27 +138,25 @@
             <div class="input-group" *ngIf="mode === 'range'">
               <label class="input-label">End</label>
               <div class="input-row">
-                <input
-                  type="number"
+                <select
                   [(ngModel)]="selectedEndChapter"
                   (ngModelChange)="onEndChapterChange()"
-                  class="number-input"
-                  [min]="selectedChapter"
-                  [max]="chapters.length"
-                />
+                  class="select-control chapter-select"
+                >
+                  <option *ngFor="let ch of endChapters" [ngValue]="ch">
+                    {{ ch }}
+                  </option>
+                </select>
                 <span class="separator">:</span>
-                <input
-                  type="number"
+                <select
                   [(ngModel)]="selectedEndVerse"
                   (ngModelChange)="onEndVerseChange()"
-                  class="number-input"
-                  [min]="
-                    mode === 'range' && selectedEndChapter === selectedChapter
-                      ? selectedVerse
-                      : 1
-                  "
-                  [max]="endVerses.length"
-                />
+                  class="select-control verse-select"
+                >
+                  <option *ngFor="let v of endVerses" [ngValue]="v">
+                    {{ v }}
+                  </option>
+                </select>
               </div>
             </div>
           </div>
@@ -183,7 +208,7 @@
           <!-- Page-specific message for FLOW -->
           <div
             class="page-message flow-message"
-            *ngIf="pageType === 'FLOW' && mode === 'range'"
+            *ngIf="pageType === 'FLOW' && mode === 'range' && showFlowTip"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
@@ -135,8 +135,56 @@
 }
 
 // Book Selector
-.book-selector {
+.book-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-bottom: 1rem;
+
+  .book-selector {
+    flex: 1;
+  }
+}
+
+.testament-filter {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #4b5563;
+
+    input[type="radio"] {
+      appearance: none;
+      width: 1rem;
+      height: 1rem;
+      border: 2px solid #3b82f6;
+      border-radius: 50%;
+      position: relative;
+
+      &::before {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background-color: #3b82f6;
+        opacity: 0;
+        transition: opacity 150ms;
+      }
+
+      &:checked::before {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 .select-control {
@@ -189,28 +237,9 @@
   gap: 0.25rem;
 }
 
-.number-input {
-  width: 3rem;
-  padding: 0.25rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.25rem;
-  text-align: center;
-  font-size: 0.875rem;
-  background-color: white;
-
-  &:focus {
-    outline: none;
-    border-color: #3b82f6;
-  }
-
-  // Hide number input arrows
-  &::-webkit-inner-spin-button,
-  &::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  -moz-appearance: textfield;
+.chapter-select,
+.verse-select {
+  width: 4rem;
 }
 
 .separator {
@@ -366,8 +395,7 @@
     }
   }
 
-  .select-control,
-  .number-input {
+  .select-control {
     background-color: rgba(0, 255, 65, 0.05);
     border-color: rgba(0, 255, 65, 0.3);
     color: #00ff41;


### PR DESCRIPTION
## Summary
- add `showFlowTip` option and OT/NT radio filter to `VersePickerComponent`
- ensure range mode never selects fewer than two verses
- hide flow tip and generic min warning in Flow page
- style testament filter radio buttons and align them next to book selector
- move testament filter to the left of the book dropdown
- use dropdowns for chapter and verse selection to prevent out-of-bound input

## Testing
- `npx prettier -w frontend/src/app/shared/components/verse-range-picker/verse-picker.component.html frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts`
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432fa7ffd08331b98bca0ae1600c09