### PR TITLE
Move Courses link to new Learning tab

### DIFF
--- a/frontend/src/app/shared/components/navigation/navigation.component.html
+++ b/frontend/src/app/shared/components/navigation/navigation.component.html
@@ -93,35 +93,16 @@
             </svg>
             Flashcards
           </a>
-          <a
-            routerLink="/courses"
-            class="dropdown-item"
-            routerLinkActive="active"
-            (click)="closeMenu()"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 3l9 5-9 5-9-5 9-5z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 13v8m0-8l5-3m-5 3l-5-3"
-              />
-            </svg>
-            Courses
-          </a>
         </div>
       </div>
+
+      <a
+        routerLink="/courses"
+        class="nav-link"
+        routerLinkActive="active"
+        (click)="closeMenu()"
+        >Learning</a
+      >
 
       <!-- Profile dropdown menu -->
       <div class="nav-dropdown profile">


### PR DESCRIPTION
## Summary
- adjust navigation menu so `Courses` is now under a top-level **Learning** tab

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a3fddaf883318bf2b06c5cc2f093