### PR TITLE
Add API.bible versions endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,7 @@ uvicorn main:app --reload
 - `POST /api/feature-requests/{id}/comments` - Add a comment
 - `GET /api/feature-requests/user/{user_id}` - Requests by user
 - `GET /api/feature-requests/trending` - Trending requests
+- `GET /api/bibles` - List available Bible translations
 
 ## Testing
 
@@ -71,3 +72,5 @@ Use with main docker-compose.yml in project root.
 ## Files
 - `backend/services/api_bible.py` - API Bible service
 - `backend/routers/user_verses.py` - Includes `/verses/texts` endpoint
+- `backend/routers/bibles.py` - Provides `/api/bibles` endpoint
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,7 +60,7 @@ app.add_middleware(
 )
 
 # Import routers after app creation to avoid circular imports
-from routers import users, user_verses, decks, feature_requests, courses
+from routers import users, user_verses, decks, feature_requests, courses, bibles
 
 # Include routers
 app.include_router(users.router, prefix="/api/users", tags=["users"])
@@ -70,6 +70,7 @@ app.include_router(
     feature_requests.router, prefix="/api/feature-requests", tags=["feature_requests"]
 )
 app.include_router(courses.router, prefix="/api/courses", tags=["courses"])
+app.include_router(bibles.router, prefix="/api/bibles", tags=["bibles"])
 
 
 @app.get("/api/health")

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -7,3 +7,4 @@ from . import user_verses
 from . import decks
 from . import feature_requests
 from . import courses
+from . import bibles

--- a/backend/routers/bibles.py
+++ b/backend/routers/bibles.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from typing import List
+import logging
+
+from services.api_bible import APIBibleService
+from config import Config
+from database import DatabaseConnection
+import db_pool
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+class BibleInfo(BaseModel):
+    id: str
+    abbreviation: str
+    name: str
+
+def get_db():
+    """Dependency to get a database connection (for consistency)."""
+    return DatabaseConnection(db_pool.db_pool)
+
+@router.get("/", response_model=List[BibleInfo])
+async def list_bibles(db: DatabaseConnection = Depends(get_db)):
+    """Return available Bible translations from API.Bible."""
+    api_bible = APIBibleService(Config.API_BIBLE_KEY, Config.DEFAULT_BIBLE_ID)
+    raw_bibles = api_bible.get_available_bibles()
+    bibles: List[BibleInfo] = []
+    for item in raw_bibles:
+        if all(k in item for k in ("id", "abbreviation", "name")):
+            bibles.append(
+                BibleInfo(id=item["id"], abbreviation=item["abbreviation"], name=item["name"])
+            )
+    logger.info(f"Returned {len(bibles)} bible versions")
+    return bibles

--- a/backend/services/test_api.py
+++ b/backend/services/test_api.py
@@ -74,6 +74,14 @@ def test_update_user_preferences():
         user = r.json()
         logger.info(f"Updated include_apocrypha: {user.get('include_apocrypha')}")
 
+def test_get_bibles():
+    """Test fetching available Bible translations"""
+    r = requests.get(f"{BASE_URL}/bibles")
+    logger.info(f"Get bibles: {r.status_code}")
+    if r.status_code == 200:
+        data = r.json()
+        logger.info(f"Retrieved {len(data)} bibles")
+
 if __name__ == "__main__":
     logger.info("Testing Well Versed API with numerical book IDs...")
     try:
@@ -84,6 +92,7 @@ if __name__ == "__main__":
         test_save_chapter()
         test_clear_chapter()
         test_update_user_preferences()
+        test_get_bibles()
         logger.info("All tests passed!")
     except Exception as e:
         logger.error(f"Test failed: {e}")

--- a/frontend/src/app/core/models/bible/interfaces.ts
+++ b/frontend/src/app/core/models/bible/interfaces.ts
@@ -40,3 +40,12 @@ export interface MemorizationProgress {
   progress: number;
   lastPracticed?: Date;
 }
+
+/**
+ * Basic information about a Bible translation
+ */
+export interface BibleVersion {
+  id: string;
+  abbreviation: string;
+  name: string;
+}

