### PR TITLE
Add Bible translation selection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -60,7 +60,7 @@ app.add_middleware(
 )
 
 # Import routers after app creation to avoid circular imports
-from routers import users, user_verses, decks, feature_requests, courses
+from routers import users, user_verses, decks, feature_requests, courses, bibles
 
 # Include routers
 app.include_router(users.router, prefix="/api/users", tags=["users"])
@@ -70,6 +70,7 @@ app.include_router(
     feature_requests.router, prefix="/api/feature-requests", tags=["feature_requests"]
 )
 app.include_router(courses.router, prefix="/api/courses", tags=["courses"])
+app.include_router(bibles.router, prefix="/api/bibles", tags=["bibles"])
 
 
 @app.get("/api/health")

--- a/backend/routers/bibles.py
+++ b/backend/routers/bibles.py
@@ -1,0 +1,19 @@
+import logging
+from fastapi import APIRouter, Depends
+from services.api_bible import APIBibleService
+from config import Config
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+def get_service() -> APIBibleService:
+    return APIBibleService(Config.API_BIBLE_KEY, Config.DEFAULT_BIBLE_ID)
+
+@router.get("/translations")
+async def list_translations(service: APIBibleService = Depends(get_service)):
+    """Return available Bible translations from API.Bible"""
+    try:
+        return service.get_available_bibles()
+    except Exception as e:
+        logger.error(f"Failed to fetch bible translations: {e}")
+        return []

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -11,18 +11,43 @@
     <!-- Success Alert -->
     <div class="alert alert-success" *ngIf="showSuccess">
       <div class="alert-content">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="alert-icon">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          class="alert-icon"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
         </svg>
         <div class="alert-text">
           <strong>Success!</strong> Profile updated successfully.
-          <span *ngIf="profileForm.includeApocrypha"> Apocryphal books are now visible in the Bible tracker.</span>
-          <span *ngIf="!profileForm.includeApocrypha"> Apocryphal books are now hidden in the Bible tracker.</span>
+          <span *ngIf="profileForm.includeApocrypha">
+            Apocryphal books are now visible in the Bible tracker.</span
+          >
+          <span *ngIf="!profileForm.includeApocrypha">
+            Apocryphal books are now hidden in the Bible tracker.</span
+          >
         </div>
       </div>
       <button class="alert-close" (click)="dismissSuccess()">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"
+          />
         </svg>
       </button>
     </div>
@@ -37,21 +62,42 @@
           <h1 class="profile-name">{{ user.name }}</h1>
           <p class="profile-email">{{ user.email }}</p>
           <p class="profile-join-date">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
             </svg>
-            Member since {{ user.createdAt | date:'mediumDate' }}
+            Member since {{ user.createdAt | date: "mediumDate" }}
           </p>
         </div>
       </div>
     </div>
-    
+
     <!-- Stats Cards -->
     <div class="stats-grid">
       <div class="stat-card">
         <div class="stat-icon-wrapper">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="stat-icon">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="stat-icon"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+            />
           </svg>
         </div>
         <div class="stat-content">
@@ -59,11 +105,22 @@
           <div class="stat-label">Verses Memorized</div>
         </div>
       </div>
-      
+
       <div class="stat-card">
         <div class="stat-icon-wrapper">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="stat-icon">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="stat-icon"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M13 10V3L4 14h7v7l9-11h-7z"
+            />
           </svg>
         </div>
         <div class="stat-content">
@@ -71,11 +128,22 @@
           <div class="stat-label">Day Streak</div>
         </div>
       </div>
-      
+
       <div class="stat-card">
         <div class="stat-icon-wrapper">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="stat-icon">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="stat-icon"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
           </svg>
         </div>
         <div class="stat-content">
@@ -89,101 +157,157 @@
     <div class="settings-card">
       <div class="card-header">
         <h2 class="card-title">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
           </svg>
           Profile Settings
         </h2>
       </div>
-      
+
       <form (ngSubmit)="saveProfile()" class="settings-form">
         <div class="form-row">
           <div class="form-group">
             <label for="firstName">First Name</label>
-            <input 
-              type="text" 
-              id="firstName" 
-              class="form-control" 
-              [(ngModel)]="profileForm.firstName" 
-              name="firstName" 
+            <input
+              type="text"
+              id="firstName"
+              class="form-control"
+              [(ngModel)]="profileForm.firstName"
+              name="firstName"
               required
-              placeholder="Enter your first name">
+              placeholder="Enter your first name"
+            />
           </div>
-              
+
           <div class="form-group">
             <label for="lastName">Last Name</label>
-            <input 
-              type="text" 
-              id="lastName" 
-              class="form-control" 
-              [(ngModel)]="profileForm.lastName" 
+            <input
+              type="text"
+              id="lastName"
+              class="form-control"
+              [(ngModel)]="profileForm.lastName"
               name="lastName"
-              placeholder="Enter your last name">
+              placeholder="Enter your last name"
+            />
           </div>
         </div>
-              
+
         <div class="form-group">
           <label for="denomination">Denomination</label>
           <div class="select-wrapper">
-            <select 
-              id="denomination" 
-              class="form-control" 
-              [(ngModel)]="profileForm.denomination" 
-              name="denomination">
-              <option *ngFor="let option of denominationOptions" [value]="option.value">
+            <select
+              id="denomination"
+              class="form-control"
+              [(ngModel)]="profileForm.denomination"
+              name="denomination"
+            >
+              <option
+                *ngFor="let option of denominationOptions"
+                [value]="option.value"
+              >
                 {{ option.text }}
               </option>
             </select>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="select-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              class="select-icon"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 9l-7 7-7-7"
