### PR TITLE
Improve merged group handling

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -198,6 +198,9 @@ export class FlowComponent implements OnInit, OnDestroy {
   onVerseSelectionChanged(selection: VerseSelection) {
     this.currentSelection = selection;
 
+    // Default to plain text view when a selection is applied
+    this.isTextMode = true;
+
     // Store selected book
     if (selection.startVerse) {
       this.selectedBook = this.bibleService

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
@@ -59,7 +59,7 @@
                   </div>
                 </div>
                 <!-- stage dots are now positioned centrally for merged groups -->
-                <span class="check-icon" *ngIf="isGroupCompleted(i) && !shouldShowAsReset(i)">✓</span>
+                <span class="check-icon" *ngIf="isCheckmarkIndex(i) && !shouldShowAsReset(i)">✓</span>
               </div>
             </ng-container>
             <div class="stage-dots-overlay" *ngIf="showStageDots && !setup" [style.left.px]="stageDotsLeft">


### PR DESCRIPTION
## Summary
- treat merged groups as single units in the memorization modal
- show one checkmark per merged group
- default FLOW mode to plain text after selection

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686331e023b48331a2c5d49622bb84d0