### PR TITLE
Apply card stack style to verse picker

### DIFF
--- a/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-picker.component.scss
@@ -429,6 +429,237 @@
   }
 }
 
+@keyframes stackReveal {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.theme-card-stack {
+  .expanded-content {
+    width: 380px;
+    margin-top: 0.75rem;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 1rem;
+    box-shadow: 0 20px 40px -10px rgba(0, 0, 0, 0.12);
+    overflow: hidden;
+
+    &.show {
+      animation: stackReveal 0.4s ease-out;
+    }
+  }
+
+  .content-divider {
+    display: none;
+  }
+
+  .controls-container {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mode-selector-inline {
+    background: #f8f9fa;
+    padding: 1rem 1.25rem;
+    gap: 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    margin: 0;
+  }
+
+  .mode-button {
+    position: relative;
+    padding-left: 2rem;
+    border-radius: 0.5rem;
+    border: 2px solid #e5e7eb;
+    background: white;
+    transition: all 0.2s ease;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0.75rem;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 0.875rem;
+    }
+
+    &:nth-child(1)::before {
+      content: '📍';
+    }
+
+    &:nth-child(2)::before {
+      content: '📏';
+    }
+
+    &:nth-child(3)::before {
+      content: '📄';
+    }
+
+    &:hover:not(:disabled) {
+      border-color: #3b82f6;
+      background: #eff6ff;
+      transform: translateY(-1px);
+    }
+
+    &.active {
+      background: #3b82f6;
+      border-color: #3b82f6;
+      color: white;
+      box-shadow: 0 2px 8px rgba(59, 130, 246, 0.25);
+    }
+  }
+
+  .book-row {
+    padding: 1.25rem;
+    background: white;
+    border-bottom: 1px solid #e5e7eb;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .testament-filter {
+    background: #f3f4f6;
+    border-radius: 0.5rem;
+    padding: 0.375rem;
+    display: flex;
+    gap: 0.25rem;
+
+    label {
+      position: relative;
+      padding: 0.375rem 0.625rem 0.375rem 2rem;
+      border-radius: 0.375rem;
+      transition: all 0.2s ease;
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0.625rem;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 0.875rem;
+      }
+    }
+
+    label:first-child::before {
+      content: '📜';
+    }
+
+    label:last-child::before {
+      content: '✨';
+    }
+
+    label:has(input:checked) {
+      background: white;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    input[type='radio'] {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+  }
+
+  .verse-inputs {
+    padding: 1.25rem;
+    background: white;
+    margin: 0;
+    gap: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .input-group {
+    background: #f9fafb;
+    padding: 0.875rem;
+    border-radius: 0.625rem;
+    border: 1px solid #e5e7eb;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: #d1d5db;
+      background: #f3f4f6;
+    }
+
+    &:has(select:focus) {
+      border-color: #3b82f6;
+      background: #eff6ff;
+    }
+  }
+
+  .input-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #4b5563;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+
+    &::before {
+      content: '';
+      font-size: 0.875rem;
+    }
+  }
+
+  .input-group:first-child .input-label::before {
+    content: '🎯';
+  }
+
+  .input-group:last-child .input-label::before {
+    content: '🏁';
+  }
+
+  .apply-button {
+    margin: 1.25rem;
+    margin-top: 0;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    font-weight: 600;
+    border-radius: 0.625rem;
+    background: #3b82f6;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: #2563eb;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+
+  .select-control {
+    background: white;
+    border: 1px solid #d1d5db;
+    font-weight: 500;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: #9ca3af;
+    }
+
+    &:focus {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+  }
+}
+
 // Responsive Design
 @media (max-width: 480px) {
   .verse-inputs {

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -37,7 +37,7 @@ export interface VerseSelection {
   styleUrls: ['./verse-picker.component.scss'],
 })
 export class VersePickerComponent implements OnInit {
-  @Input() theme: 'enhanced' | 'minimal' | 'cyberpunk' = 'enhanced';
+  @Input() theme: 'enhanced' | 'minimal' | 'cyberpunk' | 'card-stack' = 'card-stack';
   @Input() showFilters = false;
   @Input() minimumVerses = 0;
   @Input() maximumVerses = 0; // 0 means no maximum


### PR DESCRIPTION
## Summary
- switch verse picker default theme to new `card-stack` style
- implement card stack styling in SCSS

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684392f2fda4833181aac7ad1f250039