### PR TITLE
Implement auto-save on interaction

### DIFF
--- a/frontend/src/app/features/memorize/courses/course-builder.component.ts
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.ts
@@ -1,6 +1,6 @@
 // frontend/src/app/features/courses/course-builder.component.ts
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormsModule,
@@ -131,6 +131,14 @@ export class CourseBuilderComponent implements OnInit {
     }
 
     this.courseForm.valueChanges.subscribe(() => this.autoSave());
+
+    this.lessonForm.valueChanges.subscribe(() => {
+      if (this.currentStep === 2 && this.selectedLessonIndex !== null) {
+        this.saveLessonToMemory();
+      } else {
+        this.autoSave();
+      }
+    });
 
     this.userService.currentUser$.subscribe((user) => {
       if (user) {
@@ -801,6 +809,21 @@ export class CourseBuilderComponent implements OnInit {
         };
       default:
         return {};
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  onAnyButtonClick(event: Event) {
+    const target = event.target as HTMLElement;
+    if (target.closest('button') && this.currentStep === 2 && this.selectedLessonIndex !== null) {
+      this.saveLessonToMemory();
+    }
+  }
+
+  @HostListener('document:keydown')
+  onAnyKey() {
+    if (this.currentStep === 2 && this.selectedLessonIndex !== null) {
+      this.saveLessonToMemory();
     }
   }
 


### PR DESCRIPTION
## Summary
- autosave whenever lesson form values change
- autosave lesson on any button click or key press

## Testing
- `npm test --silent` *(fails: ng not found)*
- `python3 services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843a0f5d58c8331b87cd34e81a633ff