### PR TITLE
Add segmented progress component for tracker

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -23,7 +23,7 @@
           <div class="stat-progress text-green">{{ percentComplete }}% Complete</div>
         </div>
         <div class="mini-visual">
-          <canvas id="totalProgressChart"></canvas>
+          <app-segmented-progress></app-segmented-progress>
         </div>
       </div>
     </div>

--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -23,7 +23,7 @@
           <div class="stat-progress text-green">{{ percentComplete }}% Complete</div>
         </div>
         <div class="mini-visual">
-          <app-segmented-progress></app-segmented-progress>
+          <app-segmented-progress [bibleData]="bibleData"></app-segmented-progress>
         </div>
       </div>
     </div>

--- a/frontend/src/app/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.scss
@@ -103,11 +103,6 @@
   height: 80px;
 }
 
-#totalProgressChart {
-  width: 80px;
-  height: 80px;
-}
-
 
 
 

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -22,7 +22,7 @@ import { SegmentedProgressComponent } from '../shared/components/segmented-progr
   styleUrls: ['./bible-tracker.component.scss'],
 })
 export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
-  private bibleData: BibleData;
+  bibleData: BibleData;
   private subscriptions: Subscription = new Subscription();
   private testamentCharts: { [key: string]: Chart } = {};
   private isBrowser: boolean;

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -1,6 +1,6 @@
 // frontend/src/app/bible-tracker/bible-tracker.component.ts
