### PR TITLE
Add memorization modal integration

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -162,6 +162,26 @@
     <div class="action-buttons">
       <button
         class="btn btn-primary"
+        (click)="startMemorization()"
+        [disabled]="isSaving || verses.length === 0"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 8v8m4-4H8"
+          />
+        </svg>
+        Start Memorization
+      </button>
+      <button
+        class="btn btn-primary"
         (click)="saveProgress()"
         [disabled]="isSaving"
       >
@@ -223,3 +243,12 @@
     </div>
   </div>
 </div>
+
+<app-memorization-modal
+  *ngIf="showMemorization"
+  [verses]="versesForModal"
+  [chapterId]="modalBookId"
+  [chapterName]="modalChapterName"
+  [verseCount]="verses.length"
+  (completed)="onMemorizationCompleted()"
+></app-memorization-modal>

--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../shared/components/verse-range-picker/verse-range-picker.component';
 import { BibleService } from '../../../core/services/bible.service';
 import { UserService } from '../../../core/services/user.service';
+import { MemorizationModalComponent } from '../../../shared/components/memorization-modal/memorization-modal.component';
 import { User } from '../../../core/models/user';
 import { UserVerseDetail } from '../../../core/models/bible';
 import { Subject, takeUntil } from 'rxjs';
@@ -25,10 +26,24 @@ interface FlowVerse {
   verse: number;
 }
 
+interface ModalVerse {
+  code: string;
+  text: string;
+  reference: string;
+  bookId: number;
+  chapter: number;
+  verse: number;
+}
+
 @Component({
   selector: 'app-flow',
   standalone: true,
-  imports: [CommonModule, FormsModule, VersePickerComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    VersePickerComponent,
+    MemorizationModalComponent,
+  ],
   templateUrl: './flow.component.html',
   styleUrls: ['./flow.component.scss'],
 })
