### PR TITLE
Refactor Flow layout

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -91,7 +91,8 @@
   <div *ngIf="!isLoading && verses.length === 0" class="selection-prompt">
     <span class="prompt-emoji" aria-hidden="true">📖</span>
     <span class="prompt-text">
-      Select verses above and click <strong>Apply Selection</strong> to begin.
+      Select the verses on the left and click
+      <strong>Apply Selection</strong> to begin.
     </span>
   </div>
 

--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -1,32 +1,33 @@
 <!-- frontend/src/app/flow/flow.component.html -->
 <div class="flow-container">
-  <div class="flow-header">
-    <h1>FLOW Memorization</h1>
-    <p class="subtitle">
-      First Letter Of Word technique for scripture memorization
-    </p>
-  </div>
+  <div class="sidebar">
+    <div class="flow-header">
+      <h1>FLOW Memorization</h1>
+      <p class="subtitle">
+        First Letter Of Word technique for scripture memorization
+      </p>
+    </div>
 
-  <div class="controls-section">
-    <app-verse-picker
-      [theme]="'minimal'"
-      [disabledModes]="['single']"
-      [pageType]="'FLOW'"
-      [showFlowTip]="false"
-      [minimumVerses]="10"
-      [maximumVerses]="80"
-      [warningMessage]="warningMessage"
-      [initialSelection]="initialSelection"
-      (selectionApplied)="onVerseSelectionChanged($event)"
-    >
-    </app-verse-picker>
-    <div *ngIf="verses.length > 0" class="layout-controls">
-      <div class="button-group">
-        <button
-          class="layout-button"
-          [class.active]="layoutMode === 'grid'"
-          (click)="toggleLayout()"
-        >
+    <div class="controls-section">
+      <app-verse-picker
+        [theme]="'minimal'"
+        [disabledModes]="['single']"
+        [pageType]="'FLOW'"
+        [showFlowTip]="false"
+        [minimumVerses]="10"
+        [maximumVerses]="80"
+        [warningMessage]="warningMessage"
+        [initialSelection]="initialSelection"
+        (selectionApplied)="onVerseSelectionChanged($event)"
+      >
+      </app-verse-picker>
+      <div *ngIf="verses.length > 0" class="layout-controls">
+        <div class="button-group">
+          <button
+            class="layout-button"
+            [class.active]="layoutMode === 'grid'"
+            (click)="toggleLayout()"
+          >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -75,10 +76,13 @@
         Highlight 5th verses
       </label>
     </div>
+    </div>
   </div>
 
-  <!-- Loading State -->
-  <div *ngIf="isLoading" class="loading-container">
+  <div class="verses-container">
+    <div class="verses-scroll">
+      <!-- Loading State -->
+      <div *ngIf="isLoading" class="loading-container">
     <div class="loading-spinner"></div>
     <p>Loading verses...</p>
   </div>
@@ -136,35 +140,26 @@
 
   <!-- Confidence Section -->
   <div *ngIf="!isLoading && verses.length > 0" class="confidence-section">
-    <h3>Confidence Level</h3>
-    <p class="confidence-description">
-      How well do you know
-      {{ verses.length === 1 ? "this verse" : "these verses" }}?
-    </p>
-
-    <div class="slider-container">
-      <span class="slider-label">0%</span>
-      <input
-        type="range"
-        class="confidence-slider"
-        [(ngModel)]="confidenceLevel"
-        min="0"
-        max="100"
-        step="1"
-      />
-      <span class="slider-label">100%</span>
-    </div>
-
-    <div class="confidence-value">
-      Current confidence: <strong>{{ confidenceLevel }}%</strong>
-    </div>
-
-    <div class="action-buttons">
-      <button
-        class="btn btn-primary"
-        (click)="saveProgress()"
-        [disabled]="isSaving"
-      >
+    <div class="confidence-row">
+      <span class="confidence-label">Confidence Level</span>
+      <div class="slider-container">
+        <span class="slider-label">0%</span>
+        <input
+          type="range"
+          class="confidence-slider"
+          [(ngModel)]="confidenceLevel"
+          min="0"
+          max="100"
+          step="1"
+        />
+        <span class="slider-label">100%</span>
+      </div>
+      <div class="action-buttons">
+        <button
+          class="btn btn-primary"
+          (click)="saveProgress()"
+          [disabled]="isSaving"
+        >
         <svg
           *ngIf="!isSaving"
           xmlns="http://www.w3.org/2000/svg"
@@ -193,16 +188,17 @@
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M6 18L18 6M6 6l12 12"
-          />
-        </svg>
-        Clear Progress
-      </button>
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+          Clear Progress
+        </button>
+      </div>
     </div>
 
     <div class="saved-indicator" [class.show]="showSavedMessage">
