### PR TITLE
Fix Bible tracker clear data

### DIFF
--- a/frontend/src/app/core/models/bible/bible-data.model.ts
+++ b/frontend/src/app/core/models/bible/bible-data.model.ts
@@ -183,9 +183,17 @@ export class BibleData {
     throw new Error(`Group ${groupName} not found`);
   }
 
-  // Method to map user verses from API to the Bible model 
+  // Reset all memorization progress across every book and chapter
+  reset(): void {
+    this.testaments.forEach(testament => testament.reset());
+  }
+
+  // Method to map user verses from API to the Bible model
   mapUserVersesToModel(userVerses: UserVerseDetail[]): void {
     console.log(`Mapping ${userVerses.length} API verses to Bible model`);
+
+    // Clear any existing progress before applying new data
+    this.reset();
 
     // First pass: collect apocryphal status information by chapter
     const apocryphalInfo: Record<number, Record<number, boolean[]>> = {};


### PR DESCRIPTION
## Summary
- add reset method to `BibleData`
- clear progress before applying user data

## Testing
- `python3 services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `ng test --watch=false` *(fails: ng: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860460450588331b454b54bcc31a662