+              />
             </svg>
           </div>
         </div>
-              
+
+        <div class="form-group">
+          <label for="preferredLanguage">Bible Language</label>
+          <kendo-dropdownlist
+            [data]="languageOptions"
+            [filterable]="true"
+            textField="text"
+            valueField="value"
+            [(ngModel)]="selectedLanguage"
+            (valueChange)="onLanguageChange($event)"
+            name="preferredLanguage"
+          >
+          </kendo-dropdownlist>
+        </div>
+
         <div class="form-group">
           <label for="preferredBible">Preferred Bible Translation</label>
-          <div class="select-wrapper">
-            <select 
-              id="preferredBible" 
-              class="form-control" 
-              [(ngModel)]="profileForm.preferredBible" 
-              name="preferredBible">
-              <option *ngFor="let option of bibleOptions" [value]="option.value">
-                {{ option.text }}
-              </option>
-            </select>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="select-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          <kendo-dropdownlist
+            [data]="bibleOptions"
+            [filterable]="true"
+            textField="text"
+            valueField="value"
+            [(ngModel)]="profileForm.preferredBible"
+            name="preferredBible"
+          >
+          </kendo-dropdownlist>
         </div>
-              
+
         <div class="form-group">
           <div class="toggle-container">
-            <input 
-              type="checkbox" 
-              id="includeApocrypha" 
+            <input
+              type="checkbox"
+              id="includeApocrypha"
               class="toggle-input"
-              [(ngModel)]="profileForm.includeApocrypha" 
-              name="includeApocrypha">
+              [(ngModel)]="profileForm.includeApocrypha"
+              name="includeApocrypha"
+            />
             <label for="includeApocrypha" class="toggle-label">
               <span class="toggle-switch"></span>
               <span class="toggle-text">
                 <strong>Include Apocrypha</strong>
-                <small>Show apocryphal books and chapters in the Bible tracker</small>
+                <small
+                  >Show apocryphal books and chapters in the Bible
+                  tracker</small
+                >
               </span>
             </label>
           </div>
         </div>
-              
+
         <div class="form-actions">
           <button type="submit" class="btn btn-primary" [disabled]="isSaving">
-            <svg *ngIf="!isSaving" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V2" />
+            <svg
+              *ngIf="!isSaving"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V2"
+              />
             </svg>
             <div *ngIf="isSaving" class="button-spinner"></div>
-            <span>{{ isSaving ? 'Saving...' : 'Save Changes' }}</span>
+            <span>{{ isSaving ? "Saving..." : "Save Changes" }}</span>
           </button>
         </div>
       </form>

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -49,17 +49,7 @@ export class ProfileComponent implements OnInit {
   ];
   
   bibleOptions = [
-    { text: 'Select Bible Translation', value: '' },
-    { text: 'King James Version (KJV)', value: 'KJV' },
-    { text: 'New International Version (NIV)', value: 'NIV' },
-    { text: 'English Standard Version (ESV)', value: 'ESV' },
-    { text: 'New American Standard Bible (NASB)', value: 'NASB' },
-    { text: 'New Living Translation (NLT)', value: 'NLT' },
-    { text: 'Christian Standard Bible (CSB)', value: 'CSB' },
-    { text: 'New King James Version (NKJV)', value: 'NKJV' },
-    { text: 'Revised Standard Version (RSV)', value: 'RSV' },
-    { text: 'The Message (MSG)', value: 'MSG' },
-    { text: 'Amplified Bible (AMP)', value: 'AMP' }
+    { text: 'Select Bible Translation', value: '' }
   ];
   
   constructor(
@@ -69,6 +59,16 @@ export class ProfileComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadUserProfile();
+    this.loadBibleOptions();
+  }
+
+  loadBibleOptions(): void {
+    this.bibleService.getAvailableBibles().subscribe(options => {
+      this.bibleOptions = [
+        { text: 'Select Bible Translation', value: '' },
+        ...options.map(o => ({ text: `${o.abbreviation} - ${o.name}`, value: o.id }))
+      ];
+    });
   }
   
   loadUserProfile(): void {
@@ -81,6 +81,10 @@ export class ProfileComponent implements OnInit {
         if (user) {
           // Initialize the form fields with user data
           this.initializeForm(user);
+          this.bibleService.updateUserPreferences(
+            user.includeApocrypha ?? false,
+            user.preferredBible || undefined
+          );
         }
         
         this.isLoading = false;
@@ -131,10 +135,11 @@ export class ProfileComponent implements OnInit {
       next: (updatedUser: any) => {
         console.log('Profile updated successfully:', updatedUser);
         
-        // Update Bible service with new apocrypha setting
-        if (updatedUser && updatedUser.includeApocrypha !== undefined) {
-          console.log(`Explicitly updating BibleService with includeApocrypha=${updatedUser.includeApocrypha}`);
-          this.bibleService.updateUserPreferences(updatedUser.includeApocrypha);
+        if (updatedUser) {
+          this.bibleService.updateUserPreferences(
+            updatedUser.includeApocrypha ?? false,
+            updatedUser.preferredBible || undefined
+          );
         }
         
         // Show success message


### PR DESCRIPTION
## Summary
- expose available Bible translations via new `/api/bibles/translations` route
- register router in backend
- let Profile page load available translations and update BibleService
- track preferred translation in BibleService and use it when fetching verse texts

## Testing
- `python3 backend/services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843a3aae80083319458bc0df9c44cef