### PR TITLE
Add script for demo user 2 data

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -20,6 +20,7 @@ class UserResponse(BaseModel):
     denomination: Optional[str]
     preferred_bible: Optional[str]
     include_apocrypha: bool = False
+    show_charts: bool = True
     created_at: str
     verses_memorized: int = 0
     streak_days: int = 0
@@ -31,6 +32,7 @@ class UserUpdate(BaseModel):
     denomination: Optional[str] = None
     preferred_bible: Optional[str] = None
     include_apocrypha: Optional[bool] = None
+    show_charts: Optional[bool] = None
 
 def get_db():
     """Dependency to get database connection"""
@@ -43,7 +45,7 @@ async def get_user(user_id: int, db: DatabaseConnection = Depends(get_db)):
     
     # Get user info
     query = """
-        SELECT 
+        SELECT
             user_id as id,
             email,
             name,
@@ -52,6 +54,7 @@ async def get_user(user_id: int, db: DatabaseConnection = Depends(get_db)):
             denomination,
             preferred_bible,
             include_apocrypha,
+            show_charts,
             created_at::text
         FROM users
         WHERE user_id = %s
@@ -110,6 +113,10 @@ async def update_user(
     if user_update.include_apocrypha is not None:
         update_fields.append("include_apocrypha = %s")
         params.append(user_update.include_apocrypha)
+
+    if user_update.show_charts is not None:
+        update_fields.append("show_charts = %s")
+        params.append(user_update.show_charts)
     
     # Update name field (combine first and last)
     if user_update.first_name is not None or user_update.last_name is not None:

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -26,6 +26,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   private testamentCharts: { [key: string]: Chart } = {};
   private totalProgressChart: Chart | null = null;
   private isBrowser: boolean;
+  private showCharts = true;
   private groupColors: { [key: string]: string } = {
     'Law': '#10b981',
     'History': '#3b82f6',
@@ -81,6 +82,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
         } else if (!this.userVerses.length) {
           this.loadUserVerses();
         }
+        this.showCharts = user.showCharts !== undefined ? user.showCharts : true;
       } else {
         this.loadUserVerses();
       }
@@ -92,7 +94,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit() {
     // Initialize charts after view is initialized
-    if (this.isBrowser) {
+    if (this.isBrowser && this.showCharts) {
       setTimeout(() => {
         this.initializeAllCharts();
       }, 100);
@@ -125,7 +127,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
       next: (verses: any) => {
         this.userVerses = verses;
         this.isLoading = false;
-        if (this.isBrowser) {
+        if (this.isBrowser && this.showCharts) {
           this.initializeAllCharts();
         }
         this.computeProgressSegments();
@@ -145,7 +147,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private initializeAllCharts() {
-    if (!this.isBrowser) {
+    if (!this.isBrowser || !this.showCharts) {
       return;
     }
     // Initialize testament charts
@@ -155,7 +157,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private initializeTestamentCharts() {
-    if (this.isBrowser) {
+    if (this.isBrowser && this.showCharts) {
       // Wait for next tick to ensure DOM is ready
       setTimeout(() => {
         this.testaments.forEach(testament => {
@@ -166,7 +168,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private createTestamentChart(testament: BibleTestament) {
-    if (!this.isBrowser) return;
+    if (!this.isBrowser || !this.showCharts) return;
     const chartId = this.getTestamentChartId(testament);
     const canvas = document.getElementById(chartId) as HTMLCanvasElement;
     

--- a/frontend/src/app/core/models/user.ts
+++ b/frontend/src/app/core/models/user.ts
@@ -15,6 +15,7 @@ export interface User {
   denomination?: string;
   preferredBible?: string;
   includeApocrypha?: boolean;
+  showCharts?: boolean;
   
   // Statistics
   versesMemorized?: number;
@@ -35,6 +36,7 @@ export interface UserApiResponse {
   denomination?: string;
   preferred_bible?: string;
   include_apocrypha?: boolean;
+  show_charts?: boolean;
   
   verses_memorized?: number;
   streak_days?: number;
@@ -48,4 +50,5 @@ export interface UserProfileUpdate {
   denomination?: string;
   preferred_bible?: string;
   include_apocrypha?: boolean;
+  show_charts?: boolean;
 }

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -58,7 +58,8 @@ export class UserService {
       denomination: formData.denomination,
       preferred_bible: formData.preferredBible || formData.preferred_bible,
       // Use the normalized boolean value
-      include_apocrypha: includeApocrypha
+      include_apocrypha: includeApocrypha,
+      show_charts: formData.showCharts
     };
 
     console.log('Converted to API format:', apiRequestData);
@@ -103,6 +104,7 @@ export class UserService {
       denomination: apiResponse.denomination,
       preferredBible: apiResponse.preferred_bible,
       includeApocrypha: includeApocrypha,
+      showCharts: apiResponse.show_charts,
 
       versesMemorized: apiResponse.verses_memorized,
       streakDays: apiResponse.streak_days,

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -128,17 +128,35 @@
               
         <div class="form-group">
           <div class="toggle-container">
-            <input 
-              type="checkbox" 
-              id="includeApocrypha" 
+            <input
+              type="checkbox"
+              id="includeApocrypha"
               class="toggle-input"
-              [(ngModel)]="profileForm.includeApocrypha" 
+              [(ngModel)]="profileForm.includeApocrypha"
               name="includeApocrypha">
             <label for="includeApocrypha" class="toggle-label">
               <span class="toggle-switch"></span>
               <span class="toggle-text">
                 <strong>Include Apocrypha</strong>
                 <small>Show apocryphal books and chapters in the Bible tracker</small>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="toggle-container">
+            <input
+              type="checkbox"
+              id="showCharts"
+              class="toggle-input"
+              [(ngModel)]="profileForm.showCharts"
+              name="showCharts">
+            <label for="showCharts" class="toggle-label">
+              <span class="toggle-switch"></span>
+              <span class="toggle-text">
+                <strong>Show Progress Charts</strong>
+                <small>Display charts in the Bible tracker</small>
               </span>
             </label>
           </div>

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -30,7 +30,8 @@ export class ProfileComponent implements OnInit {
     lastName: '',
     denomination: '',
     preferredBible: '',
-    includeApocrypha: false
+    includeApocrypha: false,
+    showCharts: true
   };
   
   // Dropdown options
@@ -104,7 +105,8 @@ export class ProfileComponent implements OnInit {
       lastName: nameParts.slice(1).join(' ') || '',
       denomination: user.denomination || '',
       preferredBible: user.preferredBible || '',
-      includeApocrypha: user.includeApocrypha !== undefined ? user.includeApocrypha : false
+      includeApocrypha: user.includeApocrypha !== undefined ? user.includeApocrypha : false,
+      showCharts: user.showCharts !== undefined ? user.showCharts : true
     };
     
     console.log('Profile form initialized with:', this.profileForm);
@@ -122,7 +124,8 @@ export class ProfileComponent implements OnInit {
       lastName: this.profileForm.lastName,
       denomination: this.profileForm.denomination,
       preferredBible: this.profileForm.preferredBible,
-      includeApocrypha: this.profileForm.includeApocrypha
+      includeApocrypha: this.profileForm.includeApocrypha,
+      showCharts: this.profileForm.showCharts
     };
     
     console.log('Profile update payload:', profileUpdate);

--- a/sql_setup/02-create-core-tables.sql
+++ b/sql_setup/02-create-core-tables.sql
@@ -15,6 +15,7 @@ CREATE TABLE users (
     denomination VARCHAR(100),
     preferred_bible VARCHAR(50),
     include_apocrypha BOOLEAN DEFAULT FALSE,
+    show_charts BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -78,6 +79,6 @@ CREATE TRIGGER update_user_verses_updated_at BEFORE UPDATE ON user_verses
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- Insert test user
-INSERT INTO users (email, name, first_name, last_name, include_apocrypha) 
-VALUES ('test@example.com', 'Test User', 'Test', 'User', false)
+INSERT INTO users (email, name, first_name, last_name, include_apocrypha, show_charts)
+VALUES ('test@example.com', 'Test User', 'Test', 'User', false, true)
 ON CONFLICT (email) DO NOTHING;

--- a/sql_setup/10-demo-user-data.sql
+++ b/sql_setup/10-demo-user-data.sql
@@ -203,6 +203,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 10 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 3 AND verse_number = 16
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 90, 10 FROM v
 ON CONFLICT DO NOTHING;
@@ -214,6 +217,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 8 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 23 AND verse_number = 1
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 80, 8 FROM v
 ON CONFLICT DO NOTHING;
@@ -225,6 +231,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 3 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 45 AND chapter_number = 8 AND verse_number = 28
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 60, 3 FROM v
 ON CONFLICT DO NOTHING;
@@ -236,6 +245,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 5 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 20 AND chapter_number = 3 AND verse_number = 5
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 70, 5 FROM v
 ON CONFLICT DO NOTHING;
@@ -247,6 +259,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 2 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 44 AND chapter_number = 1 AND verse_number = 8
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 50, 2 FROM v
 ON CONFLICT DO NOTHING;
@@ -258,6 +273,9 @@ WITH v AS (
 INSERT INTO user_verses (user_id, verse_id, practice_count)
 SELECT 1, id, 6 FROM v
 ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 49 AND chapter_number = 2 AND verse_number = 8
+)
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 75, 6 FROM v
 ON CONFLICT DO NOTHING;

--- a/sql_setup/10-demo-user-data.sql
+++ b/sql_setup/10-demo-user-data.sql
@@ -279,3 +279,270 @@ WITH v AS (
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
 SELECT 1, id, 75, 6 FROM v
 ON CONFLICT DO NOTHING;
+
+-- Additional tracked verses for variety
+-- Genesis 1:1
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 1 AND chapter_number = 1 AND verse_number = 1
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 4 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 1 AND chapter_number = 1 AND verse_number = 1
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 60, 4 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Exodus 20:13
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 2 AND chapter_number = 20 AND verse_number = 13
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 2 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 2 AND chapter_number = 20 AND verse_number = 13
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 50, 2 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Psalm 119:105
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 119 AND verse_number = 105
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 7 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 119 AND verse_number = 105
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 80, 7 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Isaiah 40:31
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 23 AND chapter_number = 40 AND verse_number = 31
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 23 AND chapter_number = 40 AND verse_number = 31
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 65, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Matthew 28:19
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 40 AND chapter_number = 28 AND verse_number = 19
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 5 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 40 AND chapter_number = 28 AND verse_number = 19
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 70, 5 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Luke 2:11
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 42 AND chapter_number = 2 AND verse_number = 11
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 1 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 42 AND chapter_number = 2 AND verse_number = 11
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 40, 1 FROM v
+ON CONFLICT DO NOTHING;
+
+-- John 1:1
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 1 AND verse_number = 1
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 6 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 1 AND verse_number = 1
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 75, 6 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Acts 2:38
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 44 AND chapter_number = 2 AND verse_number = 38
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 44 AND chapter_number = 2 AND verse_number = 38
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 60, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Romans 10:9
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 45 AND chapter_number = 10 AND verse_number = 9
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 4 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 45 AND chapter_number = 10 AND verse_number = 9
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 70, 4 FROM v
+ON CONFLICT DO NOTHING;
+
+-- 1 Corinthians 13:4
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 46 AND chapter_number = 13 AND verse_number = 4
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 46 AND chapter_number = 13 AND verse_number = 4
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 65, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Galatians 2:20
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 48 AND chapter_number = 2 AND verse_number = 20
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 5 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 48 AND chapter_number = 2 AND verse_number = 20
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 75, 5 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Philippians 4:13
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 50 AND chapter_number = 4 AND verse_number = 13
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 8 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 50 AND chapter_number = 4 AND verse_number = 13
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 85, 8 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Colossians 3:23
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 51 AND chapter_number = 3 AND verse_number = 23
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 4 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 51 AND chapter_number = 3 AND verse_number = 23
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 70, 4 FROM v
+ON CONFLICT DO NOTHING;
+
+-- 1 Thessalonians 5:17
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 52 AND chapter_number = 5 AND verse_number = 17
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 2 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 52 AND chapter_number = 5 AND verse_number = 17
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 50, 2 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Hebrews 11:1
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 58 AND chapter_number = 11 AND verse_number = 1
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 5 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 58 AND chapter_number = 11 AND verse_number = 1
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 80, 5 FROM v
+ON CONFLICT DO NOTHING;
+
+-- James 1:2
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 59 AND chapter_number = 1 AND verse_number = 2
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 59 AND chapter_number = 1 AND verse_number = 2
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 60, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- 1 Peter 5:7
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 60 AND chapter_number = 5 AND verse_number = 7
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 4 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 60 AND chapter_number = 5 AND verse_number = 7
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 70, 4 FROM v
+ON CONFLICT DO NOTHING;
+
+-- 1 John 4:8
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 62 AND chapter_number = 4 AND verse_number = 8
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 2 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 62 AND chapter_number = 4 AND verse_number = 8
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 55, 2 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Revelation 3:20
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 66 AND chapter_number = 3 AND verse_number = 20
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 1, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 66 AND chapter_number = 3 AND verse_number = 20
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 1, id, 65, 3 FROM v
+ON CONFLICT DO NOTHING;

--- a/sql_setup/10-demo-user-data.sql
+++ b/sql_setup/10-demo-user-data.sql
@@ -4,6 +4,9 @@
 -- =====================================================
 SET search_path TO wellversed01DEV;
 
+-- Ensure only the main demo user exists
+DELETE FROM users WHERE user_id <> 1;
+
 -- -----------------------------------------------------
 -- Flashcard decks
 -- -----------------------------------------------------

--- a/sql_setup/10-demo-user-data.sql
+++ b/sql_setup/10-demo-user-data.sql
@@ -1,27 +1,22 @@
 -- =====================================================
--- 10-demo-user2-data.sql
--- Demo data for second user with decks, courses, and tracker stats
+-- 10-demo-user-data.sql
+-- Demo data for the main user with decks, courses, and tracker stats
 -- =====================================================
 SET search_path TO wellversed01DEV;
-
--- Create demo user if not exists
-INSERT INTO users (user_id, email, name, first_name, last_name, include_apocrypha)
-VALUES (2, 'demo2@example.com', 'Demo Two', 'Demo', 'Two', false)
-ON CONFLICT (user_id) DO NOTHING;
 
 -- -----------------------------------------------------
 -- Flashcard decks
 -- -----------------------------------------------------
 INSERT INTO decks (user_id, name, description, is_public) VALUES
-    (2, 'Faith Foundations', 'Core verses about salvation by faith', true),
-    (2, 'Proverbs Wisdom', 'Guidance from Proverbs', true),
-    (2, 'Acts Highlights', 'Key moments from Acts', true),
-    (2, 'Short Verses', 'Simple starter verses', false)
+    (1, 'Faith Foundations', 'Core verses about salvation by faith', true),
+    (1, 'Proverbs Wisdom', 'Guidance from Proverbs', true),
+    (1, 'Acts Highlights', 'Key moments from Acts', true),
+    (1, 'Short Verses', 'Simple starter verses', false)
 ON CONFLICT DO NOTHING;
 
 -- Faith Foundations deck - Ephesians 2:8-9
 WITH d AS (
-    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Faith Foundations'
+    SELECT deck_id FROM decks WHERE user_id = 1 AND name = 'Faith Foundations'
 ), v AS (
     SELECT id, verse_number FROM bible_verses
     WHERE book_id = 49 AND chapter_number = 2 AND verse_number BETWEEN 8 AND 9
@@ -39,7 +34,7 @@ ORDER BY v.verse_number;
 
 -- Proverbs Wisdom deck - Proverbs 3:5-6
 WITH d AS (
-    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Proverbs Wisdom'
+    SELECT deck_id FROM decks WHERE user_id = 1 AND name = 'Proverbs Wisdom'
 ), v AS (
     SELECT id, verse_number FROM bible_verses
     WHERE book_id = 20 AND chapter_number = 3 AND verse_number BETWEEN 5 AND 6
@@ -57,7 +52,7 @@ ORDER BY v.verse_number;
 
 -- Acts Highlights deck - Acts 1:8
 WITH d AS (
-    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Acts Highlights'
+    SELECT deck_id FROM decks WHERE user_id = 1 AND name = 'Acts Highlights'
 ), v AS (
     SELECT id FROM bible_verses
     WHERE book_id = 44 AND chapter_number = 1 AND verse_number = 8
@@ -73,7 +68,7 @@ FROM c;
 
 -- Short Verses deck - 1 Thessalonians 5:16
 WITH d AS (
-    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Short Verses'
+    SELECT deck_id FROM decks WHERE user_id = 1 AND name = 'Short Verses'
 ), v AS (
     SELECT id FROM bible_verses
     WHERE book_id = 52 AND chapter_number = 5 AND verse_number = 16
@@ -93,7 +88,7 @@ FROM c;
 -- Course 1: Prayer 101
 WITH c AS (
     INSERT INTO courses (user_id, name, description, is_public)
-    VALUES (2, 'Prayer 101', 'Basics of developing a prayer life', true)
+    VALUES (1, 'Prayer 101', 'Basics of developing a prayer life', true)
     RETURNING course_id
 ),
 vid AS (
@@ -105,7 +100,7 @@ vid AS (
 ),
 art AS (
     INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
-    SELECT course_id, 2, 'Read About Prayer', 'Short article on prayer', 'article',
+    SELECT course_id, 1, 'Read About Prayer', 'Short article on prayer', 'article',
            jsonb_build_object('article_text', 'Prayer is our direct line to God.')
     FROM c
     RETURNING lesson_id, course_id
@@ -120,7 +115,7 @@ FROM c;
 -- Course 2: Gospel of John
 WITH c AS (
     INSERT INTO courses (user_id, name, description, is_public)
-    VALUES (2, 'Gospel of John', 'Overview of the life of Jesus', true)
+    VALUES (1, 'Gospel of John', 'Overview of the life of Jesus', true)
     RETURNING course_id
 ),
 vid AS (
@@ -132,7 +127,7 @@ vid AS (
 ),
 art AS (
     INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
-    SELECT course_id, 2, 'Article: Themes in John', 'Key themes explained', 'article',
+    SELECT course_id, 1, 'Article: Themes in John', 'Key themes explained', 'article',
            jsonb_build_object('article_text', 'John emphasizes belief and life in Christ.')
     FROM c
     RETURNING lesson_id, course_id
@@ -147,7 +142,7 @@ FROM c;
 -- Course 3: Romans Road Study
 WITH c AS (
     INSERT INTO courses (user_id, name, description, is_public)
-    VALUES (2, 'Romans Road Study', 'Important verses from Romans', false)
+    VALUES (1, 'Romans Road Study', 'Important verses from Romans', false)
     RETURNING course_id
 ),
 vid AS (
@@ -159,7 +154,7 @@ vid AS (
 ),
 art AS (
     INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
-    SELECT course_id, 2, 'Article: Salvation Explained', 'Article on salvation', 'article',
+    SELECT course_id, 1, 'Article: Salvation Explained', 'Article on salvation', 'article',
            jsonb_build_object('article_text', 'Romans explains salvation clearly.')
     FROM c
     RETURNING lesson_id, course_id
@@ -174,7 +169,7 @@ FROM c;
 -- Course 4: Acts Adventure
 WITH c AS (
     INSERT INTO courses (user_id, name, description, is_public)
-    VALUES (2, 'Acts Adventure', 'Journey through Acts', true)
+    VALUES (1, 'Acts Adventure', 'Journey through Acts', true)
     RETURNING course_id
 ),
 vid AS (
@@ -186,7 +181,7 @@ vid AS (
 ),
 art AS (
     INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
-    SELECT course_id, 2, 'Article: Early Church', 'Growth of the early church', 'article',
+    SELECT course_id, 1, 'Article: Early Church', 'Growth of the early church', 'article',
            jsonb_build_object('article_text', 'Acts describes the spread of the Gospel.')
     FROM c
     RETURNING lesson_id, course_id
@@ -199,17 +194,17 @@ SELECT c.course_id, 3, 'Acts Quiz', 'Quiz on Acts', 'quiz',
 FROM c;
 
 -- -----------------------------------------------------
--- Bible tracker data for user 2
+-- Bible tracker data for the main user
 -- -----------------------------------------------------
 -- John 3:16
 WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 3 AND verse_number = 16
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 10 FROM v
+SELECT 1, id, 10 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 90, 10 FROM v
+SELECT 1, id, 90, 10 FROM v
 ON CONFLICT DO NOTHING;
 
 -- Psalm 23:1
@@ -217,10 +212,10 @@ WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 23 AND verse_number = 1
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 8 FROM v
+SELECT 1, id, 8 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 80, 8 FROM v
+SELECT 1, id, 80, 8 FROM v
 ON CONFLICT DO NOTHING;
 
 -- Romans 8:28
@@ -228,10 +223,10 @@ WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 45 AND chapter_number = 8 AND verse_number = 28
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 3 FROM v
+SELECT 1, id, 3 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 60, 3 FROM v
+SELECT 1, id, 60, 3 FROM v
 ON CONFLICT DO NOTHING;
 
 -- Proverbs 3:5
@@ -239,10 +234,10 @@ WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 20 AND chapter_number = 3 AND verse_number = 5
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 5 FROM v
+SELECT 1, id, 5 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 70, 5 FROM v
+SELECT 1, id, 70, 5 FROM v
 ON CONFLICT DO NOTHING;
 
 -- Acts 1:8
@@ -250,10 +245,10 @@ WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 44 AND chapter_number = 1 AND verse_number = 8
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 2 FROM v
+SELECT 1, id, 2 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 50, 2 FROM v
+SELECT 1, id, 50, 2 FROM v
 ON CONFLICT DO NOTHING;
 
 -- Ephesians 2:8
@@ -261,8 +256,8 @@ WITH v AS (
     SELECT id FROM bible_verses WHERE book_id = 49 AND chapter_number = 2 AND verse_number = 8
 )
 INSERT INTO user_verses (user_id, verse_id, practice_count)
-SELECT 2, id, 6 FROM v
+SELECT 1, id, 6 FROM v
 ON CONFLICT DO NOTHING;
 INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
-SELECT 2, id, 75, 6 FROM v
+SELECT 1, id, 75, 6 FROM v
 ON CONFLICT DO NOTHING;

--- a/sql_setup/10-demo-user2-data.sql
+++ b/sql_setup/10-demo-user2-data.sql
@@ -1,0 +1,268 @@
+-- =====================================================
+-- 10-demo-user2-data.sql
+-- Demo data for second user with decks, courses, and tracker stats
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Create demo user if not exists
+INSERT INTO users (user_id, email, name, first_name, last_name, include_apocrypha)
+VALUES (2, 'demo2@example.com', 'Demo Two', 'Demo', 'Two', false)
+ON CONFLICT (user_id) DO NOTHING;
+
+-- -----------------------------------------------------
+-- Flashcard decks
+-- -----------------------------------------------------
+INSERT INTO decks (user_id, name, description, is_public) VALUES
+    (2, 'Faith Foundations', 'Core verses about salvation by faith', true),
+    (2, 'Proverbs Wisdom', 'Guidance from Proverbs', true),
+    (2, 'Acts Highlights', 'Key moments from Acts', true),
+    (2, 'Short Verses', 'Simple starter verses', false)
+ON CONFLICT DO NOTHING;
+
+-- Faith Foundations deck - Ephesians 2:8-9
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Faith Foundations'
+), v AS (
+    SELECT id, verse_number FROM bible_verses
+    WHERE book_id = 49 AND chapter_number = 2 AND verse_number BETWEEN 8 AND 9
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, end_verse_id, position)
+    SELECT d.deck_id, 'verse_range', 'Ephesians 2:8-9', MIN(v.id), MAX(v.id), 1
+    FROM d, v
+    GROUP BY d.deck_id
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT c.card_id, v.id, v.verse_number
+FROM c, v
+ORDER BY v.verse_number;
+
+-- Proverbs Wisdom deck - Proverbs 3:5-6
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Proverbs Wisdom'
+), v AS (
+    SELECT id, verse_number FROM bible_verses
+    WHERE book_id = 20 AND chapter_number = 3 AND verse_number BETWEEN 5 AND 6
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, end_verse_id, position)
+    SELECT d.deck_id, 'verse_range', 'Proverbs 3:5-6', MIN(v.id), MAX(v.id), 1
+    FROM d, v
+    GROUP BY d.deck_id
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT c.card_id, v.id, v.verse_number
+FROM c, v
+ORDER BY v.verse_number;
+
+-- Acts Highlights deck - Acts 1:8
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Acts Highlights'
+), v AS (
+    SELECT id FROM bible_verses
+    WHERE book_id = 44 AND chapter_number = 1 AND verse_number = 8
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, position)
+    SELECT d.deck_id, 'single_verse', 'Acts 1:8', v.id, 1
+    FROM d, v
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT card_id, start_verse_id, 1
+FROM c;
+
+-- Short Verses deck - 1 Thessalonians 5:16
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Short Verses'
+), v AS (
+    SELECT id FROM bible_verses
+    WHERE book_id = 52 AND chapter_number = 5 AND verse_number = 16
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, position)
+    SELECT d.deck_id, 'single_verse', '1 Thessalonians 5:16', v.id, 1
+    FROM d, v
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT card_id, start_verse_id, 1
+FROM c;
+
+-- -----------------------------------------------------
+-- Courses and lessons
+-- -----------------------------------------------------
+-- Course 1: Prayer 101
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Prayer 101', 'Basics of developing a prayer life', true)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'Prayer Basics Video', 'Introduction video', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/prayer101')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Read About Prayer', 'Short article on prayer', 'article',
+           jsonb_build_object('article_text', 'Prayer is our direct line to God.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'Prayer Quiz', 'Check your understanding', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 3, 'pass_threshold', 85, 'randomize', true))
+FROM c;
+
+-- Course 2: Gospel of John
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Gospel of John', 'Overview of the life of Jesus', true)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'John Overview Video', 'Watch this summary', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/john-overview')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Article: Themes in John', 'Key themes explained', 'article',
+           jsonb_build_object('article_text', 'John emphasizes belief and life in Christ.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'John Quiz', 'Quiz on the gospel', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 3, 'pass_threshold', 85, 'randomize', true))
+FROM c;
+
+-- Course 3: Romans Road Study
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Romans Road Study', 'Important verses from Romans', false)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'Romans Video', 'Watch overview', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/romans-road')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Article: Salvation Explained', 'Article on salvation', 'article',
+           jsonb_build_object('article_text', 'Romans explains salvation clearly.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'Romans Quiz', 'Quiz on Romans', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 3, 'pass_threshold', 85, 'randomize', true))
+FROM c;
+
+-- Course 4: Acts Adventure
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Acts Adventure', 'Journey through Acts', true)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'Acts Intro Video', 'Introductory video', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/acts-adventure')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Article: Early Church', 'Growth of the early church', 'article',
+           jsonb_build_object('article_text', 'Acts describes the spread of the Gospel.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'Acts Quiz', 'Quiz on Acts', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 3, 'pass_threshold', 85, 'randomize', true))
+FROM c;
+
+-- -----------------------------------------------------
+-- Bible tracker data for user 2
+-- -----------------------------------------------------
+-- John 3:16
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 3 AND verse_number = 16
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 10 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 90, 10 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Psalm 23:1
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 23 AND verse_number = 1
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 8 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 80, 8 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Romans 8:28
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 45 AND chapter_number = 8 AND verse_number = 28
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 60, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Proverbs 3:5
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 20 AND chapter_number = 3 AND verse_number = 5
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 5 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 70, 5 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Acts 1:8
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 44 AND chapter_number = 1 AND verse_number = 8
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 2 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 50, 2 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Ephesians 2:8
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 49 AND chapter_number = 2 AND verse_number = 8
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 6 FROM v
+ON CONFLICT DO NOTHING;
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 75, 6 FROM v
+ON CONFLICT DO NOTHING;

--- a/sql_setup/11-user2-demo-data.sql
+++ b/sql_setup/11-user2-demo-data.sql
@@ -1,0 +1,198 @@
+-- =====================================================
+-- 11-user2-demo-data.sql
+-- Demo data for a second user with decks, courses and tracker stats
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Ensure demo user 2 exists
+INSERT INTO users (user_id, email, name, first_name, last_name, include_apocrypha, show_charts)
+VALUES (2, 'demo2@example.com', 'Demo User2', 'Demo', 'User2', false, true)
+ON CONFLICT (user_id) DO NOTHING;
+
+-- -----------------------------------------------------
+-- Flashcard decks for user 2
+-- -----------------------------------------------------
+INSERT INTO decks (user_id, name, description, is_public) VALUES
+    (2, 'Grace Passages', 'Key verses about grace', true),
+    (2, 'Psalm Favorites', 'Well-loved psalms', false),
+    (2, 'Memory Gems', 'Short memorable verses', true)
+ON CONFLICT DO NOTHING;
+
+-- Grace Passages deck - Romans 3:23-24
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Grace Passages'
+), v AS (
+    SELECT id, verse_number FROM bible_verses
+    WHERE book_id = 45 AND chapter_number = 3 AND verse_number BETWEEN 23 AND 24
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, end_verse_id, position)
+    SELECT d.deck_id, 'verse_range', 'Romans 3:23-24', MIN(v.id), MAX(v.id), 1
+    FROM d, v
+    GROUP BY d.deck_id
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT c.card_id, v.id, v.verse_number
+FROM c, v
+ORDER BY v.verse_number;
+
+-- Psalm Favorites deck - Psalm 23:1
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Psalm Favorites'
+), v AS (
+    SELECT id FROM bible_verses
+    WHERE book_id = 19 AND chapter_number = 23 AND verse_number = 1
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, position)
+    SELECT d.deck_id, 'single_verse', 'Psalm 23:1', v.id, 1
+    FROM d, v
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT card_id, start_verse_id, 1
+FROM c;
+
+-- Memory Gems deck - John 11:35
+WITH d AS (
+    SELECT deck_id FROM decks WHERE user_id = 2 AND name = 'Memory Gems'
+), v AS (
+    SELECT id FROM bible_verses
+    WHERE book_id = 43 AND chapter_number = 11 AND verse_number = 35
+), c AS (
+    INSERT INTO deck_cards (deck_id, card_type, reference, start_verse_id, position)
+    SELECT d.deck_id, 'single_verse', 'John 11:35', v.id, 1
+    FROM d, v
+    RETURNING card_id, start_verse_id
+)
+INSERT INTO card_verses (card_id, verse_id, verse_order)
+SELECT card_id, start_verse_id, 1
+FROM c;
+
+-- -----------------------------------------------------
+-- Courses for user 2
+-- -----------------------------------------------------
+-- Course: Faith Journey
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Faith Journey', 'Explore key steps of faith', true)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'Intro Video', 'Kick-off', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/faithjourney')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Read About Faith', 'Short article', 'article',
+           jsonb_build_object('article_text', 'Living by faith each day.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'Faith Quiz', 'Check understanding', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 2, 'pass_threshold', 80, 'randomize', true))
+FROM c;
+
+-- Course: Basics of Prayer
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'Basics of Prayer', 'Learn how to pray effectively', true)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'Prayer Video', 'Why pray?', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/prayerbasic')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'Prayer Article', 'Read on prayer', 'article',
+           jsonb_build_object('article_text', 'Prayer draws us to God.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'Prayer Quiz', 'Assess learning', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 2, 'pass_threshold', 80, 'randomize', true))
+FROM c;
+
+-- Course: New Testament Survey
+WITH c AS (
+    INSERT INTO courses (user_id, name, description, is_public)
+    VALUES (2, 'New Testament Survey', 'Overview of NT books', false)
+    RETURNING course_id
+),
+vid AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 1, 'NT Video', 'Survey video', 'video',
+           jsonb_build_object('youtube_url', 'https://youtu.be/ntsurvey')
+    FROM c
+    RETURNING lesson_id, course_id
+),
+art AS (
+    INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+    SELECT course_id, 2, 'NT Article', 'Read about the NT', 'article',
+           jsonb_build_object('article_text', 'The NT tells the story of Jesus and the church.')
+    FROM c
+    RETURNING lesson_id, course_id
+)
+INSERT INTO course_lessons (course_id, position, title, description, content_type, content_data)
+SELECT c.course_id, 3, 'NT Quiz', 'Quiz on NT', 'quiz',
+       jsonb_build_object('quiz_config', jsonb_build_object(
+           'source_lessons', ARRAY[(SELECT lesson_id FROM vid), (SELECT lesson_id FROM art)],
+           'verse_count', 3, 'pass_threshold', 80, 'randomize', true))
+FROM c;
+
+-- -----------------------------------------------------
+-- Bible tracker stats for user 2
+-- -----------------------------------------------------
+-- Mark 12:30
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 41 AND chapter_number = 12 AND verse_number = 30
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 5 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 41 AND chapter_number = 12 AND verse_number = 30
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 70, 5 FROM v
+ON CONFLICT DO NOTHING;
+
+-- Psalm 119:11
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 119 AND verse_number = 11
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 3 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 19 AND chapter_number = 119 AND verse_number = 11
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 60, 3 FROM v
+ON CONFLICT DO NOTHING;
+
+-- John 3:16
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 3 AND verse_number = 16
+)
+INSERT INTO user_verses (user_id, verse_id, practice_count)
+SELECT 2, id, 7 FROM v
+ON CONFLICT DO NOTHING;
+WITH v AS (
+    SELECT id FROM bible_verses WHERE book_id = 43 AND chapter_number = 3 AND verse_number = 16
+)
+INSERT INTO user_verse_confidence (user_id, verse_id, confidence_score, review_count)
+SELECT 2, id, 80, 7 FROM v
+ON CONFLICT DO NOTHING;

--- a/sql_setup/README.md
+++ b/sql_setup/README.md
@@ -105,6 +105,7 @@ sql_setup/
 ├── 08-create-courses.sql        # Course and lesson tables
 ├── 09-create-course-progress.sql      # Enrollment and lesson progress
 ├── 10-demo-user-data.sql        # Additional demo content
+├── 11-user2-demo-data.sql       # Demo data for secondary user
 ├── bible_base_data.json         # Bible structure (books, chapters, verses)
 ├── requirements.txt             # Python dependencies
 ├── setup_database.py            # Main setup script

--- a/sql_setup/README.md
+++ b/sql_setup/README.md
@@ -102,6 +102,9 @@ sql_setup/
 ├── 05-create-confidence-tracking.sql  # User progress tracking
 ├── 06-populate-test-data.sql    # Sample data (optional)
 ├── 07-create-feature-requests.sql  # Feature request system
+├── 08-create-courses.sql        # Course and lesson tables
+├── 09-create-course-progress.sql      # Enrollment and lesson progress
+├── 10-demo-user-data.sql        # Additional demo content
 ├── bible_base_data.json         # Bible structure (books, chapters, verses)
 ├── requirements.txt             # Python dependencies
 ├── setup_database.py            # Main setup script

--- a/sql_setup/setup_database.py
+++ b/sql_setup/setup_database.py
@@ -116,6 +116,11 @@ SQL_FILES = [
         'file': '10-demo-user-data.sql',
         'description': 'Insert additional demo data for main user',
         'skip_on_production': True
+    },
+    {
+        'file': '11-user2-demo-data.sql',
+        'description': 'Insert demo content for second user',
+        'skip_on_production': True
     }
 ]
 

--- a/sql_setup/setup_database.py
+++ b/sql_setup/setup_database.py
@@ -113,8 +113,8 @@ SQL_FILES = [
         'description': 'Create course enrollment and progress tables'
     },
     {
-        'file': '10-demo-user2-data.sql',
-        'description': 'Insert demo data for user 2',
+        'file': '10-demo-user-data.sql',
+        'description': 'Insert additional demo data for main user',
         'skip_on_production': True
     }
 ]

--- a/sql_setup/setup_database.py
+++ b/sql_setup/setup_database.py
@@ -111,6 +111,11 @@ SQL_FILES = [
     {
         'file': '09-create-course-progress.sql',
         'description': 'Create course enrollment and progress tables'
+    },
+    {
+        'file': '10-demo-user2-data.sql',
+        'description': 'Insert demo data for user 2',
+        'skip_on_production': True
     }
 ]
 


### PR DESCRIPTION
## Summary
- add `10-demo-user2-data.sql` with sample decks, courses and Bible tracker info for a second demo user
- register the new script in `setup_database.py`

## Testing
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684426b859c883318aeea0b0d987b1a4