-import { Component, OnInit, ChangeDetectorRef, OnDestroy, HostListener, AfterViewInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, OnInit, ChangeDetectorRef, OnDestroy, HostListener, AfterViewInit, Inject, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { DialogsModule } from '@progress/kendo-angular-dialog';
 import { ButtonsModule } from '@progress/kendo-angular-buttons';
@@ -25,6 +25,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   private bibleData: BibleData;
   private subscriptions: Subscription = new Subscription();
   private testamentCharts: { [key: string]: Chart } = {};
+  private isBrowser: boolean;
   private groupColors: { [key: string]: string } = {
     'Law': '#10b981',
     'History': '#3b82f6',
@@ -55,8 +56,10 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
     private userService: UserService,
     private modalService: ModalService,
     private cdr: ChangeDetectorRef,
-    private router: Router
+    private router: Router,
+    @Inject(PLATFORM_ID) platformId: Object
   ) {
+    this.isBrowser = isPlatformBrowser(platformId);
     this.bibleData = this.bibleService.getBibleData();
     this.selectedTestament = this.defaultTestament;
     if (this.selectedTestament?.groups.length > 0) {
@@ -85,9 +88,11 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit() {
     // Initialize charts after view is initialized
-    setTimeout(() => {
-      this.initializeAllCharts();
-    }, 100);
+    if (this.isBrowser) {
+      setTimeout(() => {
+        this.initializeAllCharts();
+      }, 100);
+    }
   }
 
   ngOnDestroy() {
@@ -110,7 +115,9 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
       next: (verses: any) => {
         this.userVerses = verses;
         this.isLoading = false;
-        this.initializeAllCharts();
+        if (this.isBrowser) {
+          this.initializeAllCharts();
+        }
         this.cdr.detectChanges();
       },
       error: (error: any) => {
@@ -127,11 +134,17 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private initializeAllCharts() {
+    if (!this.isBrowser) {
+      return;
+    }
     // Initialize testament charts
     this.initializeTestamentCharts();
   }
 
   private initializeTestamentCharts() {
+    if (!this.isBrowser) {
+      return;
+    }
     // Wait for next tick to ensure DOM is ready
     setTimeout(() => {
       this.testaments.forEach(testament => {
@@ -141,6 +154,9 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private createTestamentChart(testament: BibleTestament) {
+    if (!this.isBrowser) {
+      return;
+    }
     const chartId = this.getTestamentChartId(testament);
     const canvas = document.getElementById(chartId) as HTMLCanvasElement;
     
@@ -238,6 +254,9 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateTestamentCharts() {
+    if (!this.isBrowser) {
+      return;
+    }
     this.testaments.forEach(testament => {
       this.createTestamentChart(testament);
     });

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -12,19 +12,19 @@ import { BibleService } from '../core/services/bible.service';
 import { UserService } from '../core/services/user.service';
 import { BibleVerse } from '../core/models/bible/bible-verse.model';
 import { ModalService } from '../core/services/modal.service';
+import { SegmentedProgressComponent } from '../shared/components/segmented-progress/segmented-progress.component';
 
 @Component({
   selector: 'app-bible-tracker',
   templateUrl: './bible-tracker.component.html',
   standalone: true,
-  imports: [CommonModule, RouterModule, DialogsModule, ButtonsModule],
+  imports: [CommonModule, RouterModule, DialogsModule, ButtonsModule, SegmentedProgressComponent],
   styleUrls: ['./bible-tracker.component.scss'],
 })
 export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   private bibleData: BibleData;
   private subscriptions: Subscription = new Subscription();
   private testamentCharts: { [key: string]: Chart } = {};
-  private totalProgressChart: Chart | null = null;
   private groupColors: { [key: string]: string } = {
     'Law': '#10b981',
     'History': '#3b82f6',
@@ -94,9 +94,6 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.subscriptions.unsubscribe();
     // Destroy all charts
     Object.values(this.testamentCharts).forEach(chart => chart.destroy());
-    if (this.totalProgressChart) {
-      this.totalProgressChart.destroy();
-    }
   }
 
   @HostListener('window:resize', ['$event'])
@@ -104,9 +101,6 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
     Object.values(this.testamentCharts).forEach(chart => {
       chart.resize();
     });
-    if (this.totalProgressChart) {
-      this.totalProgressChart.resize();
-    }
   }
 
   loadUserVerses() {
@@ -135,7 +129,6 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   private initializeAllCharts() {
     // Initialize testament charts
     this.initializeTestamentCharts();
-    this.initializeTotalProgressChart();
   }
 
   private initializeTestamentCharts() {
@@ -248,69 +241,6 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.testaments.forEach(testament => {
       this.createTestamentChart(testament);
     });
-    this.initializeTotalProgressChart();
-  }
-
-  private initializeTotalProgressChart() {
-    const canvas = document.getElementById('totalProgressChart') as HTMLCanvasElement;
-    if (!canvas) return;
-
-    if (this.totalProgressChart) {
-      this.totalProgressChart.destroy();
-    }
-
-    const monthlyData = this.generateMonthlyData();
-
-    this.totalProgressChart = new Chart(canvas, {
-      type: 'line',
-      data: {
-        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-        datasets: [{
-          label: 'Verses Memorized',
-          data: monthlyData,
-          borderColor: '#3b82f6',
-          backgroundColor: 'rgba(59, 130, 246, 0.1)',
-          borderWidth: 2,
-          tension: 0.4,
-          fill: true,
-          pointRadius: 0
-        }]
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: { display: false },
-          tooltip: {
-            displayColors: false,
-            callbacks: {
-              label: (ctx: any) => `${ctx.parsed.y} verses`
-            }
-          }
-        },
-        scales: {
-          y: { beginAtZero: true, grid: { color: 'rgba(0,0,0,0.05)' } },
-          x: { grid: { display: false } }
-        }
-      }
-    });
-  }
-
-  private generateMonthlyData(): number[] {
-    const currentMonth = new Date().getMonth();
-    const totalMemorized = this.memorizedVerses;
-    const monthlyData: number[] = [];
-
-    for (let i = 0; i <= currentMonth; i++) {
-      const progress = (i + 1) / (currentMonth + 1);
-      monthlyData.push(Math.round(totalMemorized * progress));
-    }
-
-    for (let i = currentMonth + 1; i < 12; i++) {
-      monthlyData.push(0);
-    }
-
-    return monthlyData;
   }
 
   toggleAndSaveVerse(verse: BibleVerse): void {

--- a/frontend/src/app/core/models/bible/index.ts
+++ b/frontend/src/app/core/models/bible/index.ts
@@ -12,3 +12,5 @@ export * from './bible-chapter.model';
 export * from './bible-book.model';
 export * from './bible-testament.model';
 export * from './bible-data.model';
+export * from './bible-group.modle';
+export * from './bible-verse.model';

--- a/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.css
+++ b/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.css
@@ -1,0 +1,2 @@
+/* Additional styling for segmented progress bar */
+/* Tailwind utility classes handle most styling */

--- a/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.html
+++ b/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.html
@@ -1,0 +1,25 @@
+<div class="w-full max-w-xl mx-auto p-4">
+  <button class="mb-4 flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded" (click)="toggleView()">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+    <span>{{ progressViewMode === 'testament' ? 'Show Groups View' : 'Show Testament View' }}</span>
+  </button>
+
+  <div class="flex h-6 w-full rounded overflow-hidden text-xs font-semibold">
+    <div *ngFor="let segment of segments" class="relative flex items-center justify-center text-white"
+         [style.background]="segment.color" [style.width.%]="segment.percent"
+         [attr.title]="segment.name + ': ' + segment.verses + ' verses (' + segment.percent + '%)'">
+      <span *ngIf="segment.percent > 5">{{ segment.shortName }}</span>
+    </div>
+  </div>
+
+  <div class="mt-3 grid grid-cols-2 gap-2 text-sm" >
+    <div *ngFor="let segment of segments" [hidden]="segment.name === 'Remaining'" class="flex items-center gap-2">
+      <span class="w-3 h-3 rounded-sm" [style.background]="segment.color"></span>
+      <span class="flex-1">{{ segment.name }}</span>
+      <span class="font-semibold">{{ segment.percent }}%</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
+++ b/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BibleData } from '../../core/models/bible';
+import { BibleData, BibleTestament, BibleGroup } from '../../core/models/bible';
 
 interface ProgressSegment {
   name: string;
@@ -84,8 +84,8 @@ export class SegmentedProgressComponent {
 
     const result: ProgressSegment[] = [];
     const groupMap = new Map<string, { memorized: number }>();
-    this.bibleData.testaments.forEach(testament => {
-      testament.groups.forEach(group => {
+    this.bibleData.testaments.forEach((testament: BibleTestament) => {
+      testament.groups.forEach((group: BibleGroup) => {
         const current = groupMap.get(group.name) || { memorized: 0 };
         groupMap.set(group.name, { memorized: current.memorized + group.memorizedVerses });
       });

--- a/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
+++ b/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
@@ -1,0 +1,136 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface ProgressSegment {
+  name: string;
+  shortName: string;
+  percent: number;
+  color: string;
+  verses: number;
+}
+
+@Component({
+  selector: 'app-segmented-progress',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './segmented-progress.component.html',
+  styleUrls: ['./segmented-progress.component.css']
+})
+export class SegmentedProgressComponent {
+  progressViewMode: 'testament' | 'groups' = 'testament';
+
+  readonly totalVerses = 31102;
+  readonly memorizedVerses = 8432;
+
+  private readonly testamentData = {
+    OT: 5596,
+    NT: 2836
+  };
+
+  private readonly groupData: { [key: string]: number } = {
+    'Law': 1500,
+    'History': 1400,
+    'Wisdom': 1200,
+    'Major Prophets': 800,
+    'Minor Prophets': 696,
+    'Gospels': 1100,
+    'Acts': 400,
+    'Pauline Epistles': 800,
+    'General Epistles': 336,
+    'Revelation': 200
+  };
+
+  private readonly colors: { [key: string]: string } = {
+    'Old Testament': '#3b82f6',
+    'New Testament': '#10b981',
+    'Remaining': '#e5e7eb',
+    'Law': '#10b981',
+    'History': '#3b82f6',
+    'Wisdom': '#8b5cf6',
+    'Major Prophets': '#f59e0b',
+    'Minor Prophets': '#ef4444',
+    'Gospels': '#10b981',
+    'Acts': '#3b82f6',
+    'Pauline Epistles': '#8b5cf6',
+    'General Epistles': '#f59e0b',
+    'Revelation': '#ef4444'
+  };
+
+  toggleView() {
+    this.progressViewMode = this.progressViewMode === 'testament' ? 'groups' : 'testament';
+  }
+
+  get segments(): ProgressSegment[] {
+    if (this.progressViewMode === 'testament') {
+      const otPercent = Math.round((this.testamentData.OT / this.totalVerses) * 100);
+      const ntPercent = Math.round((this.testamentData.NT / this.totalVerses) * 100);
+      const remainingPercent = 100 - otPercent - ntPercent;
+      return [
+        {
+          name: 'Old Testament',
+          shortName: 'OT',
+          percent: otPercent,
+          color: this.colors['Old Testament'],
+          verses: this.testamentData.OT
+        },
+        {
+          name: 'New Testament',
+          shortName: 'NT',
+          percent: ntPercent,
+          color: this.colors['New Testament'],
+          verses: this.testamentData.NT
+        },
+        {
+          name: 'Remaining',
+          shortName: 'Remaining',
+          percent: remainingPercent,
+          color: this.colors['Remaining'],
+          verses: this.totalVerses - this.memorizedVerses
+        }
+      ];
+    }
+
+    const result: ProgressSegment[] = [];
+    let totalPercent = 0;
+    for (const [name, verses] of Object.entries(this.groupData)) {
+      const percent = Math.round((verses / this.totalVerses) * 100);
+      totalPercent += percent;
+      result.push({
+        name,
+        shortName: this.getShortName(name),
+        percent,
+        color: this.colors[name],
+        verses
+      });
+    }
+    const remainingPercent = 100 - totalPercent;
+    result.push({
+      name: 'Remaining',
+      shortName: 'Remaining',
+      percent: remainingPercent,
+      color: this.colors['Remaining'],
+      verses: this.totalVerses - this.memorizedVerses
+    });
+    return result;
+  }
+
+  private getShortName(name: string): string {
+    const map: { [key: string]: string } = {
+      'Old Testament': 'OT',
+      'New Testament': 'NT',
+      'Law': 'Law',
+      'History': 'Hist',
+      'Wisdom': 'Wis',
+      'Major Prophets': 'Major',
+      'Minor Prophets': 'Minor',
+      'Gospels': 'Gospels',
+      'Acts': 'Acts',
+      'Pauline Epistles': 'Paul',
+      'General Epistles': 'General',
+      'Revelation': 'Rev'
+    };
+    return map[name] || name;
+  }
+}
+
+export { ProgressSegment };

--- a/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
+++ b/frontend/src/app/shared/components/segmented-progress/segmented-progress.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BibleData, BibleTestament, BibleGroup } from '../../core/models/bible';
+import { BibleData, BibleTestament } from '../../core/models/bible';
+import { BibleGroup } from '../../core/models/bible/bible-group.modle';
 
-interface ProgressSegment {
+export interface ProgressSegment {
   name: string;
   shortName: string;
   percent: number;


### PR DESCRIPTION
## Summary
- implement SegmentedProgressComponent with dummy data
- replace total progress chart in tracker with segmented progress component
- remove old totalProgressChart logic

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438b03236c83319e68b5de6f137060