### PR TITLE
Remove Apocrypha from DB setup

### DIFF
--- a/sql_setup/setup_database.py
+++ b/sql_setup/setup_database.py
@@ -215,11 +215,7 @@ def populate_bible_data(conn):
             '1 Thessalonians': 52, '2 Thessalonians': 53, '1 Timothy': 54,
             '2 Timothy': 55, 'Titus': 56, 'Philemon': 57, 'Hebrews': 58,
             'James': 59, '1 Peter': 60, '2 Peter': 61, '1 John': 62,
-            '2 John': 63, '3 John': 64, 'Jude': 65, 'Revelation': 66,
-            # Apocryphal books
-            'Tobit': 67, 'Judith': 68, '1 Maccabees': 69, '2 Maccabees': 70,
-            'Wisdom of Solomon': 71, 'Sirach': 72, 'Baruch': 73,
-            '1 Esdras': 74, '3 Maccabees': 75, 'Prayer of Manasseh': 76
+            '2 John': 63, '3 John': 64, 'Jude': 65, 'Revelation': 66
         }
         
         # Book codes mapping
@@ -240,10 +236,7 @@ def populate_bible_data(conn):
             '1 Thessalonians': '1TH', '2 Thessalonians': '2TH', '1 Timothy': '1TI',
             '2 Timothy': '2TI', 'Titus': 'TIT', 'Philemon': 'PHM', 'Hebrews': 'HEB',
             'James': 'JAS', '1 Peter': '1PE', '2 Peter': '2PE', '1 John': '1JN',
-            '2 John': '2JN', '3 John': '3JN', 'Jude': 'JDE', 'Revelation': 'REV',
-            'Tobit': 'TOB', 'Judith': 'JDT', '1 Maccabees': '1MA', '2 Maccabees': '2MA',
-            'Wisdom of Solomon': 'WIS', 'Sirach': 'SIR', 'Baruch': 'BAR',
-            '1 Esdras': '1ES', '3 Maccabees': '3MA', 'Prayer of Manasseh': 'MAN'
+            '2 John': '2JN', '3 John': '3JN', 'Jude': 'JDE', 'Revelation': 'REV'
         }
         
         # Prepare data
@@ -254,9 +247,9 @@ def populate_bible_data(conn):
         
         for book in bible_data['books']:
             book_name = book['name']
-            
-            # Skip books with canonicalAffiliation NONE
-            if book.get('canonicalAffiliation') == 'NONE':
+
+            # Skip non-canonical books (Apocrypha)
+            if book.get('canonicalAffiliation') != 'All':
                 continue
             
             book_id = book_id_map.get(book_name)
@@ -280,11 +273,10 @@ def populate_bible_data(conn):
             for chapter_num, verse_count in enumerate(book['chapters'], 1):
                 for verse_num in range(1, verse_count + 1):
                     verse_code = f"{book_id}-{chapter_num}-{verse_num}"
-                    is_apocryphal = canonical_affiliation in ['Catholic', 'Eastern Orthodox']
-                    
-                    verses_to_insert.append((
-                        verse_code, book_id, chapter_num, verse_num, is_apocryphal
-                    ))
+
+                    verses_to_insert.append(
+                        (verse_code, book_id, chapter_num, verse_num)
+                    )
                     total_verses += 1
             
             # Progress indicator
