### PR TITLE
Implement guided Flow memorization

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -7,6 +7,20 @@
     </p>
   </div>
 
+  <!-- Settings Overlay -->
+  <div class="settings-overlay" *ngIf="showSettings && verses.length > 0">
+    <div class="settings-card">
+      <h2>Select Group Size</h2>
+      <p>How many verses would you like to practice at once?</p>
+      <div class="verse-options">
+        <button class="verse-option" [class.selected]="groupSize === 1" (click)="selectGroupSize(1)">1</button>
+        <button class="verse-option" [class.selected]="groupSize === 2" (click)="selectGroupSize(2)">2</button>
+        <button class="verse-option" [class.selected]="groupSize === 3" (click)="selectGroupSize(3)">3</button>
+      </div>
+      <button class="start-button" (click)="startFlow()">Start Memorizing</button>
+    </div>
+  </div>
+
   <div class="controls-section">
     <app-verse-picker
       [theme]="'minimal'"
@@ -93,7 +107,7 @@
 
   <!-- Grid View -->
   <div
-    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'grid'"
+    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'grid' && groups.length === 0"
     class="grid-view"
   >
     <div class="custom-grid">
@@ -124,13 +138,61 @@
 
   <!-- Single Column View -->
   <div
-    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'single'"
+    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'single' && groups.length === 0"
     class="single-view"
   >
     <div *ngFor="let verse of verses" [class]="getVerseClass(verse)">
       <div class="verse-reference">{{ verse.reference }}</div>
       <div class="first-letters">{{ verse.firstLetters }}</div>
       <div class="verse-text" *ngIf="showVerseText">{{ verse.text }}</div>
+    </div>
+  </div>
+
+  <!-- Practice Area -->
+  <div class="practice-area" *ngIf="!showSettings && groups.length > 0">
+    <div class="stage-progress">
+      <div class="stage-item" [class.active]="currentStage === 'full'">
+        <div class="stage-dot"></div>
+        <span>Read</span>
+      </div>
+      <div class="stage-line"></div>
+      <div class="stage-item" [class.active]="currentStage === 'initials'">
+        <div class="stage-dot"></div>
+        <span>FLOW</span>
+      </div>
+      <div class="stage-line"></div>
+      <div class="stage-item" [class.active]="currentStage === 'memory'">
+        <div class="stage-dot"></div>
+        <span>Recite</span>
+      </div>
+    </div>
+
+    <div class="verse-container">
+      <div class="verse-reference">
+        Group {{ currentGroupIndex + 1 }} of {{ iterationGroups.length }}
+      </div>
+      <div class="verse-content">
+        <div *ngIf="currentStage === 'full'">
+          <p *ngFor="let v of currentGroup">{{ v.text }}</p>
+        </div>
+        <div *ngIf="currentStage === 'initials'">
+          <p *ngFor="let v of currentGroup">{{ v.firstLetters }}</p>
+        </div>
+        <div *ngIf="currentStage === 'memory'" class="memory-stage">
+          <p>Recite from memory</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="instruction-box">
+      <p *ngIf="currentStage === 'full'">Read the verses aloud several times.</p>
+      <p *ngIf="currentStage === 'initials'">Use the first letters as prompts.</p>
+      <p *ngIf="currentStage === 'memory'">Try quoting without looking.</p>
+    </div>
+
+    <div class="nav-buttons">
+      <button class="nav-btn secondary" (click)="previousStage()" [disabled]="currentStage === 'full' && currentGroupIndex === 0">Back</button>
+      <button class="nav-btn primary" (click)="nextStage()">Next</button>
     </div>
   </div>
 

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -104,6 +104,116 @@
   }
 }
 
+// Simple styles for practice overlay
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.verse-options {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.verse-option {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.verse-option.selected {
+  background: #e0e7ff;
+  border-color: #6366f1;
+}
+
+.start-button {
+  padding: 0.5rem 1rem;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.practice-area {
+  margin-top: 2rem;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+}
+
+.stage-progress {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.stage-item {
+  text-align: center;
+}
+
+.stage-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  margin: 0 auto 0.25rem;
+}
+
+.stage-item.active .stage-dot {
+  background: #3b82f6;
+}
+
+.verse-container {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.instruction-box {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.nav-buttons {
+  display: flex;
+  justify-content: space-between;
+}
+
+.nav-btn {
+  padding: 0.5rem 1.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.nav-btn.primary {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.nav-btn.secondary {
+  background: #f3f4f6;
+}
+
 // Loading State
 .loading-container {
   display: flex;


### PR DESCRIPTION
## Summary
- introduce stage-based memorization logic
- allow selecting a verse group size
- cycle through full text, initials and memory stages
- mark the chapter as memorized when all groups are complete
- add UI for stage progress and navigation

## Testing
- `npm test --silent -- -c --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860908d2cfc8331a8f98a02c2faeb54