### PR TITLE
Switch flashcard routes to deck routes

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -14,15 +14,15 @@ import { CourseListComponent } from './features/memorize/courses/course-list.com
 import { CourseBuilderComponent } from './features/memorize/courses/course-builder.component';
 import { LessonPracticeComponent } from './features/memorize/courses/lesson-practice/lesson-practice.component';
 
-//TODO move /flashcard paths to be /deck instead
+// Routing configuration
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'tracker', component: BibleTrackerComponent },
   { path: 'profile', component: ProfileComponent },
   { path: 'stats', component: StatsComponent },
-  { path: 'flashcard', component: DeckListComponent },
-  { path: 'flashcards', component: DeckListComponent },
-  { path: 'flashcards/study/:deckId', component: DeckStudyComponent },
+  { path: 'deck', component: DeckListComponent },
+  { path: 'decks', component: DeckListComponent },
+  { path: 'decks/study/:deckId', component: DeckStudyComponent },
   { path: 'deck-editor/:deckId', component: DeckEditorComponent },
   { path: 'courses/:courseId/lessons/:lessonId/practice', component: LessonPracticeComponent },
   {

--- a/frontend/src/app/features/home/home.component.ts
+++ b/frontend/src/app/features/home/home.component.ts
@@ -74,7 +74,7 @@ export class HomeComponent {
         'Smart review scheduling',
         'Track confidence levels per verse'
       ],
-      route: '/flashcard',
+      route: '/deck',
       color: '#f59e0b'
     },
     {

--- a/frontend/src/app/features/memorize/courses/lesson/lesson-view.component.ts
+++ b/frontend/src/app/features/memorize/courses/lesson/lesson-view.component.ts
@@ -722,7 +722,7 @@ export class LessonViewComponent implements OnInit {
   }
 
   goToFlashcards() {
-    this.router.navigate(['/flashcard']);
+    this.router.navigate(['/deck']);
   }
 
   goBack() {

--- a/frontend/src/app/features/memorize/decks/components/deck-card/deck-card.component.html
+++ b/frontend/src/app/features/memorize/decks/components/deck-card/deck-card.component.html
@@ -144,7 +144,7 @@
     <div class="deck-actions-compact">
       <!-- My Decks Actions -->
       <ng-container *ngIf="viewMode === 'my-decks'">
-        <button class="action-button primary" [routerLink]="['/flashcards/study', deck.deck_id]">
+        <button class="action-button primary" [routerLink]="['/decks/study', deck.deck_id]">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <polygon points="5 3 19 12 5 21 5 3"/>
           </svg>
@@ -168,7 +168,7 @@
 
       <!-- Public/Saved Decks Actions -->
       <ng-container *ngIf="viewMode !== 'my-decks'">
-        <button class="action-button primary" [routerLink]="['/flashcards/study', deck.deck_id]">
+        <button class="action-button primary" [routerLink]="['/decks/study', deck.deck_id]">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <polygon points="5 3 19 12 5 21 5 3"/>
           </svg>

--- a/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-editor/deck-editor.component.ts
@@ -465,6 +465,6 @@ export class DeckEditorComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/flashcards']);
+    this.router.navigate(['/decks']);
   }
 }

--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
@@ -165,7 +165,7 @@ export class DeckStudyComponent implements OnInit {
   }
 
   exitStudy() {
-    this.router.navigate(['/flashcards']);
+    this.router.navigate(['/decks']);
   }
 
   onConfidenceChange() {

--- a/frontend/src/app/shared/components/navigation/navigation.component.html
+++ b/frontend/src/app/shared/components/navigation/navigation.component.html
@@ -73,7 +73,7 @@
             FLOW Method
           </a>
           <a
-            routerLink="/flashcard"
+            routerLink="/deck"
             class="dropdown-item"
             routerLinkActive="active"
             (click)="closeMenu()"


### PR DESCRIPTION
## Summary
- update front-end routing to use `/deck` and `/decks`
- update navigation link to deck list
- ensure components navigate to new deck paths

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438219aea08331a43a5e974346318e