--- a/frontend/src/app/core/services/bible.service.ts
+++ b/frontend/src/app/core/services/bible.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { Observable, of, throwError, BehaviorSubject } from 'rxjs';
 import { tap, catchError, switchMap } from 'rxjs/operators';
 import { isPlatformBrowser } from '@angular/common';
-import { BibleData, UserVerseDetail } from '../models/bible';
+import { BibleData, UserVerseDetail, BibleVersion } from '../models/bible';
 import { environment } from '../../../environments/environment';
 
 @Injectable({
@@ -180,6 +180,18 @@ export class BibleService {
         const emptyTexts: Record<string, string> = {};
         verseCodes.forEach(code => emptyTexts[code] = '');
         return of(emptyTexts);
+      })
+    );
+  }
+
+  /**
+   * Get available Bible translations from the backend
+   */
+  getAvailableBibles(): Observable<BibleVersion[]> {
+    return this.http.get<BibleVersion[]>(`${this.apiUrl}/bibles`).pipe(
+      catchError((error: HttpErrorResponse) => {
+        console.error('Error getting bibles:', error);
+        return of([]);
       })
     );
   }

--- a/frontend/src/app/features/memorize/courses/lesson-practice/lesson-practice.component.ts
+++ b/frontend/src/app/features/memorize/courses/lesson-practice/lesson-practice.component.ts
@@ -332,6 +332,7 @@ export class LessonPracticeComponent implements OnInit, OnDestroy {
   courseId!: number;
   lessonId!: number;
   userId = 1;
+  preferredBibleId = '';
 
   // Practice settings
   showSettings = true;
@@ -378,6 +379,10 @@ export class LessonPracticeComponent implements OnInit, OnDestroy {
     this.userService.currentUser$.subscribe((user) => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
+        const abbr = user.preferredBible || '';
+        this.bibleService.getBibleIdFromAbbreviation(abbr).subscribe(id => {
+          this.preferredBibleId = id || '';
+        });
       }
     });
 
