### PR TITLE
Update FLOW verse loading behavior

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -16,7 +16,7 @@
       [minimumVerses]="10"
       [maximumVerses]="80"
       [warningMessage]="warningMessage"
-      (selectionChanged)="onVerseSelectionChanged($event)"
+      (selectionApplied)="onVerseSelectionChanged($event)"
     >
     </app-verse-picker>
     <div *ngIf="verses.length > 0" class="layout-controls">
@@ -80,6 +80,14 @@
   <div *ngIf="isLoading" class="loading-container">
     <div class="loading-spinner"></div>
     <p>Loading verses...</p>
+  </div>
+
+  <!-- Prompt when no selection applied -->
+  <div *ngIf="!isLoading && verses.length === 0" class="selection-prompt">
+    <span class="prompt-emoji" aria-hidden="true">📖</span>
+    <span class="prompt-text">
+      Select verses above and click <strong>Apply Selection</strong> to begin.
+    </span>
   </div>
 
   <!-- Grid View -->

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -114,6 +114,30 @@
   text-align: center;
 }
 
+// Prompt when no verses selected
+.selection-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  font-size: 1.125rem;
+  color: #4b5563;
+  text-align: center;
+  background: #f9fafb;
+  border: 2px dashed #cbd5e1;
+  border-radius: 0.75rem;
+}
+
+.prompt-emoji {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.prompt-text strong {
+  color: #1f2937;
+}
+
 .loading-spinner {
   width: 3rem;
   height: 3rem;

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -99,6 +99,11 @@ export class VersePickerComponent implements OnInit {
       (m) => !this.disabledModes.includes(m),
     );
 
+    // Default FLOW pages to chapter mode when available
+    if (this.pageType === 'FLOW' && !this.disabledModes.includes('chapter')) {
+      this.mode = 'chapter';
+    }
+
     // Set default mode based on disabled modes
     if (this.disabledModes.includes(this.mode)) {
       // Find first available mode


### PR DESCRIPTION
## Summary
- require clicking **Apply Selection** before Flow loads verses
- show a prompt when no selection has been applied
- default Flow verse picker to chapter mode
- polish the prompt with an emoji and styled container

## Testing
- `npm test --silent` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_684335a50f848331ac6f054230fb0b0e