### PR TITLE
Update tracker layout

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -10,7 +10,6 @@
   <div class="header">
     <h1>Bible Memory Tracker</h1>
     <p>Track your scripture memorization progress</p>
-    <p class="header-subtitle">✨ Interactive visualizations powered by Chart.js</p>
   </div>
 
   <!-- Summary Stats -->
@@ -24,58 +23,11 @@
           <div class="stat-progress text-green">{{ percentComplete }}% Complete</div>
         </div>
         <div class="mini-visual">
-          <div class="ring-progress">
-            <svg width="80" height="80">
-              <circle cx="40" cy="40" r="36" class="ring-bg"></circle>
-              <circle cx="40" cy="40" r="36" class="ring-fill" 
-                      [attr.stroke-dasharray]="226" 
-                      [attr.stroke-dashoffset]="226 - (226 * percentComplete / 100)"></circle>
-            </svg>
-            <div class="ring-text">{{ percentComplete }}%</div>
-          </div>
+          <canvas id="totalProgressChart"></canvas>
         </div>
       </div>
     </div>
 
-    <!-- Progress Milestones -->
-    <div class="card">
-      <div class="card-title">Progress Milestones</div>
-      <div class="milestone-bar">
-        <div class="milestone-fill" [style.width.%]="percentComplete"></div>
-        <div class="milestone-markers">
-          <span class="milestone-marker" [class.reached]="percentComplete >= 0">🌱</span>
-          <span class="milestone-marker" [class.reached]="percentComplete >= 25">📖</span>
-          <span class="milestone-marker" [class.reached]="percentComplete >= 50">📚</span>
-          <span class="milestone-marker" [class.reached]="percentComplete >= 75">🎯</span>
-          <span class="milestone-marker" [class.reached]="percentComplete >= 100">🏆</span>
-        </div>
-      </div>
-      <div class="milestone-labels">
-        <span>Start</span>
-        <span>25%</span>
-        <span>50%</span>
-        <span>75%</span>
-        <span>Complete</span>
-      </div>
-    </div>
-
-    <!-- Streak -->
-    <div class="card">
-      <div class="stat-card">
-        <div class="stat-content">
-          <div class="stat-number">{{ currentStreak }}</div>
-          <div class="stat-label">Day Streak 🔥</div>
-          <div class="stat-progress text-orange">{{ streakMessage }}</div>
-        </div>
-        <div class="mini-visual">
-          <div class="streak-visual">
-            <div class="streak-bar" *ngFor="let height of streakHeights; let i = index" 
-                 [style.height.%]="height"
-                 [class.current]="i === streakHeights.length - 1"></div>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 
   <!-- Testament Progress -->
@@ -120,6 +72,28 @@
     </div>
   </div>
 
+  <!-- Book Cards -->
+  <div class="card" *ngIf="selectedGroup">
+    <h3 class="card-title">{{ selectedGroup.name }} Books</h3>
+    <div class="book-grid">
+      <div class="book-card" *ngFor="let book of selectedGroup.books"
+           [class.active]="book === selectedBook"
+           [class.apocryphal]="isApocryphalBook(book)"
+           (click)="setBook(book)">
+        <div class="book-name">{{ book.name }}</div>
+        <div class="book-progress">
+          <div class="book-progress-bar"
+               [style.width.%]="book.percentComplete"
+               [style.background]="getBookProgressColor(book)"></div>
+        </div>
+        <div class="book-stats">
+          <span>{{ book.totalChapters }} chapters</span>
+          <span [style.color]="getBookProgressColor(book)" style="font-weight: 600;">{{ book.percentComplete }}%</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Chapter Heatmap -->
   <div class="card" *ngIf="selectedBook">
     <h3 class="card-title">{{ selectedBook.name }} - Chapter Progress Heatmap</h3>
@@ -152,47 +126,21 @@
         <span>81-100%</span>
       </div>
     </div>
-  </div>
-
-  <!-- Timeline -->
-  <div class="card">
-    <h3 class="card-title">Memorization Timeline - This Year</h3>
-    <div class="timeline-container">
-      <canvas id="timelineChart"></canvas>
+    <div class="action-container">
+      <button (click)="selectAllChapters()"
+              class="action-btn primary"
+              [disabled]="isLoading || isSavingBulk">
+        Memorize All Chapters
+      </button>
     </div>
   </div>
 
-  <!-- Book Cards -->
-  <div class="card" *ngIf="selectedGroup">
-    <h3 class="card-title">{{ selectedGroup.name }} Books</h3>
-    <div class="book-grid">
-      <div class="book-card" *ngFor="let book of selectedGroup.books"
-           [class.active]="book === selectedBook"
-           [class.apocryphal]="isApocryphalBook(book)"
-           (click)="setBook(book)">
-        <div class="book-name">{{ book.name }}</div>
-        <div class="book-progress">
-          <div class="book-progress-bar" 
-               [style.width.%]="book.percentComplete"
-               [style.background]="getBookProgressColor(book)"></div>
-        </div>
-        <div class="book-stats">
-          <span>{{ book.totalChapters }} chapters</span>
-          <span [style.color]="getBookProgressColor(book)" style="font-weight: 600;">{{ book.percentComplete }}%</span>
-        </div>
-      </div>
-    </div>
-  </div>
 
   <!-- Verse Grid -->
   <div class="card" *ngIf="selectedChapter">
     <h3 class="card-title">{{ selectedBook?.name }} {{ selectedChapter.chapterNumber }} - Verse Progress</h3>
     <div class="verse-header">
