### PR TITLE
Add segmented progress view to Bible tracker

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -35,7 +35,7 @@
         <div class="segmented-progress">
           <div class="segmented-bar">
             <div class="segment" 
-                 *ngFor="let segment of getProgressSegments()"
+                 *ngFor="let segment of progressSegments"
                  [style.width.%]="segment.percent"
                  [style.background]="segment.color"
                  [title]="segment.name + ': ' + segment.verses + ' verses (' + segment.percent + '%)'">
@@ -47,7 +47,7 @@
 
           <!-- Legend -->
           <div class="progress-legend">
-            <div class="legend-item" *ngFor="let segment of getProgressSegments()">
+            <div class="legend-item" *ngFor="let segment of progressSegments">
               <ng-container *ngIf="segment.name !== 'Remaining'">
                 <div class="legend-dot" [style.background]="segment.color"></div>
                 <span class="legend-name">{{ segment.name }}</span>

--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -12,22 +12,52 @@
     <p>Track your scripture memorization progress</p>
   </div>
 
-  <!-- Summary Stats -->
+  <!-- Summary Stats with Segmented Progress Bar -->
   <div class="stats-grid">
-    <!-- Total Progress -->
+    <!-- Total Progress with Segmented Bar -->
     <div class="card">
       <div class="stat-card">
-        <div class="stat-content">
-          <div class="stat-number">{{ memorizedVerses | number }}</div>
-          <div class="stat-label">Verses Memorized</div>
-          <div class="stat-progress text-green">{{ percentComplete }}% Complete</div>
+        <div class="stat-header">
+          <div class="stat-content">
+            <div class="stat-number">{{ memorizedVerses | number }}</div>
+            <div class="stat-label">Verses Memorized</div>
+            <div class="stat-progress text-green">{{ percentComplete }}% Complete</div>
+          </div>
+          <button class="view-toggle-btn" (click)="toggleProgressView()">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="toggle-icon">
+              <path d="M12 3v18m9-9H3"/>
+            </svg>
+            {{ progressViewMode === 'testament' ? 'Groups' : 'Testament' }}
+          </button>
         </div>
-        <div class="mini-visual">
-          <canvas id="totalProgressChart"></canvas>
+
+        <!-- Segmented Progress Bar -->
+        <div class="segmented-progress">
+          <div class="segmented-bar">
+            <div class="segment" 
+                 *ngFor="let segment of getProgressSegments()"
+                 [style.width.%]="segment.percent"
+                 [style.background]="segment.color"
+                 [title]="segment.name + ': ' + segment.verses + ' verses (' + segment.percent + '%)'">
+              <span class="segment-label" *ngIf="segment.percent > 5">
+                {{ segment.shortName }}
+              </span>
+            </div>
+          </div>
+
+          <!-- Legend -->
+          <div class="progress-legend">
+            <div class="legend-item" *ngFor="let segment of getProgressSegments()">
+              <ng-container *ngIf="segment.name !== 'Remaining'">
+                <div class="legend-dot" [style.background]="segment.color"></div>
+                <span class="legend-name">{{ segment.name }}</span>
+                <span class="legend-value">{{ segment.percent }}%</span>
+              </ng-container>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-
   </div>
 
   <!-- Testament Progress -->

--- a/frontend/src/app/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.scss
@@ -71,8 +71,14 @@
 /* Stats cards */
 .stat-card {
   display: flex;
+  flex-direction: column;
+}
+
+.stat-header {
+  display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
 }
 
 .stat-content {
@@ -97,19 +103,105 @@
   margin-top: 0.5rem;
 }
 
-/* Mini visualizations */
-.mini-visual {
-  width: 80px;
-  height: 80px;
+/* View toggle button */
+.view-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #4b5563;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #e5e7eb;
+    color: #1f2937;
+  }
+
+  .toggle-icon {
+    width: 14px;
+    height: 14px;
+  }
 }
 
-#totalProgressChart {
-  width: 80px;
-  height: 80px;
+/* Segmented progress bar */
+.segmented-progress {
+  margin-top: 1rem;
 }
 
+.segmented-bar {
+  display: flex;
+  height: 24px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
 
+.segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: all 0.3s ease;
+  cursor: pointer;
 
+  &:hover {
+    filter: brightness(1.1);
+  }
+
+  &:first-child {
+    border-top-left-radius: 12px;
+    border-bottom-left-radius: 12px;
+  }
+
+  &:last-child {
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
+  }
+}
+
+.segment-label {
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.progress-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.813rem;
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .legend-name {
+    color: #4b5563;
+  }
+
+  .legend-value {
+    color: #1f2937;
+    font-weight: 600;
+    margin-left: 0.25rem;
+  }
+}
 
 /* Testament cards */
 .testament-card {
@@ -540,5 +632,27 @@
   
   .book-grid {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .stat-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .view-toggle-btn {
+    align-self: flex-start;
+  }
+
+  .progress-legend {
+    font-size: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .segmented-bar {
+    height: 20px;
+  }
+
+  .segment-label {
+    font-size: 0.625rem;
   }
 }


### PR DESCRIPTION
## Summary
- implement segmented progress bars for Bible progress
- toggle between testament and group view
- update styles for new segmented progress bar

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843969f5fac8331860a4f6ee842e41f