### PR TITLE
Rename workflows to courses

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -60,7 +60,7 @@ app.add_middleware(
 )
 
 # Import routers after app creation to avoid circular imports
-from routers import users, user_verses, decks, feature_requests, workflows
+from routers import users, user_verses, decks, feature_requests, courses
 
 # Include routers
 app.include_router(users.router, prefix="/api/users", tags=["users"])
@@ -69,7 +69,7 @@ app.include_router(decks.router, prefix="/api/decks", tags=["decks"])
 app.include_router(
     feature_requests.router, prefix="/api/feature-requests", tags=["feature_requests"]
 )
-app.include_router(workflows.router, prefix="/api/workflows", tags=["workflows"])
+app.include_router(courses.router, prefix="/api/courses", tags=["courses"])
 
 
 @app.get("/api/health")

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -6,4 +6,4 @@ from . import users
 from . import user_verses
 from . import decks
 from . import feature_requests
-from . import workflows
+from . import courses

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,8 +10,8 @@ import { DeckEditorComponent } from './features/memorize/decks/deck-editor/deck-
 import { DeckStudyComponent } from './features/memorize/decks/deck-study/deck-study.component';
 import { DeckListComponent } from './features/memorize/decks/deck-list/deck-list.component';
 import { FeatureRequestComponent } from './features/feature-request/feature-request.component';
-import { WorkflowListComponent } from './features/memorize/courses/workflow-list.component';
-import { WorkflowBuilderComponent } from './features/memorize/courses/workflow-builder.component';
+import { CourseListComponent } from './features/memorize/courses/workflow-list.component';
+import { CourseBuilderComponent } from './features/memorize/courses/workflow-builder.component';
 import { LessonPracticeComponent } from './features/memorize/courses/lesson-practice/lesson-practice.component';
 
 //TODO move /flashcard paths to be /deck instead
@@ -30,8 +30,8 @@ export const routes: Routes = [
     component: FeatureRequestComponent,
     title: 'Feature Requests & Bug Reports',
   },
-  { path: 'courses/create', component: WorkflowBuilderComponent },
-  { path: 'courses', component: WorkflowListComponent },
+  { path: 'courses/create', component: CourseBuilderComponent },
+  { path: 'courses', component: CourseListComponent },
   { path: 'flow', component: FlowComponent },
   { path: '**', redirectTo: '' },
 ];

--- a/frontend/src/app/core/models/course.model.ts
+++ b/frontend/src/app/core/models/course.model.ts
@@ -1,6 +1,6 @@
 // frontend/src/app/core/models/workflow.model.ts
 