-      <div>
-        <span class="verse-pattern" *ngIf="getConsecutiveVerses().length > 0">Pattern Detection: 
-          <span class="pattern-highlight">Consecutive Verses {{ getConsecutiveVerses() }}!</span>
-        </span>
-      </div>
+      <div></div>
       <div>
         <span class="verse-count">{{ selectedChapter.memorizedVerses }}/{{ selectedChapter.totalVerses }}</span>
         <span class="verse-label"> verses</span>

--- a/frontend/src/app/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.scss
@@ -103,62 +103,13 @@
   height: 80px;
 }
 
-/* Ring progress */
-.ring-progress {
-  position: relative;
+#totalProgressChart {
   width: 80px;
   height: 80px;
-
-  svg {
-    transform: rotate(-90deg);
-  }
 }
 
-.ring-bg {
-  fill: none;
-  stroke: #e5e7eb;
-  stroke-width: 8;
-}
 
-.ring-fill {
-  fill: none;
-  stroke: #10b981;
-  stroke-width: 8;
-  stroke-linecap: round;
-  transition: stroke-dasharray 1s ease;
-}
 
-.ring-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #1f2937;
-}
-
-/* Streak visualization */
-.streak-visual {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  height: 60px;
-  padding: 0 10px;
-}
-
-.streak-bar {
-  flex: 1;
-  background: #fbbf24;
-  min-height: 4px;
-  border-radius: 2px;
-  opacity: 0.7;
-
-  &.current {
-    background: #f59e0b;
-    opacity: 1;
-  }
-}
 
 /* Testament cards */
 .testament-card {
@@ -241,7 +192,7 @@
 }
 
 .mini-bar {
-  width: 100px;
+  flex: 1;
   height: 8px;
   background: #e5e7eb;
   border-radius: 4px;
@@ -363,15 +314,6 @@
   margin-bottom: 1rem;
 }
 
-.verse-pattern {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
-
-.pattern-highlight {
-  font-weight: 600;
-  color: #10b981;
-}
 
 .verse-count {
   font-size: 1.5rem;
@@ -487,11 +429,6 @@
   font-weight: 600;
 }
 
-/* Timeline */
-.timeline-container {
-  height: 250px;
-  padding: 1rem;
-}
 
 /* Action buttons */
 .action-container {
@@ -520,20 +457,22 @@
   }
 
   &.primary {
-    background-color: #10b981;
-    color: white;
+    background-color: #ecfdf5;
+    color: #065f46;
+    border: 1px solid #10b981;
 
     &:hover:not(:disabled) {
-      background-color: #059669;
+      background-color: #d1fae5;
     }
   }
 
   &.secondary {
-    background-color: #e5e7eb;
+    background-color: #f3f4f6;
     color: #374151;
+    border: 1px solid #d1d5db;
 
     &:hover:not(:disabled) {
-      background-color: #d1d5db;
+      background-color: #e5e7eb;
     }
   }
 
@@ -543,46 +482,6 @@
   }
 }
 
-/* Progress milestone */
-.milestone-bar {
-  position: relative;
-  background: #e5e7eb;
-  height: 12px;
-  border-radius: 6px;
-  margin: 30px 0;
-}
-
-.milestone-fill {
-  background: linear-gradient(90deg, #10b981 0%, #3b82f6 100%);
-  height: 100%;
-  border-radius: 6px;
-  transition: width 1s ease;
-}
-
-.milestone-markers {
-  position: absolute;
-  top: -20px;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: space-between;
-}
-
-.milestone-marker {
-  font-size: 1.25rem;
-  transition: transform 0.3s ease;
-
-  &.reached {
-    transform: scale(1.2);
-  }
-}
-
-.milestone-labels {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.75rem;
-  color: #6b7280;
-}
 
 /* Utility classes */
 .text-green { color: #10b981; }

--- a/frontend/src/app/shared/components/modal/modal.component.ts
+++ b/frontend/src/app/shared/components/modal/modal.component.ts
@@ -1,5 +1,5 @@
 // frontend/src/app/shared/components/modal/modal.component.ts
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject, takeUntil } from 'rxjs';
 import { ModalService, ModalConfig, ModalResult } from '../../../core/services/modal.service';
@@ -68,6 +68,18 @@ export class ModalComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   constructor(private modalService: ModalService) {}
+
+  @HostListener('document:keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent) {
+    if (!this.isVisible) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.onCancel();
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      this.onConfirm();
+    }
+  }
 
   ngOnInit() {
     this.modalService.modal$


### PR DESCRIPTION
## Summary
- simplify summary section
- remove streaks and milestones from the tracker
- drop memorization timeline
- show group books before chapter heatmap
- remove pattern detection and Chart.js tagline
- add total progress line chart
- make mini bars stretch to full width
- close modals with Enter or Escape
- add book-level 'Memorize All Chapters' action

## Testing
- `npm --prefix frontend test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843689fb8b88331803e29c0e4bac848