### PR TITLE
Add lesson duration option

### DIFF
--- a/frontend/src/app/core/models/course.model.ts
+++ b/frontend/src/app/core/models/course.model.ts
@@ -31,6 +31,8 @@ export interface Lesson {
   article_text?: string;
   external_url?: string;
   external_title?: string;
+  /** Estimated minutes to complete the lesson */
+  expected_minutes?: number;
   flashcards_required: number;
   position: number;
 }
@@ -106,6 +108,8 @@ export interface CreateLessonRequest {
   description?: string;
   content_type: 'video' | 'article' | 'external_link' | 'quiz';
   content_data: LessonContent;
+  /** Estimated minutes to complete the lesson */
+  expected_minutes?: number;
   position?: number;
 }
 

--- a/frontend/src/app/features/memorize/courses/course-builder.component.html
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.html
@@ -146,7 +146,9 @@
     <div class="editor-panel lessons-panel">
       <div class="panel-header">
         <h3>Course Structure</h3>
-        <span class="lesson-count">{{ lessons.length }} lessons</span>
+        <span class="lesson-count">
+          {{ lessons.length }} lessons • {{ totalExpectedMinutes }} mins
+        </span>
       </div>
 
       <div class="lesson-list">
@@ -266,6 +268,18 @@
             rows="2"
             placeholder="Brief description of the lesson (optional)"
           ></textarea>
+        </div>
+
+        <div class="form-group">
+          <label>Expected Time (mins)</label>
+          <input
+            type="number"
+            class="form-control"
+            formControlName="expected_minutes"
+            min="5"
+            max="30"
+            step="5"
+          />
         </div>
 
         <div class="form-group">

--- a/frontend/src/app/features/memorize/courses/course-builder.component.html
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.html
@@ -272,14 +272,9 @@
 
         <div class="form-group">
           <label>Expected Time (mins)</label>
-          <input
-            type="number"
-            class="form-control"
-            formControlName="expected_minutes"
-            min="5"
-            max="30"
-            step="5"
-          />
+          <select class="form-control" formControlName="expected_minutes">
+            <option *ngFor="let t of expectedTimeOptions" [value]="t">{{ t }}</option>
+          </select>
         </div>
 
         <div class="form-group">

--- a/frontend/src/app/features/memorize/courses/course-builder.component.scss
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.scss
@@ -371,13 +371,11 @@ textarea.form-control {
 .lesson-number {
   width: 40px;
   height: 40px;
-  background: #e5e7eb;
-  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 1.5rem;
+  font-size: 2rem;
   flex-shrink: 0;
 }
 

--- a/frontend/src/app/features/memorize/courses/course-builder.component.scss
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.scss
@@ -369,15 +369,15 @@ textarea.form-control {
 }
 
 .lesson-number {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   background: #e5e7eb;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 1.125rem;
+  font-size: 1.5rem;
   flex-shrink: 0;
 }
 

--- a/frontend/src/app/features/memorize/courses/course-builder.component.ts
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.ts
@@ -37,6 +37,7 @@ interface Lesson {
   article_text?: string;
   external_url?: string;
   external_title?: string;
+  expected_minutes?: number;
   // Quiz specific fields
   quiz_verse_count?: number;
   quiz_pass_threshold?: number;
@@ -173,6 +174,7 @@ export class CourseBuilderComponent implements OnInit {
       article_text: [''],
       external_url: [''],
       external_title: [''],
+      expected_minutes: [10, [Validators.min(5), Validators.max(30)]],
       quiz_verse_count: [5],
       quiz_pass_threshold: [85],
       quiz_randomize: [true],
@@ -369,6 +371,7 @@ export class CourseBuilderComponent implements OnInit {
           article_text: lesson.content_data?.article_text,
           external_url: lesson.content_data?.external_url,
           external_title: lesson.content_data?.external_title,
+          expected_minutes: (lesson as any).expected_minutes || 10,
           quiz_verse_count: lesson.content_data?.quiz_config?.verse_count,
           quiz_pass_threshold: lesson.content_data?.quiz_config?.pass_threshold,
           quiz_randomize: lesson.content_data?.quiz_config?.randomize,
@@ -399,6 +402,7 @@ export class CourseBuilderComponent implements OnInit {
       article_text: lesson.article_text || '',
       external_url: lesson.external_url || '',
       external_title: lesson.external_title || '',
+      expected_minutes: lesson.expected_minutes || 10,
       quiz_verse_count: lesson.quiz_cards
         ? lesson.quiz_cards.reduce((t, c) => t + c.verseCodes.length, 0)
         : lesson.quiz_verse_count || 5,
@@ -427,6 +431,7 @@ export class CourseBuilderComponent implements OnInit {
     const newLesson: Lesson = {
       title: `Lesson ${this.lessons.length + 1}`,
       content_type: '',
+      expected_minutes: 10,
       quiz_verse_count: 5,
       quiz_pass_threshold: 85,
       quiz_randomize: true,
@@ -547,9 +552,15 @@ export class CourseBuilderComponent implements OnInit {
     this.autoSave();
   }
 
+  get totalExpectedMinutes(): number {
+    return this.lessons.reduce(
+      (sum, l) => sum + (l.expected_minutes || 0),
+      0,
+    );
+  }
+
   get estimatedDuration(): number {
-    // Estimate ~30 minutes per lesson
-    return Math.ceil(this.lessons.length * 0.5);
+    return Math.ceil(this.totalExpectedMinutes / 60);
   }
 
   get pieSlices() {
@@ -764,6 +775,7 @@ export class CourseBuilderComponent implements OnInit {
               description: lesson.description,
               content_type: lesson.content_type as any,
               content_data: this.buildContentData(lesson),
+              expected_minutes: lesson.expected_minutes,
               position: lesson.position,
             })
             .toPromise();

--- a/frontend/src/app/features/memorize/courses/course-builder.component.ts
+++ b/frontend/src/app/features/memorize/courses/course-builder.component.ts
@@ -78,6 +78,7 @@ export class CourseBuilderComponent implements OnInit {
 
   availableTags: string[] = [];
   selectedTags: string[] = [];
+  expectedTimeOptions = [5, 10, 15, 20, 25, 30];
 
   userId!: number;
 


### PR DESCRIPTION
## Summary
- bump lesson icons size for better visibility in the builder
- allow specifying expected lesson time with default 10 minutes
- display total expected time beside lesson count
- include expected time in course creation request

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a34225788331b9db3c2ac3bf3224