@@ -316,10 +308,10 @@ def populate_bible_data(conn):
             
             execute_values(
                 cur,
-                """INSERT INTO bible_verses (verse_code, book_id, chapter_number, verse_number, is_apocryphal)
+                """INSERT INTO bible_verses (verse_code, book_id, chapter_number, verse_number)
                    VALUES %s ON CONFLICT (verse_code) DO NOTHING""",
                 batch,
-                template="(%s, %s, %s, %s, %s)"
+                template="(%s, %s, %s, %s)"
             )
             
             # Progress bar

--- a/sql_setup/sql_backup_20250628_185704/01-drop-schema.sql
+++ b/sql_setup/sql_backup_20250628_185704/01-drop-schema.sql
@@ -1,0 +1,6 @@
+-- =====================================================
+-- 01-drop-schema.sql
+-- WARNING: This drops everything! Use with caution.
+-- =====================================================
+DROP SCHEMA IF EXISTS wellversed01DEV CASCADE;
+DROP SCHEMA IF EXISTS wellversed01dev CASCADE;

--- a/sql_setup/sql_backup_20250628_185704/02-create-core-tables.sql
+++ b/sql_setup/sql_backup_20250628_185704/02-create-core-tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE users (
     last_name VARCHAR(100),
     denomination VARCHAR(100),
     preferred_bible VARCHAR(50),
+    include_apocrypha BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -38,6 +39,7 @@ CREATE TABLE bible_verses (
     book_id INTEGER NOT NULL REFERENCES bible_books(book_id),
     chapter_number INTEGER NOT NULL,
     verse_number INTEGER NOT NULL,
+    is_apocryphal BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -76,6 +78,6 @@ CREATE TRIGGER update_user_verses_updated_at BEFORE UPDATE ON user_verses
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- Insert test user
-INSERT INTO users (email, name, first_name, last_name)
-VALUES ('test@example.com', 'Test User', 'Test', 'User')
+INSERT INTO users (email, name, first_name, last_name, include_apocrypha) 
+VALUES ('test@example.com', 'Test User', 'Test', 'User', false)
 ON CONFLICT (email) DO NOTHING;

--- a/sql_setup/sql_backup_20250628_185704/03-create-decks.sql
+++ b/sql_setup/sql_backup_20250628_185704/03-create-decks.sql
@@ -1,0 +1,49 @@
+-- =====================================================
+-- 03-create-decks.sql
+-- Deck system including saved_decks
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Decks table
+CREATE TABLE decks (
+    deck_id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    is_public BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Saved decks table (users can save other users' public decks)
+CREATE TABLE saved_decks (
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    deck_id INTEGER NOT NULL REFERENCES decks(deck_id) ON DELETE CASCADE,
+    saved_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, deck_id)
+);
+
+-- Tags table (for future use)
+CREATE TABLE deck_tags (
+    tag_id SERIAL PRIMARY KEY,
+    tag_name VARCHAR(50) UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Deck-tag relationship
+CREATE TABLE deck_tag_map (
+    deck_id INTEGER REFERENCES decks(deck_id) ON DELETE CASCADE,
+    tag_id INTEGER REFERENCES deck_tags(tag_id) ON DELETE CASCADE,
+    PRIMARY KEY (deck_id, tag_id)
+);
+
+-- Indexes
+CREATE INDEX idx_decks_user ON decks(user_id);
+CREATE INDEX idx_decks_public ON decks(is_public);
+CREATE INDEX idx_saved_decks_user_id ON saved_decks(user_id);
+CREATE INDEX idx_saved_decks_deck_id ON saved_decks(deck_id);
+CREATE INDEX idx_saved_decks_saved_at ON saved_decks(saved_at);
+
+-- Update trigger
+CREATE TRIGGER update_decks_updated_at BEFORE UPDATE ON decks
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/sql_setup/sql_backup_20250628_185704/04-create-deck-cards.sql
+++ b/sql_setup/sql_backup_20250628_185704/04-create-deck-cards.sql
@@ -1,0 +1,31 @@
+-- =====================================================
+-- 04-create-deck-cards.sql
+-- Flashcard system for decks
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Flashcards table
+CREATE TABLE deck_cards (
+    card_id SERIAL PRIMARY KEY,
+    deck_id INTEGER NOT NULL REFERENCES decks(deck_id) ON DELETE CASCADE,
+    card_type VARCHAR(20) DEFAULT 'verse_range',
+    reference TEXT NOT NULL,
+    start_verse_id INTEGER NOT NULL REFERENCES bible_verses(id),
+    end_verse_id INTEGER REFERENCES bible_verses(id),
+    position INTEGER DEFAULT 0,
+    added_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Verses within a card
+CREATE TABLE card_verses (
+    card_id INTEGER NOT NULL REFERENCES deck_cards(card_id) ON DELETE CASCADE,
+    verse_id INTEGER NOT NULL REFERENCES bible_verses(id) ON DELETE CASCADE,
+    verse_order INTEGER NOT NULL,
+    PRIMARY KEY (card_id, verse_id)
+);
+
+-- Indexes
+CREATE INDEX idx_deck_cards_deck ON deck_cards(deck_id);
+CREATE INDEX idx_deck_cards_position ON deck_cards(deck_id, position);
+CREATE INDEX idx_card_verses_card ON card_verses(card_id);
+CREATE INDEX idx_card_verses_order ON card_verses(card_id, verse_order);

--- a/sql_setup/sql_backup_20250628_185704/05-create-confidence-tracking.sql
+++ b/sql_setup/sql_backup_20250628_185704/05-create-confidence-tracking.sql
@@ -1,0 +1,26 @@
+-- =====================================================
+-- 05-create-confidence-tracking.sql
+-- Track user confidence/mastery of verses
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Confidence tracking table
+CREATE TABLE user_verse_confidence (
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    verse_id INTEGER NOT NULL REFERENCES bible_verses(id) ON DELETE CASCADE,
+    confidence_score INTEGER NOT NULL CHECK (confidence_score >= 0 AND confidence_score <= 100),
+    last_reviewed TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    review_count INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, verse_id)
+);
+
+-- Indexes
+CREATE INDEX idx_confidence_user ON user_verse_confidence(user_id);
+CREATE INDEX idx_confidence_last_reviewed ON user_verse_confidence(last_reviewed);
+CREATE INDEX idx_confidence_score ON user_verse_confidence(confidence_score);
+
+-- Update trigger
+CREATE TRIGGER update_confidence_updated_at BEFORE UPDATE ON user_verse_confidence
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/sql_setup/sql_backup_20250628_185704/06-populate-test-data.sql
+++ b/sql_setup/sql_backup_20250628_185704/06-populate-test-data.sql
@@ -1,0 +1,17 @@
+-- =====================================================
+-- 06-populate-test-data.sql
+-- Insert test data (run after all tables created)
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Create test decks
+INSERT INTO decks (user_id, name, description, is_public) VALUES 
+(1, 'Psalms of Praise', 'Popular psalms for memorization', true),
+(1, 'Gospel Essentials', 'Key verses from the Gospels', true),
+(1, 'Romans Road', 'Salvation verses from Romans', false)
+ON CONFLICT DO NOTHING;
+
+-- Add sample saved deck
+INSERT INTO saved_decks (user_id, deck_id)
+SELECT 1, deck_id FROM decks WHERE name = 'Psalms of Praise' AND is_public = true
+ON CONFLICT DO NOTHING;

--- a/sql_setup/sql_backup_20250628_185704/07-create-feature-requests.sql
+++ b/sql_setup/sql_backup_20250628_185704/07-create-feature-requests.sql
@@ -1,0 +1,64 @@
+-- =====================================================
+-- 07-create-feature-requests.sql
+-- Feature request and feedback system
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Main feature requests table
+CREATE TABLE feature_requests (
+    request_id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    type VARCHAR(50),
+    status VARCHAR(50) DEFAULT 'open',
+    priority VARCHAR(20),
+    user_id INTEGER REFERENCES users(user_id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Voting table (up/down votes)
+CREATE TABLE feature_request_votes (
+    request_id INTEGER REFERENCES feature_requests(request_id) ON DELETE CASCADE,
+    user_id INTEGER REFERENCES users(user_id) ON DELETE CASCADE,
+    vote_type VARCHAR(4) NOT NULL CHECK (vote_type IN ('up','down')),
+    voted_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (request_id, user_id)
+);
+
+-- Comments table
+CREATE TABLE feature_request_comments (
+    comment_id SERIAL PRIMARY KEY,
+    request_id INTEGER REFERENCES feature_requests(request_id) ON DELETE CASCADE,
+    user_id INTEGER REFERENCES users(user_id) ON DELETE CASCADE,
+    comment TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tags table
+CREATE TABLE feature_request_tags (
+    tag_id SERIAL PRIMARY KEY,
+    tag_name VARCHAR(50) UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Request-tag mapping
+CREATE TABLE feature_request_tag_map (
+    request_id INTEGER REFERENCES feature_requests(request_id) ON DELETE CASCADE,
+    tag_id INTEGER REFERENCES feature_request_tags(tag_id) ON DELETE CASCADE,
+    PRIMARY KEY (request_id, tag_id)
+);
+
+-- Indexes
+CREATE INDEX idx_feature_requests_user ON feature_requests(user_id);
+CREATE INDEX idx_feature_requests_status ON feature_requests(status);
+CREATE INDEX idx_feature_requests_type ON feature_requests(type);
+CREATE INDEX idx_feature_request_votes_request ON feature_request_votes(request_id);
+CREATE INDEX idx_feature_request_votes_user ON feature_request_votes(user_id);
+CREATE INDEX idx_feature_request_comments_request ON feature_request_comments(request_id);
+CREATE INDEX idx_feature_request_comments_user ON feature_request_comments(user_id);
+CREATE INDEX idx_feature_request_tag_map_request ON feature_request_tag_map(request_id);
+
+-- Update trigger for updated_at
+CREATE TRIGGER update_feature_requests_updated_at BEFORE UPDATE ON feature_requests
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/sql_setup/sql_backup_20250628_185704/08-create-courses.sql
+++ b/sql_setup/sql_backup_20250628_185704/08-create-courses.sql
@@ -1,0 +1,54 @@
+-- =====================================================
+-- 08-create-courses.sql
+-- Course and lesson tables
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Main courses table
+CREATE TABLE courses (
+    course_id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    thumbnail_url TEXT,
+    is_public BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tags table
+CREATE TABLE course_tags (
+    tag_id SERIAL PRIMARY KEY,
+    tag_name VARCHAR(50) UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE course_tag_map (
+    course_id INTEGER REFERENCES courses(course_id) ON DELETE CASCADE,
+    tag_id INTEGER REFERENCES course_tags(tag_id) ON DELETE CASCADE,
+    PRIMARY KEY (course_id, tag_id)
+);
+
+CREATE TABLE course_lessons (
+    lesson_id SERIAL PRIMARY KEY,
+    course_id INTEGER NOT NULL REFERENCES courses(course_id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    content_type VARCHAR(20) NOT NULL,
+    content_data JSONB,
+    flashcards_required INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes
+CREATE INDEX idx_courses_user ON courses(user_id);
+CREATE INDEX idx_courses_public ON courses(is_public);
+CREATE INDEX idx_lessons_course ON course_lessons(course_id);
+CREATE INDEX idx_lessons_position ON course_lessons(course_id, position);
+CREATE INDEX idx_course_tag_map_course ON course_tag_map(course_id);
+CREATE INDEX idx_course_tag_name ON course_tags(tag_name);
+
+-- Trigger for updated_at on courses
+CREATE TRIGGER update_courses_updated_at BEFORE UPDATE ON courses
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/sql_setup/sql_backup_20250628_185704/09-create-course-progress.sql
+++ b/sql_setup/sql_backup_20250628_185704/09-create-course-progress.sql
@@ -1,0 +1,54 @@
+-- =====================================================
+-- 09-create-course-progress.sql
+-- Course enrollment and progress tracking
+-- =====================================================
+SET search_path TO wellversed01DEV;
+
+-- Track which users are enrolled in which courses
+CREATE TABLE course_enrollments (
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    course_id INTEGER NOT NULL REFERENCES courses(course_id) ON DELETE CASCADE,
+    current_lesson_id INTEGER REFERENCES course_lessons(lesson_id),
+    current_lesson_position INTEGER DEFAULT 1,
+    lessons_completed INTEGER DEFAULT 0,
+    enrolled_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    last_accessed TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (user_id, course_id)
+);
+
+CREATE INDEX idx_course_enrollment_user ON course_enrollments(user_id);
+CREATE INDEX idx_course_enrollment_course ON course_enrollments(course_id);
+
+-- Track user progress for each lesson
+CREATE TABLE lesson_progress (
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    lesson_id INTEGER NOT NULL REFERENCES course_lessons(lesson_id) ON DELETE CASCADE,
+    course_id INTEGER NOT NULL REFERENCES courses(course_id) ON DELETE CASCADE,
+    started_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP WITH TIME ZONE,
+    flashcards_required INTEGER DEFAULT 0,
+    flashcards_completed INTEGER DEFAULT 0,
+    is_unlocked BOOLEAN DEFAULT TRUE,
+    quiz_attempts INTEGER DEFAULT 0,
+    best_score INTEGER,
+    last_attempt TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (user_id, lesson_id)
+);
+
+CREATE INDEX idx_lesson_progress_user ON lesson_progress(user_id);
+CREATE INDEX idx_lesson_progress_lesson ON lesson_progress(lesson_id);
+
+-- Flashcards tied to lessons
+CREATE TABLE lesson_flashcards (
+    flashcard_id SERIAL PRIMARY KEY,
+    lesson_id INTEGER NOT NULL REFERENCES course_lessons(lesson_id) ON DELETE CASCADE,
+    card_type VARCHAR(20) NOT NULL,
+    front_content TEXT NOT NULL,
+    back_content TEXT NOT NULL,
+    verse_codes TEXT[],
+    position INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_lesson_flashcards_lesson ON lesson_flashcards(lesson_id);


### PR DESCRIPTION
## Summary
- back up current SQL setup
- strip apocrypha fields from core schema
- ignore apocryphal books when populating data

## Testing
- `python3 backend/services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python3 -m py_compile sql_setup/setup_database.py`

------
https://chatgpt.com/codex/tasks/task_e_68603a824bb083319c9b07d95febc66d