### PR TITLE
Add clearing chapters and FLOW integration

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -164,11 +164,20 @@
       </div>
     </div>
     <div class="action-container">
-      <button (click)="selectAllChapters()"
-              class="action-btn primary"
-              [disabled]="isLoading || isSavingBulk">
-        Memorize All Chapters
-      </button>
+      <div class="left-actions">
+        <button (click)="clearAllChapters()"
+                class="action-btn secondary"
+                [disabled]="isLoading || isSavingBulk">
+          Clear All Chapters
+        </button>
+      </div>
+      <div class="right-actions">
+        <button (click)="selectAllChapters()"
+                class="action-btn primary"
+                [disabled]="isLoading || isSavingBulk">
+          Memorize All Chapters
+        </button>
+      </div>
     </div>
   </div>
 
@@ -196,22 +205,31 @@
 
     <!-- Chapter Actions -->
     <div class="action-container">
-      <button (click)="selectAllVerses()" 
-              class="action-btn primary" 
-              [disabled]="isLoading || isSavingBulk">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-        </svg>
-        Memorize All Verses
-      </button>
-      <button (click)="clearAllVerses()" 
-              class="action-btn secondary" 
-              [disabled]="isLoading || isSavingBulk">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-        Clear All Verses
-      </button>
+      <div class="left-actions">
+        <a class="action-btn secondary"
+           [routerLink]="'/flow'"
+           [queryParams]="{ bookId: selectedBook?.id, chapter: selectedChapter?.chapterNumber }">
+          Practice in FLOW
+        </a>
+        <button (click)="clearAllVerses()"
+                class="action-btn secondary"
+                [disabled]="isLoading || isSavingBulk">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          Clear All Verses
+        </button>
+      </div>
+      <div class="right-actions">
+        <button (click)="selectAllVerses()"
+                class="action-btn primary"
+                [disabled]="isLoading || isSavingBulk">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          Memorize All Verses
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.scss
@@ -536,10 +536,16 @@
 /* Action buttons */
 .action-container {
   display: flex;
-  gap: 0.75rem;
+  justify-content: space-between;
   margin-top: 1rem;
   padding-top: 1rem;
   border-top: 1px solid #e5e7eb;
+
+  .left-actions,
+  .right-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
 }
 
 .action-btn {

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -565,6 +565,45 @@ export class BibleTrackerComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
+  async clearAllChapters(): Promise<void> {
+    if (!this.selectedBook) return;
+
+    const confirmed = await this.modalService.danger(
+      'Clear All Chapters?',
+      `Are you sure you want to clear all memorized verses in ${this.selectedBook.name}? This action cannot be undone.`,
+      'Clear Chapters'
+    );
+
+    if (!confirmed) return;
+
+    this.isSavingBulk = true;
+
+    this.bibleService.clearBook(
+      this.userId,
+      this.selectedBook.id
+    ).subscribe({
+      next: () => {
+        this.selectedBook!.chapters.forEach(ch => ch.clearAllVerses());
+        this.isSavingBulk = false;
+        this.updateTestamentCharts();
+        this.modalService.success(
+          'Book Cleared',
+          `${this.selectedBook!.name} has been cleared.`
+        );
+        this.cdr.detectChanges();
+      },
+      error: (error: any) => {
+        console.error('Error clearing book:', error);
+        this.isSavingBulk = false;
+        this.modalService.alert(
+          'Error Clearing Book',
+          'Unable to clear chapters in this book. Please try again.',
+          'danger'
+        );
+      }
+    });
+  }
+
   // Helper methods
   isChapterVisible(chapter: BibleChapter): boolean {
     return this.includeApocrypha || !chapter.isApocryphal;

--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -16,6 +16,7 @@
       [minimumVerses]="10"
       [maximumVerses]="80"
       [warningMessage]="warningMessage"
+      [initialSelection]="initialSelection"
       (selectionApplied)="onVerseSelectionChanged($event)"
     >
     </app-verse-picker>


### PR DESCRIPTION
## Summary
- add book-level clearAllChapters method
- separate action buttons into left and right sections
- include FLOW link in the verse actions
- allow FLOW page to preload a chapter via query params
- style action buttons with new flex layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860713bfcc883318971d821dcda2785