-export interface Workflow {
+export interface Course {
   id: number;
   creator_id: number;
   creator_name: string;
@@ -56,9 +56,9 @@ export interface LessonContent {
   };
 }
 
-export interface UserWorkflowProgress {
+export interface UserCourseProgress {
   user_id: number;
-  workflow_id: number;
+  course_id: number;
   current_lesson_id: number;
   current_lesson_position: number;
   lessons_completed: number;
@@ -70,7 +70,7 @@ export interface UserWorkflowProgress {
 export interface UserLessonProgress {
   user_id: number;
   lesson_id: number;
-  workflow_id: number;
+  course_id: number;
   started_at: string;
   completed_at?: string;
   flashcards_required: number;
@@ -92,7 +92,7 @@ export interface LessonFlashcard {
   position: number;
 }
 
-export interface CreateWorkflowRequest {
+export interface CreateCourseRequest {
   title: string;
   description: string;
   thumbnail_url?: string;
@@ -101,7 +101,7 @@ export interface CreateWorkflowRequest {
 }
 
 export interface CreateLessonRequest {
-  workflow_id: number;
+  course_id: number;
   title: string;
   description?: string;
   content_type: 'video' | 'article' | 'external_link' | 'quiz';

--- a/frontend/src/app/core/services/course.service.ts
+++ b/frontend/src/app/core/services/course.service.ts
@@ -1,4 +1,4 @@
-// frontend/src/app/core/services/workflow.service.ts
+// frontend/src/app/core/services/course.service.ts
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
@@ -6,157 +6,157 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import {
-  Workflow,
+  Course,
   Lesson,
-  UserWorkflowProgress,
+  UserCourseProgress,
   UserLessonProgress,
   LessonFlashcard,
-  CreateWorkflowRequest,
+  CreateCourseRequest,
   CreateLessonRequest,
   AddFlashcardsToQueueRequest
-} from '../models/workflow.model';
+} from '../models/course.model';
 
-export interface WorkflowListResponse {
+export interface CourseListResponse {
   total: number;
-  workflows: Workflow[];
+  courses: Course[];
   page: number;
   per_page: number;
 }
 
-export interface WorkflowDetailResponse extends Workflow {
+export interface CourseDetailResponse extends Course {
   lessons: Lesson[];
   is_enrolled: boolean;
-  user_progress?: UserWorkflowProgress;
+  user_progress?: UserCourseProgress;
 }
 
 @Injectable({
   providedIn: 'root'
 })
-export class WorkflowService {
-  private apiUrl = `${environment.apiUrl}/workflows`;
+export class CourseService {
+  private apiUrl = `${environment.apiUrl}/courses`;
   
-  // Track current workflow being viewed/edited
-  private currentWorkflowSubject = new BehaviorSubject<WorkflowDetailResponse | null>(null);
-  public currentWorkflow$ = this.currentWorkflowSubject.asObservable();
+  // Track current course being viewed/edited
+  private currentCourseSubject = new BehaviorSubject<CourseDetailResponse | null>(null);
+  public currentCourse$ = this.currentCourseSubject.asObservable();
   
-  // Track user's enrolled workflows
-  private enrolledWorkflowsSubject = new BehaviorSubject<Workflow[]>([]);
-  public enrolledWorkflows$ = this.enrolledWorkflowsSubject.asObservable();
+  // Track user's enrolled courses
+  private enrolledCoursesSubject = new BehaviorSubject<Course[]>([]);
+  public enrolledCourses$ = this.enrolledCoursesSubject.asObservable();
 
   constructor(private http: HttpClient) {}
 
-  // ========== Workflow Management ==========
+  // ========== Course Management ==========
 
-  // Get all public workflows
-  getPublicWorkflows(
+  // Get all public courses
+  getPublicCourses(
     page: number = 1,
     perPage: number = 20,
     search?: string,
     tags?: string[]
-  ): Observable<WorkflowListResponse> {
-    console.log(`Fetching public workflows page=${page} perPage=${perPage}`);
+  ): Observable<CourseListResponse> {
+    console.log(`Fetching public courses page=${page} perPage=${perPage}`);
     let url = `${this.apiUrl}/public?page=${page}&per_page=${perPage}`;
     if (search) url += `&search=${encodeURIComponent(search)}`;
     if (tags?.length) url += `&tags=${tags.join(',')}`;
     
-    return this.http.get<WorkflowListResponse>(url).pipe(
-      tap(r => console.log(`Loaded ${r.workflows.length} workflows`)),
-      catchError(err => { console.error('Error loading workflows', err); throw err; })
+    return this.http.get<CourseListResponse>(url).pipe(
+      tap(r => console.log(`Loaded ${r.courses.length} courses`)),
+      catchError(err => { console.error('Error loading courses', err); throw err; })
     );
   }
 
-  // Get workflows created by a user
-  getUserWorkflows(userId: number): Observable<WorkflowListResponse> {
-    console.log(`Fetching user workflows for ${userId}`);
-    return this.http.get<WorkflowListResponse>(`${this.apiUrl}/user/${userId}`).pipe(
-      tap(r => console.log(`Loaded ${r.workflows.length} user workflows`)),
-      catchError(err => { console.error('Error loading user workflows', err); throw err; })
+  // Get courses created by a user
+  getUserCourses(userId: number): Observable<CourseListResponse> {
+    console.log(`Fetching user courses for ${userId}`);
+    return this.http.get<CourseListResponse>(`${this.apiUrl}/user/${userId}`).pipe(
+      tap(r => console.log(`Loaded ${r.courses.length} user courses`)),
+      catchError(err => { console.error('Error loading user courses', err); throw err; })
     );
   }
 
-  // Get enrolled workflows for a user
-  getEnrolledWorkflows(userId: number): Observable<Workflow[]> {
-    console.log(`Fetching enrolled workflows for user ${userId}`);
-    return this.http.get<Workflow[]>(`${this.apiUrl}/enrolled/${userId}`).pipe(
-      tap(workflows => {
-        console.log(`Loaded ${workflows.length} enrolled workflows`);
-        this.enrolledWorkflowsSubject.next(workflows);
+  // Get enrolled courses for a user
+  getEnrolledCourses(userId: number): Observable<Course[]> {
+    console.log(`Fetching enrolled courses for user ${userId}`);
+    return this.http.get<Course[]>(`${this.apiUrl}/enrolled/${userId}`).pipe(
+      tap(courses => {
+        console.log(`Loaded ${courses.length} enrolled courses`);
+        this.enrolledCoursesSubject.next(courses);
       }),
-      catchError(err => { console.error('Error loading enrolled workflows', err); throw err; })
+      catchError(err => { console.error('Error loading enrolled courses', err); throw err; })
     );
   }
 
-  // Get workflow details with lessons
-  getWorkflow(workflowId: number, userId?: number): Observable<WorkflowDetailResponse> {
-    console.log(`Fetching workflow ${workflowId}`);
-    let url = `${this.apiUrl}/${workflowId}`;
+  // Get course details with lessons
+  getCourse(courseId: number, userId?: number): Observable<CourseDetailResponse> {
+    console.log(`Fetching course ${courseId}`);
+    let url = `${this.apiUrl}/${courseId}`;
     if (userId) url += `?user_id=${userId}`;
 
-    return this.http.get<WorkflowDetailResponse>(url).pipe(
-      tap(workflow => {
-        console.log('Loaded workflow', workflow);
-        this.currentWorkflowSubject.next(workflow);
+    return this.http.get<CourseDetailResponse>(url).pipe(
+      tap(course => {
+        console.log('Loaded course', course);
+        this.currentCourseSubject.next(course);
       }),
-      catchError(err => { console.error('Error loading workflow', err); throw err; })
+      catchError(err => { console.error('Error loading course', err); throw err; })
     );
   }
 
-  // Create a new workflow
-  createWorkflow(workflow: CreateWorkflowRequest, userId: number): Observable<Workflow> {
-    console.log('Creating workflow', workflow);
-    return this.http.post<Workflow>(this.apiUrl, {
-      ...workflow,
+  // Create a new course
+  createCourse(course: CreateCourseRequest, userId: number): Observable<Course> {
+    console.log('Creating course', course);
+    return this.http.post<Course>(this.apiUrl, {
+      ...course,
       creator_id: userId
     }).pipe(
-      tap(() => console.log('Workflow created')),
-      catchError(err => { console.error('Error creating workflow', err); throw err; })
+      tap(() => console.log('Course created')),
+      catchError(err => { console.error('Error creating course', err); throw err; })
     );
   }
 
-  // Update workflow
-  updateWorkflow(workflowId: number, updates: Partial<CreateWorkflowRequest>): Observable<Workflow> {
-    console.log(`Updating workflow ${workflowId}`);
-    return this.http.put<Workflow>(`${this.apiUrl}/${workflowId}`, updates).pipe(
-      tap(() => console.log('Workflow updated')),
-      catchError(err => { console.error('Error updating workflow', err); throw err; })
+  // Update course
+  updateCourse(courseId: number, updates: Partial<CreateCourseRequest>): Observable<Course> {
+    console.log(`Updating course ${courseId}`);
+    return this.http.put<Course>(`${this.apiUrl}/${courseId}`, updates).pipe(
+      tap(() => console.log('Course updated')),
+      catchError(err => { console.error('Error updating course', err); throw err; })
     );
   }
 
-  // Delete workflow
-  deleteWorkflow(workflowId: number): Observable<any> {
-    console.log(`Deleting workflow ${workflowId}`);
-    return this.http.delete(`${this.apiUrl}/${workflowId}`).pipe(
-      tap(() => console.log('Workflow deleted')),
-      catchError(err => { console.error('Error deleting workflow', err); throw err; })
+  // Delete course
+  deleteCourse(courseId: number): Observable<any> {
+    console.log(`Deleting course ${courseId}`);
+    return this.http.delete(`${this.apiUrl}/${courseId}`).pipe(
+      tap(() => console.log('Course deleted')),
+      catchError(err => { console.error('Error deleting course', err); throw err; })
     );
   }
 
   // ========== Enrollment & Progress ==========
 
-  // Enroll in a workflow
-  enrollInWorkflow(workflowId: number, userId: number): Observable<UserWorkflowProgress> {
-    console.log(`Enrolling user ${userId} in workflow ${workflowId}`);
-    return this.http.post<UserWorkflowProgress>(`${this.apiUrl}/${workflowId}/enroll`, {
+  // Enroll in a course
+  enrollInCourse(courseId: number, userId: number): Observable<UserCourseProgress> {
+    console.log(`Enrolling user ${userId} in course ${courseId}`);
+    return this.http.post<UserCourseProgress>(`${this.apiUrl}/${courseId}/enroll`, {
       user_id: userId
     }).pipe(
-      tap(() => console.log('Enrolled in workflow')),
-      catchError(err => { console.error('Error enrolling in workflow', err); throw err; })
+      tap(() => console.log('Enrolled in course')),
+      catchError(err => { console.error('Error enrolling in course', err); throw err; })
     );
   }
 
-  // Unenroll from a workflow
-  unenrollFromWorkflow(workflowId: number, userId: number): Observable<any> {
-    console.log(`Unenrolling user ${userId} from workflow ${workflowId}`);
-    return this.http.delete(`${this.apiUrl}/${workflowId}/enroll/${userId}`).pipe(
-      tap(() => console.log('Unenrolled from workflow')),
-      catchError(err => { console.error('Error unenrolling from workflow', err); throw err; })
+  // Unenroll from a course
+  unenrollFromCourse(courseId: number, userId: number): Observable<any> {
+    console.log(`Unenrolling user ${userId} from course ${courseId}`);
+    return this.http.delete(`${this.apiUrl}/${courseId}/enroll/${userId}`).pipe(
+      tap(() => console.log('Unenrolled from course')),
+      catchError(err => { console.error('Error unenrolling from course', err); throw err; })
     );
   }
 
-  // Get user's progress in a workflow
-  getUserWorkflowProgress(workflowId: number, userId: number): Observable<UserWorkflowProgress> {
-    console.log(`Fetching workflow progress for workflow ${workflowId} user ${userId}`);
-    return this.http.get<UserWorkflowProgress>(`${this.apiUrl}/${workflowId}/progress/${userId}`).pipe(
+  // Get user's progress in a course
+  getUserCourseProgress(courseId: number, userId: number): Observable<UserCourseProgress> {
+    console.log(`Fetching course progress for course ${courseId} user ${userId}`);
+    return this.http.get<UserCourseProgress>(`${this.apiUrl}/${courseId}/progress/${userId}`).pipe(
       tap(progress => console.log('Loaded progress', progress)),
       catchError(err => { console.error('Error loading progress', err); throw err; })
     );
@@ -178,7 +178,7 @@ export class WorkflowService {
   // Create a new lesson
   createLesson(lesson: CreateLessonRequest): Observable<Lesson> {
     console.log('Creating lesson', lesson);
-    return this.http.post<Lesson>(`${this.apiUrl}/${lesson.workflow_id}/lessons`, lesson).pipe(
+    return this.http.post<Lesson>(`${this.apiUrl}/${lesson.course_id}/lessons`, lesson).pipe(
       tap(() => console.log('Lesson created')),
       catchError(err => { console.error('Error creating lesson', err); throw err; })
     );
@@ -203,9 +203,9 @@ export class WorkflowService {
   }
 
   // Reorder lessons
-  reorderLessons(workflowId: number, lessonIds: number[]): Observable<any> {
-    console.log(`Reordering lessons for workflow ${workflowId}`);
-    return this.http.post(`${this.apiUrl}/${workflowId}/lessons/reorder`, {
+  reorderLessons(courseId: number, lessonIds: number[]): Observable<any> {
+    console.log(`Reordering lessons for course ${courseId}`);
+    return this.http.post(`${this.apiUrl}/${courseId}/lessons/reorder`, {
       lesson_ids: lessonIds
     }).pipe(
       tap(() => console.log('Lessons reordered')),

--- a/frontend/src/app/features/memorize/courses/browse/browse-workflows.component.ts
+++ b/frontend/src/app/features/memorize/courses/browse/browse-workflows.component.ts
@@ -1,24 +1,24 @@
-// frontend/src/app/features/workflows/browse/browse-workflows.component.ts
+// frontend/src/app/features/courses/browse/browse-courses.component.ts
 
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
-import { WorkflowService } from '../../../../core/services/workflow.service';
+import { CourseService } from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
-import { Workflow } from '../../../../core/models/workflow.model';
+import { Course } from '../../../../core/models/course.model';
 import { User } from '../../../../core/models/user';
 
 @Component({
-  selector: 'app-browse-workflows',
+  selector: 'app-browse-courses',
   standalone: true,
   imports: [CommonModule, FormsModule, RouterModule],
-  templateUrl: './browse-workflows.component.html',
-  styleUrls: ['./browse-workflows.component.scss'],
+  templateUrl: './browse-courses.component.html',
+  styleUrls: ['./browse-courses.component.scss'],
 })
-export class BrowseWorkflowsComponent implements OnInit {
-  workflows: Workflow[] = [];
-  enrolledWorkflowIds: number[] = [];
+export class BrowseCoursesComponent implements OnInit {
+  courses: Course[] = [];
+  enrolledCourseIds: number[] = [];
   loading = false;
   searchQuery = '';
   selectedTags: string[] = [];
@@ -31,33 +31,33 @@ export class BrowseWorkflowsComponent implements OnInit {
   perPage = 12;
 
   constructor(
-    private workflowService: WorkflowService,
+    private courseService: CourseService,
     private userService: UserService,
     private router: Router,
   ) {}
 
   ngOnInit() {
     this.loadAvailableTags();
-    this.loadWorkflows();
+    this.loadCourses();
 
     // Subscribe to current user
     this.userService.currentUser$.subscribe((user) => {
       this.currentUser = user;
       if (user) {
-        this.loadEnrolledWorkflows();
+        this.loadEnrolledCourses();
       }
     });
   }
 
   loadAvailableTags() {
-    this.availableTags = this.workflowService.getSuggestedTags();
+    this.availableTags = this.courseService.getSuggestedTags();
   }
 
-  loadWorkflows() {
+  loadCourses() {
     this.loading = true;
 
-    this.workflowService
-      .getPublicWorkflows(
+    this.courseService
+      .getPublicCourses(
         this.currentPage,
         this.perPage,
         this.searchQuery,
@@ -65,18 +65,18 @@ export class BrowseWorkflowsComponent implements OnInit {
       )
       .subscribe({
         next: (response) => {
-          this.workflows = response.workflows;
+          this.courses = response.courses;
           this.totalPages = Math.ceil(response.total / this.perPage);
           this.loading = false;
         },
         error: (error) => {
-          console.error('Error loading workflows:', error);
+          console.error('Error loading courses:', error);
           this.loading = false;
         },
       });
   }
 
-  loadEnrolledWorkflows() {
+  loadEnrolledCourses() {
     if (!this.currentUser) return;
 
     const userId =
@@ -84,19 +84,19 @@ export class BrowseWorkflowsComponent implements OnInit {
         ? parseInt(this.currentUser.id)
         : this.currentUser.id;
 
-    this.workflowService.getEnrolledWorkflows(userId).subscribe({
-      next: (workflows) => {
-        this.enrolledWorkflowIds = workflows.map((w) => w.id);
+    this.courseService.getEnrolledCourses(userId).subscribe({
+      next: (courses) => {
+        this.enrolledCourseIds = courses.map((w) => w.id);
       },
       error: (error) => {
-        console.error('Error loading enrolled workflows:', error);
+        console.error('Error loading enrolled courses:', error);
       },
     });
   }
 
-  searchWorkflows() {
+  searchCourses() {
     this.currentPage = 1;
-    this.loadWorkflows();
+    this.loadCourses();
   }
 
   toggleTag(tag: string) {
@@ -106,7 +106,7 @@ export class BrowseWorkflowsComponent implements OnInit {
     } else {
       this.selectedTags.push(tag);
     }
-    this.searchWorkflows();
+    this.searchCourses();
   }
 
   formatTag(tag: string): string {
@@ -116,15 +116,15 @@ export class BrowseWorkflowsComponent implements OnInit {
       .join(' ');
   }
 
-  viewWorkflow(workflow: Workflow) {
-    this.router.navigate(['/courses', workflow.id]);
+  viewCourse(course: Course) {
+    this.router.navigate(['/courses', course.id]);
   }
 
-  isEnrolled(workflowId: number): boolean {
-    return this.enrolledWorkflowIds.includes(workflowId);
+  isEnrolled(courseId: number): boolean {
+    return this.enrolledCourseIds.includes(courseId);
   }
 
-  toggleEnrollment(event: Event, workflow: Workflow) {
+  toggleEnrollment(event: Event, course: Course) {
     event.stopPropagation();
 
     if (!this.currentUser) {
@@ -137,19 +137,19 @@ export class BrowseWorkflowsComponent implements OnInit {
         ? parseInt(this.currentUser.id)
         : this.currentUser.id;
 
-    if (this.isEnrolled(workflow.id)) {
-      // If enrolled, navigate to the workflow
-      this.viewWorkflow(workflow);
+    if (this.isEnrolled(course.id)) {
+      // If enrolled, navigate to the course
+      this.viewCourse(course);
     } else {
-      // Enroll in the workflow
-      this.workflowService.enrollInWorkflow(workflow.id, userId).subscribe({
+      // Enroll in the course
+      this.courseService.enrollInCourse(course.id, userId).subscribe({
         next: () => {
-          this.enrolledWorkflowIds.push(workflow.id);
-          // Navigate to the workflow after enrollment
-          this.viewWorkflow(workflow);
+          this.enrolledCourseIds.push(course.id);
+          // Navigate to the course after enrollment
+          this.viewCourse(course);
         },
         error: (error) => {
-          console.error('Error enrolling in workflow:', error);
+          console.error('Error enrolling in course:', error);
         },
       });
     }

--- a/frontend/src/app/features/memorize/courses/detail/workflow-detail.component.ts
+++ b/frontend/src/app/features/memorize/courses/detail/workflow-detail.component.ts
@@ -5,12 +5,12 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import {
   WorkflowDetailResponse,
-  WorkflowService,
-} from '../../../../core/services/workflow.service';
+  CourseService,
+} from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
 import { ModalService } from '../../../../core/services/modal.service';
 import { User } from '../../../../core/models/user';
-import { Lesson } from '../../../../core/models/workflow.model';
+import { Lesson } from '../../../../core/models/course.model';
 
 @Component({
   selector: 'app-workflow-detail',
@@ -577,7 +577,7 @@ export class WorkflowDetailComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
     private modalService: ModalService,
   ) {}

--- a/frontend/src/app/features/memorize/courses/editor/workflow-editor.component.ts
+++ b/frontend/src/app/features/memorize/courses/editor/workflow-editor.component.ts
@@ -11,14 +11,14 @@ import {
   Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { WorkflowService } from '../../../../core/services/workflow.service';
+import { CourseService } from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
 import { ModalService } from '../../../../core/services/modal.service';
 import {
   CreateWorkflowRequest,
   CreateLessonRequest,
   Lesson,
-} from '../../../../core/models/workflow.model';
+} from '../../../../core/models/course.model';
 
 @Component({
   selector: 'app-workflow-editor',
@@ -421,7 +421,7 @@ export class WorkflowEditorComponent implements OnInit {
     private fb: FormBuilder,
     private route: ActivatedRoute,
     private router: Router,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
     private modalService: ModalService,
   ) {

--- a/frontend/src/app/features/memorize/courses/lesson-practice/lesson-practice.component.ts
+++ b/frontend/src/app/features/memorize/courses/lesson-practice/lesson-practice.component.ts
@@ -11,7 +11,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { BibleService } from '../../../../core/services/bible.service';
-import { WorkflowService } from '../../../../core/services/workflow.service';
+import { CourseService } from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
 
 interface VerseSet {
@@ -359,7 +359,7 @@ export class LessonPracticeComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private bibleService: BibleService,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
   ) {}
 

--- a/frontend/src/app/features/memorize/courses/lesson/lesson-view.component.ts
+++ b/frontend/src/app/features/memorize/courses/lesson/lesson-view.component.ts
@@ -5,13 +5,13 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { WorkflowService } from '../../../../core/services/workflow.service';
+import { CourseService } from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
 import {
   Lesson,
   LessonFlashcard,
   UserLessonProgress,
-} from '../../../../core/models/workflow.model';
+} from '../../../../core/models/course.model';
 import { VersePickerComponent } from '../../../../shared/components/verse-range-picker/verse-range-picker.component';
 
 @Component({
@@ -591,7 +591,7 @@ export class LessonViewComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
     private sanitizer: DomSanitizer,
   ) {}

--- a/frontend/src/app/features/memorize/courses/quiz-practice/quiz-practice.component.ts
+++ b/frontend/src/app/features/memorize/courses/quiz-practice/quiz-practice.component.ts
@@ -11,7 +11,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { BibleService } from '../../../../core/services/bible.service';
-import { WorkflowService } from '../../../../core/services/workflow.service';
+import { CourseService } from '../../../../core/services/course.service';
 import { UserService } from '../../../../core/services/user.service';
 import { ModalService } from '../../../../core/services/modal.service';
 
@@ -419,7 +419,7 @@ export class QuizPracticeComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private bibleService: BibleService,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
     private modalService: ModalService,
   ) {}

--- a/frontend/src/app/features/memorize/courses/workflow-builder.component.ts
+++ b/frontend/src/app/features/memorize/courses/workflow-builder.component.ts
@@ -11,11 +11,11 @@ import {
   FormArray,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { WorkflowService } from '../../../core/services/workflow.service';
+import { CourseService } from '../../../core/services/course.service';
 import { UserService } from '../../../core/services/user.service';
 import { ModalService } from '../../../core/services/modal.service';
 
-import { LessonContent } from '../../../core/models/workflow.model';
+import { LessonContent } from '../../../core/models/course.model';
 import {
   VersePickerComponent,
   VerseSelection,
@@ -46,7 +46,7 @@ interface Lesson {
 }
 
 @Component({
-  selector: 'app-workflow-builder',
+  selector: 'app-course-builder',
   standalone: true,
   imports: [
     CommonModule,
@@ -57,7 +57,7 @@ interface Lesson {
   templateUrl: './workflow-builder.component.html',
   styleUrls: ['./workflow-builder.component.scss'],
 })
-export class WorkflowBuilderComponent implements OnInit {
+export class CourseBuilderComponent implements OnInit {
   workflowForm!: FormGroup;
   lessonForm!: FormGroup;
 
@@ -92,7 +92,7 @@ export class WorkflowBuilderComponent implements OnInit {
     private fb: FormBuilder,
     private route: ActivatedRoute,
     private router: Router,
-    private workflowService: WorkflowService,
+    private workflowService: CourseService,
     private userService: UserService,
     private modalService: ModalService,
   ) {

--- a/frontend/src/app/features/memorize/courses/workflow-list.component.ts
+++ b/frontend/src/app/features/memorize/courses/workflow-list.component.ts
@@ -2,13 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
-import { WorkflowService } from '../../../core/services/workflow.service';
+import { CourseService } from '../../../core/services/course.service';
 import { UserService } from '../../../core/services/user.service';
-import { Workflow } from '../../../core/models/workflow.model';
+import { Course } from '../../../core/models/course.model';
 import { User } from '../../../core/models/user';
 
 @Component({
-  selector: 'app-workflow-list',
+  selector: 'app-course-list',
   standalone: true,
   imports: [CommonModule, FormsModule, RouterModule],
   template: `
@@ -83,7 +83,7 @@ import { User } from '../../../core/models/user';
               class="search-input"
               placeholder="Search courses, topics, or creators..."
               [(ngModel)]="searchQuery"
-              (keyup.enter)="searchWorkflows()"
+              (keyup.enter)="searchCourses()"
             />
           </div>
 
@@ -164,7 +164,7 @@ import { User } from '../../../core/models/user';
         </div>
 
         <div class="results-count" *ngIf="!loading">
-          Showing {{ workflows.length }} of {{ totalPages * perPage }} courses
+          Showing {{ courses.length }} of {{ totalPages * perPage }} courses
           <button
             *ngIf="selectedTags.length > 0"
             class="clear-btn"
@@ -175,98 +175,98 @@ import { User } from '../../../core/models/user';
         </div>
       </div>
 
-      <!-- Workflows Grid -->
+      <!-- Courses Grid -->
       <div
         class="grid-view"
-        *ngIf="viewMode === 'grid' && !loading && workflows.length > 0"
+        *ngIf="viewMode === 'grid' && !loading && courses.length > 0"
       >
         <div
           class="grid-card"
-          *ngFor="let workflow of workflows"
-          (click)="viewWorkflow(workflow)"
+          *ngFor="let course of courses"
+          (click)="viewCourse(course)"
         >
           <div class="grid-thumb">
             <img
-              *ngIf="workflow.thumbnail_url"
-              [src]="workflow.thumbnail_url"
+              *ngIf="course.thumbnail_url"
+              [src]="course.thumbnail_url"
               alt=""
             />
-            <div *ngIf="!workflow.thumbnail_url" class="thumb-placeholder">
-              {{ getWorkflowIcon(workflow) }}
+            <div *ngIf="!course.thumbnail_url" class="thumb-placeholder">
+              {{ getCourseIcon(course) }}
             </div>
-            <div *ngIf="isEnrolled(workflow.id)" class="grid-progress">
+            <div *ngIf="isEnrolled(course.id)" class="grid-progress">
               <div class="progress-bar">
                 <div
                   class="progress"
-                  [style.width.%]="getProgress(workflow.id)"
+                  [style.width.%]="getProgress(course.id)"
                 ></div>
               </div>
               <span class="progress-label"
-                >{{ getProgress(workflow.id) }}% Complete</span
+                >{{ getProgress(course.id) }}% Complete</span
               >
             </div>
           </div>
           <div class="grid-content">
-            <h3 class="grid-title">{{ workflow.title }}</h3>
-            <p class="grid-desc">{{ workflow.description }}</p>
+            <h3 class="grid-title">{{ course.title }}</h3>
+            <p class="grid-desc">{{ course.description }}</p>
             <div class="grid-meta">
-              <span>{{ workflow.lesson_count }} lessons</span>
-              <span *ngIf="getDuration(workflow)">{{
-                getDuration(workflow)
+              <span>{{ course.lesson_count }} lessons</span>
+              <span *ngIf="getDuration(course)">{{
+                getDuration(course)
               }}</span>
             </div>
             <div class="grid-tags">
-              <span *ngFor="let tag of workflow.tags.slice(0, 3)">{{
+              <span *ngFor="let tag of course.tags.slice(0, 3)">{{
                 formatTag(tag)
               }}</span>
             </div>
             <div class="grid-footer">
               <div class="creator">
-                <div class="avatar">{{ workflow.creator_name.charAt(0) }}</div>
-                <span class="creator-name">{{ workflow.creator_name }}</span>
+                <div class="avatar">{{ course.creator_name.charAt(0) }}</div>
+                <span class="creator-name">{{ course.creator_name }}</span>
               </div>
               <button
                 class="action-btn"
-                (click)="handleActionClick($event, workflow)"
-                [class.enrolled]="isEnrolled(workflow.id)"
+                (click)="handleActionClick($event, course)"
+                [class.enrolled]="isEnrolled(course.id)"
               >
-                {{ isEnrolled(workflow.id) ? 'Continue' : 'Enroll' }}
+                {{ isEnrolled(course.id) ? 'Continue' : 'Enroll' }}
               </button>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Workflows List -->
+      <!-- Courses List -->
       <div
         class="list"
-        *ngIf="viewMode === 'list' && !loading && workflows.length > 0"
+        *ngIf="viewMode === 'list' && !loading && courses.length > 0"
       >
-        <div class="workflow-item" *ngFor="let workflow of workflows">
-          <div class="item-main" (click)="toggleExpanded(workflow.id)">
+        <div class="course-item" *ngFor="let course of courses">
+          <div class="item-main" (click)="toggleExpanded(course.id)">
             <div class="thumb">
-              <span *ngIf="!workflow.thumbnail_url">{{
-                getWorkflowIcon(workflow)
+              <span *ngIf="!course.thumbnail_url">{{
+                getCourseIcon(course)
               }}</span>
               <img
-                *ngIf="workflow.thumbnail_url"
-                [src]="workflow.thumbnail_url"
+                *ngIf="course.thumbnail_url"
+                [src]="course.thumbnail_url"
                 alt=""
               />
             </div>
 
             <div class="info">
               <div class="info-header">
-                <h3 class="item-title">{{ workflow.title }}</h3>
+                <h3 class="item-title">{{ course.title }}</h3>
                 <span
                   class="completed"
                   *ngIf="
-                    isEnrolled(workflow.id) && getProgress(workflow.id) === 100
+                    isEnrolled(course.id) && getProgress(course.id) === 100
                   "
                   >Completed</span
                 >
               </div>
-              <p class="item-desc">{{ workflow.description }}</p>
+              <p class="item-desc">{{ course.description }}</p>
 
               <div class="meta">
                 <span class="meta-item">
@@ -284,9 +284,9 @@ import { User } from '../../../core/models/user';
                       d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
                     />
                   </svg>
-                  {{ workflow.lesson_count }} lessons
+                  {{ course.lesson_count }} lessons
                 </span>
-                <span class="meta-item" *ngIf="getDuration(workflow)">
+                <span class="meta-item" *ngIf="getDuration(course)">
                   <svg
                     width="14"
                     height="14"
@@ -301,7 +301,7 @@ import { User } from '../../../core/models/user';
                       d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  {{ getDuration(workflow) }}
+                  {{ getDuration(course) }}
                 </span>
                 <span class="meta-item">
                   <svg
@@ -318,34 +318,34 @@ import { User } from '../../../core/models/user';
                       d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
                     />
                   </svg>
-                  {{ workflow.enrolled_count }} enrolled
+                  {{ course.enrolled_count }} enrolled
                 </span>
-                <span class="creator">by {{ workflow.creator_name }}</span>
+                <span class="creator">by {{ course.creator_name }}</span>
               </div>
 
-              <div *ngIf="isEnrolled(workflow.id)" class="progress-wrapper">
+              <div *ngIf="isEnrolled(course.id)" class="progress-wrapper">
                 <div class="progress-bar">
                   <div
                     class="progress"
-                    [style.width.%]="getProgress(workflow.id)"
+                    [style.width.%]="getProgress(course.id)"
                   ></div>
                 </div>
                 <span class="progress-label"
-                  >{{ getProgress(workflow.id) }}%</span
+                  >{{ getProgress(course.id) }}%</span
                 >
               </div>
             </div>
 
             <button
               class="action-btn"
-              (click)="handleActionClick($event, workflow)"
-              [class.enrolled]="isEnrolled(workflow.id)"
+              (click)="handleActionClick($event, course)"
+              [class.enrolled]="isEnrolled(course.id)"
             >
-              {{ isEnrolled(workflow.id) ? 'Continue' : 'Start Learning' }}
+              {{ isEnrolled(course.id) ? 'Continue' : 'Start Learning' }}
             </button>
           </div>
 
-          <div class="item-expanded" *ngIf="expandedId === workflow.id">
+          <div class="item-expanded" *ngIf="expandedId === course.id">
             <div class="expanded-content">
               <div class="lesson-overview">
                 <h4>Lesson Overview</h4>
@@ -355,11 +355,11 @@ import { User } from '../../../core/models/user';
                 >
                   <div
                     class="lesson-number"
-                    [class.done]="isEnrolled(workflow.id) && i < 2"
+                    [class.done]="isEnrolled(course.id) && i < 2"
                   >
-                    {{ isEnrolled(workflow.id) && i < 2 ? '✓' : i + 1 }}
+                    {{ isEnrolled(course.id) && i < 2 ? '✓' : i + 1 }}
                   </div>
-                  <span [class.strike]="isEnrolled(workflow.id) && i < 2"
+                  <span [class.strike]="isEnrolled(course.id) && i < 2"
                     >Lesson {{ i + 1 }}</span
                   >
                 </div>
@@ -383,7 +383,7 @@ import { User } from '../../../core/models/user';
         <p>Loading courses...</p>
       </div>
 
-      <div class="empty-state" *ngIf="!loading && workflows.length === 0">
+      <div class="empty-state" *ngIf="!loading && courses.length === 0">
         <svg
           width="64"
           height="64"
@@ -425,11 +425,11 @@ import { User } from '../../../core/models/user';
       </div>
     </div>
   `,
-  styleUrls: ['./workflow-list.component.scss'],
+  styleUrls: ['./course-list.component.scss'],
 })
-export class WorkflowListComponent implements OnInit {
-  workflows: Workflow[] = [];
-  enrolledWorkflows: Map<number, any> = new Map();
+export class CourseListComponent implements OnInit {
+  courses: Course[] = [];
+  enrolledCourses: Map<number, any> = new Map();
   loading = false;
   searchQuery = '';
   selectedTags: string[] = [];
@@ -444,32 +444,32 @@ export class WorkflowListComponent implements OnInit {
   viewMode: 'list' | 'grid' = 'list';
 
   constructor(
-    private workflowService: WorkflowService,
+    private courseService: CourseService,
     private userService: UserService,
     private router: Router,
   ) {}
 
   ngOnInit() {
     this.loadAvailableTags();
-    this.loadWorkflows();
+    this.loadCourses();
 
     this.userService.currentUser$.subscribe((user) => {
       this.currentUser = user;
       if (user) {
-        this.loadEnrolledWorkflows();
+        this.loadEnrolledCourses();
       }
     });
   }
 
   loadAvailableTags() {
-    this.availableTags = this.workflowService.getSuggestedTags();
+    this.availableTags = this.courseService.getSuggestedTags();
   }
 
-  loadWorkflows() {
+  loadCourses() {
     this.loading = true;
 
-    this.workflowService
-      .getPublicWorkflows(
+    this.courseService
+      .getPublicCourses(
         this.currentPage,
         this.perPage,
         this.searchQuery,
@@ -477,18 +477,18 @@ export class WorkflowListComponent implements OnInit {
       )
       .subscribe({
         next: (response) => {
-          this.workflows = response.workflows;
+          this.courses = response.courses;
           this.totalPages = Math.ceil(response.total / this.perPage);
           this.loading = false;
         },
         error: (error) => {
-          console.error('Error loading workflows:', error);
+          console.error('Error loading courses:', error);
           this.loading = false;
         },
       });
   }
 
-  loadEnrolledWorkflows() {
+  loadEnrolledCourses() {
     if (!this.currentUser) return;
 
     const userId =
@@ -496,10 +496,10 @@ export class WorkflowListComponent implements OnInit {
         ? parseInt(this.currentUser.id)
         : this.currentUser.id;
 
-    this.workflowService.getEnrolledWorkflows(userId).subscribe({
-      next: (workflows) => {
-        workflows.forEach((w) => {
-          this.enrolledWorkflows.set(w.id, {
+    this.courseService.getEnrolledCourses(userId).subscribe({
+      next: (courses) => {
+        courses.forEach((w) => {
+          this.enrolledCourses.set(w.id, {
             progress: 0,
             completedLessons: 0,
           });
@@ -508,9 +508,9 @@ export class WorkflowListComponent implements OnInit {
     });
   }
 
-  searchWorkflows() {
+  searchCourses() {
     this.currentPage = 1;
-    this.loadWorkflows();
+    this.loadCourses();
   }
 
   toggleTag(tag: string) {
@@ -520,12 +520,12 @@ export class WorkflowListComponent implements OnInit {
     } else {
       this.selectedTags.push(tag);
     }
-    this.searchWorkflows();
+    this.searchCourses();
   }
 
   clearTags() {
     this.selectedTags = [];
-    this.searchWorkflows();
+    this.searchCourses();
   }
 
   formatTag(tag: string): string {
@@ -542,33 +542,33 @@ export class WorkflowListComponent implements OnInit {
       .join(', ');
   }
 
-  viewWorkflow(workflow: Workflow) {
-    this.router.navigate(['/courses', workflow.id]);
+  viewCourse(course: Course) {
+    this.router.navigate(['/courses', course.id]);
   }
 
-  isEnrolled(workflowId: number): boolean {
-    return this.enrolledWorkflows.has(workflowId);
+  isEnrolled(courseId: number): boolean {
+    return this.enrolledCourses.has(courseId);
   }
 
-  getProgress(workflowId: number): number {
-    return this.enrolledWorkflows.get(workflowId)?.progress || 0;
+  getProgress(courseId: number): number {
+    return this.enrolledCourses.get(courseId)?.progress || 0;
   }
 
-  getCompletedLessons(workflowId: number): number {
-    return this.enrolledWorkflows.get(workflowId)?.completedLessons || 0;
+  getCompletedLessons(courseId: number): number {
+    return this.enrolledCourses.get(courseId)?.completedLessons || 0;
   }
 
-  getDuration(workflow: Workflow): string {
-    const hours = Math.ceil(workflow.lesson_count * 0.5);
+  getDuration(course: Course): string {
+    const hours = Math.ceil(course.lesson_count * 0.5);
     return hours === 1 ? '1 hour' : `${hours} hours`;
   }
 
-  getWorkflowIcon(workflow: Workflow): string {
+  getCourseIcon(course: Course): string {
     const icons = ['📖', '🙏', '✝️', '🕊️', '💫', '🌟'];
-    return icons[workflow.id % icons.length];
+    return icons[course.id % icons.length];
   }
 
-  handleActionClick(event: Event, workflow: Workflow) {
+  handleActionClick(event: Event, course: Course) {
     event.stopPropagation();
 
     if (!this.currentUser) {
@@ -576,21 +576,21 @@ export class WorkflowListComponent implements OnInit {
       return;
     }
 
-    if (this.isEnrolled(workflow.id)) {
-      this.viewWorkflow(workflow);
+    if (this.isEnrolled(course.id)) {
+      this.viewCourse(course);
     } else {
       const userId =
         typeof this.currentUser.id === 'string'
           ? parseInt(this.currentUser.id)
           : this.currentUser.id;
 
-      this.workflowService.enrollInWorkflow(workflow.id, userId).subscribe({
+      this.courseService.enrollInCourse(course.id, userId).subscribe({
         next: () => {
-          this.enrolledWorkflows.set(workflow.id, {
+          this.enrolledCourses.set(course.id, {
             progress: 0,
             completedLessons: 0,
           });
-          this.viewWorkflow(workflow);
+          this.viewCourse(course);
         },
       });
     }
@@ -602,7 +602,7 @@ export class WorkflowListComponent implements OnInit {
 
   goToPage(page: number) {
     this.currentPage = page;
-    this.loadWorkflows();
+    this.loadCourses();
   }
 
   toggleExpanded(id: number) {


### PR DESCRIPTION
## Summary
- rename backend workflows router to courses and update imports
- rename model and service files from workflow to course
- update routes and components to use new course naming

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843434c7e508331abe48361f26b6d84