### PR TITLE
Add staged practice workflow to FLOW

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -77,6 +77,20 @@
     </div>
   </div>
 
+  <!-- Initial Settings Overlay -->
+  <div class="settings-overlay" *ngIf="showSettings && verses.length > 0">
+    <div class="settings-card">
+      <h2>Practice Settings</h2>
+      <p>How many verses per group?</p>
+      <div class="verse-options">
+        <button [class.selected]="versesPerGroup === 1" (click)="selectVersesPerGroup(1)">1</button>
+        <button [class.selected]="versesPerGroup === 2" (click)="selectVersesPerGroup(2)">2</button>
+        <button [class.selected]="versesPerGroup === 3" (click)="selectVersesPerGroup(3)">3</button>
+      </div>
+      <button class="start-button" (click)="startPractice()">Start Practice</button>
+    </div>
+  </div>
+
   <!-- Loading State -->
   <div *ngIf="isLoading" class="loading-container">
     <div class="loading-spinner"></div>
@@ -93,7 +107,7 @@
 
   <!-- Grid View -->
   <div
-    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'grid'"
+    *ngIf="!isLoading && !isPracticing && verses.length > 0 && layoutMode === 'grid'"
     class="grid-view"
   >
     <div class="custom-grid">
@@ -124,7 +138,7 @@
 
   <!-- Single Column View -->
   <div
-    *ngIf="!isLoading && verses.length > 0 && layoutMode === 'single'"
+    *ngIf="!isLoading && !isPracticing && verses.length > 0 && layoutMode === 'single'"
     class="single-view"
   >
     <div *ngFor="let verse of verses" [class]="getVerseClass(verse)">
@@ -134,8 +148,43 @@
     </div>
   </div>
 
+  <!-- Practice Area -->
+  <div class="practice-area" *ngIf="isPracticing && currentGroup">
+    <div class="stage-progress">
+      <div class="stage-item" [class.active]="currentGroup.currentStage === 'full'">Read</div>
+      <div class="stage-item" [class.active]="currentGroup.currentStage === 'initials'">FLOW</div>
+      <div class="stage-item" [class.active]="currentGroup.currentStage === 'memory'">Recite</div>
+    </div>
+    <div class="verse-display">
+      <div class="verse-reference">{{ getCurrentGroupReference() }}</div>
+      <div *ngIf="currentGroup.currentStage === 'full'">
+        <p *ngFor="let v of currentGroup.verses">{{ v.text }}</p>
+      </div>
+      <div *ngIf="currentGroup.currentStage === 'initials'">
+        <p *ngFor="let v of currentGroup.verses">{{ v.firstLetters }}</p>
+      </div>
+      <div *ngIf="currentGroup.currentStage === 'memory'" class="memory-stage">
+        <p class="memory-prompt">Recite from memory</p>
+      </div>
+    </div>
+    <div class="recording-section">
+      <button class="record-btn" (click)="toggleRecording()" [class.recording]="isRecording" [disabled]="!canRecord">
+        <span *ngIf="!currentGroup.audioUrl">{{ isRecording ? 'Recording...' : 'Record' }}</span>
+        <span *ngIf="currentGroup.audioUrl && !isRecording">Recorded ✓</span>
+      </button>
+      <div class="audio-controls" *ngIf="currentGroup.audioUrl && !isRecording">
+        <audio #audioPlayer [src]="currentGroup.audioUrl"></audio>
+        <button class="audio-btn" (click)="playAudio()">Play</button>
+      </div>
+    </div>
+    <div class="nav-buttons">
+      <button class="nav-btn secondary" (click)="previousStage()">Back</button>
+      <button class="nav-btn primary" (click)="nextStage()">{{ getNextButtonText() }}</button>
+    </div>
+  </div>
+
   <!-- Confidence Section -->
-  <div *ngIf="!isLoading && verses.length > 0" class="confidence-section">
+  <div *ngIf="!isLoading && !isPracticing && verses.length > 0" class="confidence-section">
     <h3>Confidence Level</h3>
     <p class="confidence-description">
       How well do you know

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -104,6 +104,128 @@
   }
 }
 
+// Settings Overlay
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+
+  .settings-card {
+    background: white;
+    padding: 2rem;
+    border-radius: 0.5rem;
+    text-align: center;
+
+    .verse-options {
+      display: flex;
+      gap: 1rem;
+      margin: 1rem 0;
+
+      button {
+        padding: 0.5rem 1rem;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.375rem;
+        cursor: pointer;
+
+        &.selected {
+          background-color: #3b82f6;
+          color: white;
+        }
+      }
+    }
+
+    .start-button {
+      margin-top: 1rem;
+      padding: 0.5rem 1rem;
+      background-color: #10b981;
+      color: white;
+      border: none;
+      border-radius: 0.375rem;
+      cursor: pointer;
+    }
+  }
+}
+
+// Practice Area
+.practice-area {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  margin-bottom: 2rem;
+
+  .stage-progress {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    .stage-item {
+      flex: 1;
+      text-align: center;
+      padding: 0.25rem;
+      border-bottom: 2px solid #e5e7eb;
+
+      &.active {
+        border-color: #3b82f6;
+        font-weight: 600;
+      }
+    }
+  }
+
+  .verse-display {
+    margin-bottom: 1rem;
+
+    .memory-prompt {
+      font-weight: 600;
+      color: #1e3a8a;
+    }
+  }
+
+  .recording-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    .record-btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      border: 1px solid #e5e7eb;
+      cursor: pointer;
+
+      &.recording {
+        background-color: #f87171;
+        color: white;
+      }
+    }
+  }
+
+  .nav-buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1rem;
+
+    .nav-btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      border: 1px solid #e5e7eb;
+      cursor: pointer;
+
+      &.primary {
+        background-color: #3b82f6;
+        color: white;
+      }
+    }
+  }
+}
+
 // Loading State
 .loading-container {
   display: flex;


### PR DESCRIPTION
## Summary
- enable staged practice on FLOW page similar to lessons
- allow selecting verses per group before starting
- add overlay and practice area with recording support

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608b484a4883319104d8f1c36fa1b4