@@ -413,7 +418,7 @@ export class LessonPracticeComponent implements OnInit, OnDestroy {
 
   async createVerseSets() {
     const texts = await this.bibleService
-      .getVerseTexts(this.userId, this.allVerseCodes)
+      .getVerseTexts(this.userId, this.allVerseCodes, this.preferredBibleId)
       .toPromise();
 
     for (let i = 0; i < this.allVerseCodes.length; i += this.versesPerSet) {

--- a/frontend/src/app/features/memorize/courses/quiz-practice/quiz-practice.component.ts
+++ b/frontend/src/app/features/memorize/courses/quiz-practice/quiz-practice.component.ts
@@ -386,6 +386,7 @@ export class QuizPracticeComponent implements OnInit, OnDestroy {
   courseId!: number;
   lessonId!: number;
   userId = 1;
+  preferredBibleId = '';
 
   // Lesson data
   lesson: any;
@@ -434,6 +435,10 @@ export class QuizPracticeComponent implements OnInit, OnDestroy {
     this.userService.currentUser$.subscribe((user) => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
+        const abbr = user.preferredBible || '';
+        this.bibleService.getBibleIdFromAbbreviation(abbr).subscribe(id => {
+          this.preferredBibleId = id || '';
+        });
       }
     });
 
@@ -468,7 +473,7 @@ export class QuizPracticeComponent implements OnInit, OnDestroy {
 
       // Load verse texts
       const texts = await this.bibleService
-        .getVerseTexts(this.userId, verseCodes)
+        .getVerseTexts(this.userId, verseCodes, this.preferredBibleId)
         .toPromise();
 
       this.quizVerses = verseCodes.map((code) => {

--- a/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
+++ b/frontend/src/app/features/memorize/decks/deck-study/deck-study.component.ts
@@ -48,9 +48,10 @@ export class DeckStudyComponent implements OnInit {
     this.userService.currentUser$.subscribe(user => {
       if (user) {
         this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
-        // Map preferred Bible to API Bible ID if needed
-        // For now, we'll use the default from the backend
-        this.preferredBibleId = ''; // Let backend use its default
+        const abbr = user.preferredBible || '';
+        this.bibleService.getBibleIdFromAbbreviation(abbr).subscribe(id => {
+          this.preferredBibleId = id || '';
+        });
       }
     });
 

--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -74,6 +74,7 @@ export class FlowComponent implements OnInit, OnDestroy {
   
   // User
   userId = 1;
+  preferredBibleId = '';
 
   // Memorization modal
   showMemorization = false;
@@ -136,6 +137,10 @@ export class FlowComponent implements OnInit, OnDestroy {
       .subscribe((user: User | null) => {
         if (user) {
           this.userId = typeof user.id === 'string' ? parseInt(user.id) : user.id;
+          const abbr = user.preferredBible || '';
+          this.bibleService.getBibleIdFromAbbreviation(abbr).subscribe(id => {
+            this.preferredBibleId = id || '';
+          });
         }
       });
 
@@ -227,7 +232,7 @@ export class FlowComponent implements OnInit, OnDestroy {
 
     try {
       const verseTexts = await this.bibleService
-        .getVerseTexts(this.userId, this.currentSelection.verseCodes)
+        .getVerseTexts(this.userId, this.currentSelection.verseCodes, this.preferredBibleId)
         .pipe(takeUntil(this.loadVersesCancel$))
         .toPromise();
 
@@ -632,7 +637,9 @@ export class FlowComponent implements OnInit, OnDestroy {
     const missingCodes = this.verses.filter(v => !v.text).map(v => v.verseCode);
     if (missingCodes.length) {
       try {
-        const texts = await this.bibleService.getVerseTexts(this.userId, missingCodes).toPromise();
+        const texts = await this.bibleService
+          .getVerseTexts(this.userId, missingCodes, this.preferredBibleId)
+          .toPromise();
         this.verses.forEach(v => {
           if (!v.text && texts && texts[v.verseCode]) {
             v.text = texts[v.verseCode];

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -50,17 +50,7 @@ export class ProfileComponent implements OnInit {
   ];
   
   bibleOptions = [
-    { text: 'Select Bible Translation', value: '' },
-    { text: 'King James Version (KJV)', value: 'KJV' },
-    { text: 'New International Version (NIV)', value: 'NIV' },
-    { text: 'English Standard Version (ESV)', value: 'ESV' },
-    { text: 'New American Standard Bible (NASB)', value: 'NASB' },
-    { text: 'New Living Translation (NLT)', value: 'NLT' },
-    { text: 'Christian Standard Bible (CSB)', value: 'CSB' },
-    { text: 'New King James Version (NKJV)', value: 'NKJV' },
-    { text: 'Revised Standard Version (RSV)', value: 'RSV' },
-    { text: 'The Message (MSG)', value: 'MSG' },
-    { text: 'Amplified Bible (AMP)', value: 'AMP' }
+    { text: 'Select Bible Translation', value: '' }
   ];
   
   constructor(
@@ -71,7 +61,29 @@ export class ProfileComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+    this.loadBibleOptions();
     this.loadUserProfile();
+  }
+
+  loadBibleOptions(): void {
+    const desired = ['KJV', 'NIV', 'ESV', 'NASB', 'NLT', 'CSB', 'NKJV', 'RSV', 'MSG', 'AMP'];
+    this.bibleService.getAvailableBibles().subscribe({
+      next: (versions) => {
+        const options = [{ text: 'Select Bible Translation', value: '' }];
+        versions.forEach(v => {
+          if (desired.includes(v.abbreviation)) {
+            options.push({ text: `${v.name} (${v.abbreviation})`, value: v.abbreviation });
+          }
+        });
+        // Only replace if we received results
+        if (options.length > 1) {
+          this.bibleOptions = options;
+        }
+      },
+      error: (err) => {
+        console.error('Error loading bible versions', err);
+      }
+    });
   }
   
   loadUserProfile(): void {


### PR DESCRIPTION
## Summary
- expose `/api/bibles` to list available translations from API.Bible
- document the new endpoint
- expose `BibleVersion` model and service methods to fetch bibles
- load Bible options dynamically in the profile page
- extend backend API test script

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68633e8da54c833197f93750a8dbc5b4