@@ -221,5 +217,7 @@
       </svg>
       Progress saved!
     </div>
+  </div>
+  </div>
   </div>
 </div>

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -6,13 +6,14 @@
 }
 
 .sidebar {
-  width: 360px;
+  width: 420px;
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   overflow-y: auto;
   overflow-x: visible;
   padding: 1.5rem;
@@ -21,7 +22,7 @@
 
 .verses-container {
   flex: 1;
-  margin-left: 360px;
+  margin-left: 420px;
   height: 100vh;
   overflow: hidden;
   padding: 2rem;
@@ -191,20 +192,14 @@
   margin-bottom: 2rem;
 
   .custom-grid {
-    display: table;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 4px;
     width: 100%;
-    border-collapse: separate;
-    border-spacing: 4px;
   }
 
   .grid-row {
-    display: table-row;
-  }
-
-  .grid-row > div {
-    display: table-cell;
-    width: 20%;
-    vertical-align: top;
+    display: contents;
   }
 }
 

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -1,16 +1,37 @@
 // frontend/src/app/flow/flow.component.scss
 .flow-container {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 2rem;
+  display: flex;
+  height: 100vh;
   background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-  min-height: 100vh;
+}
+
+.sidebar {
+  width: 300px;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.verses-container {
+  flex: 1;
+  margin-left: 300px;
+  height: 100vh;
+  overflow: hidden;
+  padding: 2rem;
+}
+
+.verses-scroll {
+  height: 100%;
+  overflow-y: auto;
 }
 
 // Header
 .flow-header {
-  text-align: center;
-  margin-bottom: 3rem;
+  text-align: left;
+  margin-bottom: 1.5rem;
 
   h1 {
     font-size: 2.5rem;
@@ -28,8 +49,8 @@
 // Controls Section
 .controls-section {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: 1rem;
   margin-bottom: 2rem;
   background: white;
   padding: 1.5rem;
@@ -39,6 +60,7 @@
   .layout-controls {
     display: flex;
     gap: 1rem;
+    justify-content: space-between;
   }
 
   .button-group {
@@ -248,35 +270,27 @@
 }
 
 // Confidence Section
+
 .confidence-section {
   background: white;
-  padding: 2rem;
-  border-radius: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-  text-align: center;
 
-  h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #1f2937;
-    margin-bottom: 0.5rem;
-  }
-
-  .confidence-description {
-    color: #6b7280;
-    margin-bottom: 2rem;
+  .confidence-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.875rem;
   }
 
   .slider-container {
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
-    max-width: 500px;
-    margin-left: auto;
-    margin-right: auto;
-
+    flex: 1;
+    gap: 0.5rem;
+    margin-bottom: 0;
+    
     .slider-label {
       font-size: 0.875rem;
       color: #6b7280;
@@ -353,35 +367,22 @@
       transform: translateY(0);
     }
   }
-
-  .confidence-value {
-    font-size: 1.125rem;
-    color: #4b5563;
-    margin-bottom: 2rem;
-
-    strong {
-      color: #3b82f6;
-      font-size: 1.25rem;
-    }
-  }
-
   .action-buttons {
     display: flex;
-    gap: 1rem;
-    justify-content: center;
+    gap: 0.5rem;
 
     .btn {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      padding: 0.75rem 1.5rem;
+      padding: 0.5rem 1rem;
       border-radius: 0.5rem;
-      font-size: 1rem;
+      font-size: 0.875rem;
       font-weight: 500;
       cursor: pointer;
       transition: all 0.2s;
       border: none;
-      min-width: 150px;
+      min-width: 100px;
       justify-content: center;
 
       svg {

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -6,18 +6,22 @@
 }
 
 .sidebar {
-  width: 300px;
+  width: 360px;
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
+  overflow-x: visible;
   padding: 1.5rem;
+  z-index: 100;
 }
 
 .verses-container {
   flex: 1;
-  margin-left: 300px;
+  margin-left: 360px;
   height: 100vh;
   overflow: hidden;
   padding: 2rem;
@@ -59,12 +63,13 @@
 
   .layout-controls {
     display: flex;
-    gap: 1rem;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 
   .button-group {
     display: flex;
+    flex-direction: column;
     border-radius: 0.5rem;
     overflow: hidden;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -109,7 +114,8 @@
 
   .display-options {
     display: flex;
-    gap: 1.5rem;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 
   .checkbox-option {


### PR DESCRIPTION
## Summary
- adjust Flow layout with a fixed sidebar for controls
- keep verse area scrollable only
- align header in sidebar and tighten confidence section

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686074f384a8833199aaf03bb102d1ec