### PR TITLE
Add danger zone reset feature

### DIFF
--- a/backend/routers/user_verses.py
+++ b/backend/routers/user_verses.py
@@ -348,3 +348,21 @@ async def update_confidence(
     )
 
     return {"message": "Confidence updated"}
+
+
+@router.delete("/{user_id}")
+async def clear_user_memorization(
+    user_id: int, db: DatabaseConnection = Depends(get_db)
+) -> dict:
+    """Remove all memorization data for a user."""
+    logger.info(f"Clearing memorization data for user {user_id}")
+
+    try:
+        db.execute("DELETE FROM user_verse_confidence WHERE user_id = %s", (user_id,))
+        db.execute("DELETE FROM user_verses WHERE user_id = %s", (user_id,))
+        logger.info(f"Memorization data cleared for user {user_id}")
+        return {"message": "Memorization data cleared"}
+    except Exception as e:
+        logger.error(f"Failed to clear data for user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to clear memorization data")
+

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -141,3 +141,5 @@ async def update_user(
     except Exception as e:
         logger.error(f"Failed to update user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to update user")
+
+

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -83,6 +83,15 @@ export class UserService {
     this.currentUserSubject.next(null);
   }
 
+  clearMemorizationData(): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/user-verses/1`).pipe(
+      catchError(error => {
+        console.error('Error clearing data:', error);
+        throw error;
+      })
+    );
+  }
+
   // Helper method to convert API response (snake_case) to User model (camelCase)
   private mapApiResponseToUser(apiResponse: UserApiResponse): User {
     // Convert include_apocrypha to a proper boolean if it exists

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -84,7 +84,8 @@ export class UserService {
   }
 
   clearMemorizationData(): Observable<any> {
-    return this.http.delete(`${this.apiUrl}/user-verses/1`).pipe(
+    const userId = this.getCurrentUser()?.id || 1;
+    return this.http.delete(`${this.apiUrl}/user-verses/${userId}`).pipe(
       catchError(error => {
         console.error('Error clearing data:', error);
         throw error;

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -159,7 +159,11 @@
       <div class="danger-zone">
         <h3>Danger Zone</h3>
         <p>Clear your memorization data and start from scratch.</p>
-        <button class="btn btn-danger" (click)="clearAllData()">Clear All Data</button>
+        <div class="danger-actions">
+          <button type="button" class="btn btn-danger" (click)="clearAllData()">
+            Clear All Data
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -154,6 +154,13 @@
           </button>
         </div>
       </form>
+
+      <!-- Danger Zone -->
+      <div class="danger-zone">
+        <h3>Danger Zone</h3>
+        <p>Clear your memorization data and start from scratch.</p>
+        <button class="btn btn-danger" (click)="clearAllData()">Clear All Data</button>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/features/profile/profile.component.scss
+++ b/frontend/src/app/features/profile/profile.component.scss
@@ -462,6 +462,42 @@
   animation: spin 1s linear infinite;
 }
 
+.danger-zone {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid #d0d7de;
+  border-radius: 0.5rem;
+  background: #fff5f5;
+
+  h3 {
+    color: #cf222e;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    color: #57606a;
+    margin-bottom: 1rem;
+  }
+
+  .danger-actions {
+    text-align: right;
+  }
+
+  .btn-danger {
+    background: #cf222e;
+    color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+
+    &:hover {
+      background: #a40e26;
+    }
+  }
+}
+
 // Responsive Design
 @media (max-width: 768px) {
   
@@ -487,28 +523,5 @@
   .btn {
     width: 100%;
     justify-content: center;
-  }
-
-  .danger-zone {
-    margin-top: 2rem;
-    padding: 1.5rem;
-    border: 1px solid #f87171;
-    background: #fef2f2;
-    border-radius: 0.5rem;
-    text-align: center;
-
-    h3 {
-      color: #b91c1c;
-      margin-bottom: 0.5rem;
-    }
-
-    .btn-danger {
-      background: #dc2626;
-      color: #fff;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 0.375rem;
-      cursor: pointer;
-    }
   }
 }

--- a/frontend/src/app/features/profile/profile.component.scss
+++ b/frontend/src/app/features/profile/profile.component.scss
@@ -488,4 +488,27 @@
     width: 100%;
     justify-content: center;
   }
+
+  .danger-zone {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border: 1px solid #f87171;
+    background: #fef2f2;
+    border-radius: 0.5rem;
+    text-align: center;
+
+    h3 {
+      color: #b91c1c;
+      margin-bottom: 0.5rem;
+    }
+
+    .btn-danger {
+      background: #dc2626;
+      color: #fff;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      cursor: pointer;
+    }
+  }
 }

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { User } from '../../core/models/user';
 import { UserService } from '../../core/services/user.service';
 import { BibleService } from '../../core/services/bible.service';
@@ -64,7 +64,8 @@ export class ProfileComponent implements OnInit {
   
   constructor(
     private userService: UserService,
-    private bibleService: BibleService
+    private bibleService: BibleService,
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -157,5 +158,19 @@ export class ProfileComponent implements OnInit {
   
   dismissSuccess(): void {
     this.showSuccess = false;
+  }
+
+  clearAllData(): void {
+    if (confirm('This will delete all your data. Are you sure?')) {
+      this.userService.clearMemorizationData().subscribe({
+        next: () => {
+          alert('All data has been removed.');
+          this.router.navigate(['/']);
+        },
+        error: (error: any) => {
+          console.error('Error clearing data:', error);
+        }
+      });
+    }
   }
 }

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule, Router } from '@angular/router';
+import { ModalService } from '../../core/services/modal.service';
 import { User } from '../../core/models/user';
 import { UserService } from '../../core/services/user.service';
 import { BibleService } from '../../core/services/bible.service';
@@ -65,7 +66,8 @@ export class ProfileComponent implements OnInit {
   constructor(
     private userService: UserService,
     private bibleService: BibleService,
-    private router: Router
+    private router: Router,
+    private modalService: ModalService
   ) { }
 
   ngOnInit(): void {
@@ -160,17 +162,24 @@ export class ProfileComponent implements OnInit {
     this.showSuccess = false;
   }
 
-  clearAllData(): void {
-    if (confirm('This will delete all your data. Are you sure?')) {
-      this.userService.clearMemorizationData().subscribe({
-        next: () => {
-          alert('All data has been removed.');
-          this.router.navigate(['/']);
-        },
-        error: (error: any) => {
-          console.error('Error clearing data:', error);
-        }
-      });
-    }
+  async clearAllData(): Promise<void> {
+    const confirmed = await this.modalService.danger(
+      'Clear All Data',
+      'This will remove all of your memorization progress. Your account will remain. This action cannot be undone.',
+      'Clear Data'
+    );
+
+    if (!confirmed) return;
+
+    this.userService.clearMemorizationData().subscribe({
+      next: () => {
+        this.modalService.success('Data Cleared', 'All memorization data has been removed.');
+        this.router.navigate(['/']);
+      },
+      error: (error: any) => {
+        console.error('Error clearing data:', error);
+        this.modalService.alert('Error', 'Failed to clear data. Please try again.', 'danger');
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add endpoint to clear all memorization data for a user
- expose `clearMemorizationData` in `UserService`
- adjust profile page Danger Zone to use new API and clarify text
- remove DELETE user API since we don't remove the user

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686027db135483319b17977627ce947e