@@ -54,6 +69,12 @@ export class FlowComponent implements OnInit, OnDestroy {
 
   // Add property for selected book
   selectedBook: any = null;
+
+  // Memorization modal state
+  showMemorization = false;
+  versesForModal: ModalVerse[] = [];
+  modalBookId = 0;
+  modalChapterName = '';
 
   // Request management
   private destroy$ = new Subject<void>();
@@ -86,7 +107,9 @@ export class FlowComponent implements OnInit, OnDestroy {
           if (book) {
             const chapterData = book.chapters[chapter - 1];
             if (chapterData) {
-              const verseCodes = chapterData.verses.map(v => `${book.id}-${chapter}-${v.verseNumber}`);
+              const verseCodes = chapterData.verses.map(
+                (v) => `${book.id}-${chapter}-${v.verseNumber}`,
+              );
               this.initialSelection = {
                 mode: 'chapter',
                 startVerse: {
@@ -432,5 +455,30 @@ export class FlowComponent implements OnInit, OnDestroy {
     }
     // Removed memorized class to keep cells white
     return classes.join(' ');
+  }
+
+  startMemorization() {
+    if (!this.verses.length || !this.selectedBook) return;
+
+    this.versesForModal = this.verses.map((v) => {
+      const [bookId, chapter, verse] = v.verseCode.split('-').map(Number);
+      return {
+        code: v.verseCode,
+        text: v.text,
+        reference: v.reference,
+        bookId,
+        chapter,
+        verse,
+      } as ModalVerse;
+    });
+
+    const first = this.verses[0];
+    this.modalBookId = this.selectedBook.id;
+    this.modalChapterName = `${this.selectedBook.name} ${first.chapter}`;
+    this.showMemorization = true;
+  }
+
+  onMemorizationCompleted() {
+    this.showMemorization = false;
   }
 }

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
@@ -1,0 +1,26 @@
+/* frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss */
+.memorization-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.memorization-container {
+  background: #fff;
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.group-selector button.active {
+  font-weight: bold;
+}
+
+.recording-controls button.recording {
+  color: red;
+}

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
@@ -1,0 +1,274 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnDestroy,
+  ViewChild,
+  ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { BibleService } from '../../../core/services/bible.service';
+import { UserService } from '../../../core/services/user.service';
+import { Subject, takeUntil } from 'rxjs';
+
+interface Verse {
+  code: string;
+  text: string;
+  reference: string;
+  bookId: number;
+  chapter: number;
+  verse: number;
+}
+
+@Component({
+  selector: 'app-memorization-modal',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="memorization-overlay" *ngIf="visible">
+      <div class="memorization-container">
+        <!-- Setup Stage -->
+        <ng-container *ngIf="setup">
+          <h2>Memorization Setup</h2>
+          <p>Select how many verses to practice at once</p>
+          <div class="group-selector">
+            <button
+              *ngFor="let s of [1, 2, 3]"
+              (click)="setGroupSize(s)"
+              [class.active]="groupSize === s"
+            >
+              {{ s }}
+            </button>
+          </div>
+          <button class="start-btn" (click)="start()">Start</button>
+        </ng-container>
+
+        <!-- Practice Stage -->
+        <ng-container *ngIf="!setup && !review">
+          <div class="progress">
+            Group {{ currentGroupIndex + 1 }} / {{ verseGroups.length }}
+          </div>
+
+          <div class="verse-display" *ngIf="currentStage === 0">
+            <p *ngFor="let v of verseGroups[currentGroupIndex]">{{ v.text }}</p>
+            <p class="instruction">Read aloud 2-3 times</p>
+          </div>
+
+          <div class="verse-display" *ngIf="currentStage === 1">
+            <p *ngFor="let v of verseGroups[currentGroupIndex]">
+              {{ getInitials(v.text) }}
+            </p>
+            <p class="instruction">Read using first letters</p>
+          </div>
+
+          <div class="verse-display" *ngIf="currentStage === 2">
+            <p class="instruction">Recite from memory</p>
+          </div>
+
+          <div class="recording-controls">
+            <button (click)="toggleRecording()" [class.recording]="isRecording">
+              {{ isRecording ? 'Stop' : currentAudio ? 'Re-record' : 'Record' }}
+            </button>
+            <audio #player *ngIf="currentAudio" [src]="currentAudio"></audio>
+            <button *ngIf="currentAudio" (click)="playAudio()">Play</button>
+          </div>
+
+          <button class="next-btn" (click)="next()">Next</button>
+        </ng-container>
+
+        <!-- Review Stage -->
+        <ng-container *ngIf="review">
+          <div class="progress">
+            Review {{ reviewIndex + 1 }} /
+            {{ reviewStages[currentReviewStage].length }}
+          </div>
+          <div class="verse-display">
+            <p *ngFor="let v of reviewStages[currentReviewStage][reviewIndex]">
+              {{ v.text }}
+            </p>
+            <p class="instruction">Recite from memory</p>
+          </div>
+          <button class="next-btn" (click)="nextReview()">Next</button>
+        </ng-container>
+      </div>
+    </div>
+  `,
+  styleUrls: ['./memorization-modal.component.scss'],
+})
+export class MemorizationModalComponent implements OnInit, OnDestroy {
+  @Input() verses: Verse[] = [];
+  @Input() chapterId = 0; // book id
+  @Input() chapterName = '';
+  @Input() verseCount = 0;
+
+  @Output() completed = new EventEmitter<{ memorized: boolean }>();
+
+  @ViewChild('player') player!: ElementRef<HTMLAudioElement>;
+
+  visible = true;
+  setup = true;
+  groupSize = 2;
+
+  verseGroups: Verse[][] = [];
+  currentGroupIndex = 0;
+  currentStage = 0;
+
+  isRecording = false;
+  mediaRecorder?: MediaRecorder;
+  audioChunks: Blob[] = [];
+  currentAudio: string | null = null;
+
+  review = false;
+  reviewStages: Verse[][][] = [];
+  currentReviewStage = 0;
+  reviewIndex = 0;
+
+  private destroy$ = new Subject<void>();
+  private userId = 1;
+
+  constructor(
+    private bibleService: BibleService,
+    private userService: UserService,
+    private router: Router,
+  ) {}
+
+  ngOnInit() {
+    this.userService.currentUser$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((user) => {
+        if (user) {
+          this.userId =
+            typeof user.id === 'string' ? parseInt(user.id) : user.id;
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.stopRecording();
+  }
+
+  setGroupSize(size: number) {
+    this.groupSize = size;
+  }
+
+  start() {
+    this.setup = false;
+    this.createGroups();
+  }
+
+  createGroups() {
+    for (let i = 0; i < this.verses.length; i += this.groupSize) {
+      this.verseGroups.push(this.verses.slice(i, i + this.groupSize));
+    }
+  }
+
+  next() {
+    if (this.currentStage < 2) {
+      this.currentStage++;
+    } else {
+      this.currentStage = 0;
+      this.currentGroupIndex++;
+      this.currentAudio = null;
+      if (this.currentGroupIndex >= this.verseGroups.length) {
+        this.prepareReview();
+      }
+    }
+  }
+
+  prepareReview() {
+    this.review = true;
+    let groups = this.verseGroups.slice();
+    while (groups.length > 1) {
+      const stage: Verse[][] = [];
+      for (let i = 0; i < groups.length; i += 2) {
+        const pair = groups.slice(i, i + 2).flat();
+        stage.push(pair);
+      }
+      this.reviewStages.push(stage);
+      groups = stage;
+    }
+    if (groups.length === 1) {
+      this.reviewStages.push([groups[0]]);
+    }
+    this.currentReviewStage = 0;
+    this.reviewIndex = 0;
+  }
+
+  nextReview() {
+    this.reviewIndex++;
+    if (this.reviewIndex >= this.reviewStages[this.currentReviewStage].length) {
+      this.reviewIndex = 0;
+      this.currentReviewStage++;
+    }
+    if (this.currentReviewStage >= this.reviewStages.length) {
+      this.complete();
+    }
+  }
+
+  async complete() {
+    try {
+      const chapterNum = this.verses[0]?.chapter || 1;
+      await this.bibleService
+        .saveChapter(this.userId, this.chapterId, chapterNum)
+        .toPromise();
+      this.completed.emit({ memorized: true });
+    } catch (err) {
+      console.error('Error marking chapter memorized', err);
+      this.completed.emit({ memorized: false });
+    }
+    this.visible = false;
+    this.router.navigate(['/profile'], {
+      queryParams: { memorized: true },
+    });
+  }
+
+  getInitials(text: string): string {
+    return text
+      .split(' ')
+      .map((word) => word[0] || '')
+      .join(' ');
+  }
+
+  async toggleRecording() {
+    if (this.isRecording) {
+      this.stopRecording();
+    } else {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
+        this.mediaRecorder = new MediaRecorder(stream);
+        this.audioChunks = [];
+        this.mediaRecorder.ondataavailable = (e) =>
+          this.audioChunks.push(e.data);
+        this.mediaRecorder.onstop = () => {
+          const blob = new Blob(this.audioChunks, { type: 'audio/webm' });
+          this.currentAudio = URL.createObjectURL(blob);
+          stream.getTracks().forEach((t) => t.stop());
+        };
+        this.mediaRecorder.start();
+        this.isRecording = true;
+      } catch (err) {
+        console.error('Recording error', err);
+      }
+    }
+  }
+
+  stopRecording() {
+    if (this.mediaRecorder && this.isRecording) {
+      this.mediaRecorder.stop();
+      this.isRecording = false;
+    }
+  }
+
+  playAudio() {
+    if (this.player) {
+      this.player.nativeElement.play();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- hook up memorization modal to Flow memorization page
- map loaded verses to modal input and display modal on demand

## Testing
- `npx prettier --write src/app/features/memorize/flow/flow.component.ts src/app/features/memorize/flow/flow.component.html`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609dc0721883319aa6ebe839eb1a69