### PR TITLE
UI tweaks for memorization workflow

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -149,20 +149,6 @@
             </div>
           </div>
 
-          <div class="sidebar-section keyboard-shortcuts">
-            <h3 class="section-title">Keyboard Shortcuts</h3>
-            <div class="shortcut-list">
-              <div class="shortcut">
-                <kbd>&larr;</kbd> Previous chapter
-              </div>
-              <div class="shortcut">
-                <kbd>&rarr;</kbd> Next chapter
-              </div>
-              <div class="shortcut">
-                <kbd>T</kbd> Toggle view mode
-              </div>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -170,6 +156,21 @@
 
     <!-- Main Content Area -->
     <main class="content-area">
+      <div class="passage-header" *ngIf="verses.length > 0">
+        <button class="nav-btn" (click)="navigateToPreviousChapter()" [disabled]="!hasPreviousChapter()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+          <span class="nav-label">{{ getPreviousChapterLabel() }}</span>
+        </button>
+        <h2 class="passage-title">{{ getPassageTitle() }}</h2>
+        <button class="nav-btn" (click)="navigateToNextChapter()" [disabled]="!hasNextChapter()">
+          <span class="nav-label">{{ getNextChapterLabel() }}</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="9 18 15 12 9 6"></polyline>
+          </svg>
+        </button>
+      </div>
       <!-- Loading State -->
       <div *ngIf="isLoading" class="loading-state">
         <div class="spinner"></div>

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -239,33 +239,6 @@
     }
   }
   
-  // Keyboard Shortcuts
-  .keyboard-shortcuts {
-    .shortcut-list {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      font-size: 0.813rem;
-      color: #6b7280;
-      
-      .shortcut {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        
-        kbd {
-          background: #f3f4f6;
-          border: 1px solid #e5e7eb;
-          border-radius: 0.25rem;
-          padding: 0.125rem 0.375rem;
-          font-family: monospace;
-          font-size: 0.75rem;
-          color: #374151;
-          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-        }
-      }
-    }
-  }
   
   // Action Buttons
   .actions {

--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -98,36 +98,6 @@ export class FlowComponent implements OnInit, OnDestroy {
     private sanitizer: DomSanitizer
   ) {}
 
-  // Keyboard shortcuts
-  @HostListener('window:keydown', ['$event'])
-  handleKeyboardEvent(event: KeyboardEvent) {
-    // Ignore if user is typing in an input field
-    if (event.target instanceof HTMLInputElement || 
-        event.target instanceof HTMLTextAreaElement) {
-      return;
-    }
-
-    switch (event.key.toLowerCase()) {
-      case 'arrowleft':
-        if (this.hasPreviousChapter()) {
-          event.preventDefault();
-          this.navigateToPreviousChapter();
-        }
-        break;
-      case 'arrowright':
-        if (this.hasNextChapter()) {
-          event.preventDefault();
-          this.navigateToNextChapter();
-        }
-        break;
-      case 't':
-        if (!event.ctrlKey && !event.metaKey && !event.altKey) {
-          event.preventDefault();
-          this.toggleViewMode();
-        }
-        break;
-    }
-  }
 
   ngOnInit() {
     // Get current user

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
@@ -17,12 +17,7 @@
             <span>{{ elapsedTime }}</span>
           </div>
           <!-- Settings Button -->
-          <button class="settings-btn" *ngIf="!setup && !promptSave" (click)="toggleSettings()">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="3"></circle>
-              <path d="M12 1v6m0 6v6m3.22-10.22l4.24-4.24m-4.24 13.68l4.24 4.24M20 12h-6m-8 0H1m3.22-9.46L8.46 7.78m0 8.44l-4.24 4.24"></path>
-            </svg>
-          </button>
+          <button class="settings-btn" *ngIf="!setup && !promptSave" (click)="toggleSettings()">⚙️</button>
           <div class="progress-info">
             <span class="progress-text">{{ progressPercentage }}% Complete</span>
           </div>
@@ -203,8 +198,53 @@
 
       <!-- Settings Panel -->
       <div class="settings-panel" *ngIf="showSettings && !setup && !promptSave" @slideUp>
+        <div class="stage-indicators-compact">
+          <div
+            class="stage-compact"
+            *ngFor="let s of stageNames; let i = index"
+            [attr.data-tooltip]="s"
+          >
+            <div
+              class="stage-circle-compact"
+              [class.active]="currentStepIndex === i"
+              [class.completed]="currentStepIndex > i"
+              [style.background]="getStageColor(i)"
+            >
+              <span class="stage-icon" [innerHTML]="getStageIcon(s)"></span>
+            </div>
+          </div>
+        </div>
+
         <h3>Display Settings</h3>
         
+        <div class="setting-group">
+          <label class="setting-label">View Mode</label>
+          <div class="radio-group">
+            <label class="radio-option">
+              <input type="radio" name="viewMode" value="flow" [(ngModel)]="settings.displayMode" (change)="saveSettings()" />
+              <span>FLOW Layout</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="viewMode" value="text" [(ngModel)]="settings.displayMode" (change)="saveSettings()" />
+              <span>Plain Text</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="setting-group" *ngIf="settings.displayMode === 'flow'">
+          <label class="setting-label">FLOW Layout Options</label>
+          <div class="radio-group">
+            <label class="radio-option">
+              <input type="radio" name="gridLayout" value="grid" [(ngModel)]="layoutMode" (change)="layoutMode='grid';saveSettings()" />
+              <span>5-Column Grid</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="gridLayout" value="single" [(ngModel)]="layoutMode" (change)="layoutMode='single';saveSettings()" />
+              <span>Single Column</span>
+            </label>
+          </div>
+        </div>
+
         <div class="setting-group">
           <label class="setting-label">Font Size</label>
           <div class="font-controls">
@@ -224,17 +264,11 @@
         </div>
 
         <div class="setting-group">
-          <label class="setting-label">Display Mode</label>
-          <div class="display-options">
-            <label class="radio-option">
-              <input type="radio" name="displayMode" value="single" 
-                     [(ngModel)]="settings.displayMode" (change)="saveSettings()">
-              <span>Verse by Verse</span>
-            </label>
-            <label class="radio-option" *ngIf="currentVerses.length < 6">
-              <input type="radio" name="displayMode" value="grid" 
-                     [(ngModel)]="settings.displayMode" (change)="saveSettings()">
-              <span>{{ getGridColumnCount() }}-Column Grid</span>
+          <label class="setting-label">Display Options</label>
+          <div class="checkbox-group">
+            <label class="checkbox-option">
+              <input type="checkbox" [(ngModel)]="highlightFifthVerse" />
+              <span>Highlight 5th verses</span>
             </label>
           </div>
         </div>
@@ -244,7 +278,7 @@
       <ng-container *ngIf="!setup && !promptSave && currentStage">
         <div class="practice-wrapper" [class.with-settings]="showSettings">
           <div class="practice-header">
-            <div class="stage-indicators-compact" @slideUp>
+            <div class="stage-indicators-compact" *ngIf="!showSettings" @slideUp>
               <div
                 class="stage-compact"
                 *ngFor="let s of stageNames; let i = index"
@@ -267,9 +301,10 @@
 
           <div class="verse-display" [style.font-size.px]="settings.fontSize">
             <!-- Single Verse Display Mode -->
-            <div *ngIf="settings.displayMode === 'single'" class="single-mode">
+            <div *ngIf="settings.displayMode === 'flow' && layoutMode === 'single'" class="single-mode">
               <div
                 class="verse-block"
+                [class.highlight-fifth]="highlightFifthVerse && v.isFifth"
                 *ngFor="let v of currentVerses; let idx = index"
                 [@verseTransition]="currentStepIndex"
               >
@@ -279,12 +314,13 @@
             </div>
 
             <!-- Grid Display Mode -->
-            <div *ngIf="settings.displayMode === 'grid' && currentVerses.length < 6" class="grid-mode">
+            <div *ngIf="settings.displayMode === 'flow' && layoutMode === 'grid' && currentVerses.length < 6" class="grid-mode">
               <div class="verse-grid" [class.cols-3]="currentVerses.length === 3"
                                      [class.cols-4]="currentVerses.length === 4"
                                      [class.cols-5]="currentVerses.length === 5">
                 <div
                   class="verse-cell"
+                  [class.highlight-fifth]="highlightFifthVerse && v.isFifth"
                   *ngFor="let v of currentVerses; let idx = index"
                   [@verseTransition]="currentStepIndex"
                 >
@@ -292,6 +328,16 @@
                   <p class="verse-text" [class.memory-mode]="currentStepIndex === 2">{{ getVerseDisplay(v) }}</p>
                 </div>
               </div>
+            </div>
+
+            <!-- Text Display Mode -->
+            <div *ngIf="settings.displayMode === 'text'" class="text-mode">
+              <p class="combined-text">
+                <span *ngFor="let v of currentVerses; let i = index">
+                  <sup class="verse-num">{{ v.verse }}</sup>
+                  {{ getVerseDisplay(v) }}<span *ngIf="i < currentVerses.length - 1"> </span>
+                </span>
+              </p>
             </div>
           </div>
 
@@ -381,9 +427,10 @@
     </div>
 
     <!-- Star Popup (positioned fixed) -->
-    <div 
-      *ngIf="starPopup && starPopup.show" 
+    <div
+      *ngIf="starPopup && starPopup.show"
       class="star-popup"
+      [class.visible]="starPopupVisible"
       [@popupSlide]="starPopup.show ? 'show' : 'hide'"
     >
       <span class="popup-icon">⭐</span>

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
@@ -460,6 +460,11 @@
   align-items: center;
   gap: 0.75rem;
   white-space: nowrap;
+  visibility: hidden;
+
+  &.visible {
+    visibility: visible;
+  }
   
   &::after {
     content: '';
@@ -791,13 +796,13 @@
 /* Settings Panel */
 .settings-panel {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 3.5rem;
+  left: 0;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   padding: 1.5rem;
-  border-radius: 0 0 0 1rem;
-  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.1);
+  border-radius: 0 1rem 1rem 0;
+  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.1);
   z-index: 10;
   min-width: 280px;
   
@@ -899,7 +904,7 @@
   overflow: hidden;
   
   &.with-settings {
-    padding-right: 300px;
+    padding-left: 300px;
   }
 }
 
@@ -1041,6 +1046,11 @@
 // Single mode display
 .single-mode {
   .verse-block {
+    &.highlight-fifth {
+      background: #dbeafe;
+      padding: 1rem;
+      border-radius: 0.75rem;
+    }
     & + & {
       border-top: 2px solid #f3f4f6;
       margin-top: 2rem;
@@ -1055,6 +1065,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.text-mode {
+  .combined-text {
+    text-align: justify;
+  }
+
+  .verse-num {
+    font-size: 0.75em;
+    color: #6b7280;
+    margin-right: 0.25em;
+  }
 }
 
 .verse-grid {
@@ -1081,6 +1103,11 @@
   padding: 1.5rem;
   text-align: center;
   transition: all 0.3s;
+
+  &.highlight-fifth {
+    background: #dbeafe;
+    border: 1px solid #93c5fd;
+  }
   
   &:hover {
     transform: translateY(-2px);
@@ -1092,7 +1119,7 @@
   font-weight: 800;
   color: #374151;
   margin-bottom: 0.75rem;
-  font-size: 0.875rem;
+  font-size: 0.8em;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   display: inline-block;
@@ -1104,10 +1131,10 @@
 .verse-text {
   color: #1f2937;
   line-height: 1.8;
-  font-size: 1.25rem;
-  
+  font-size: 1em;
+
   &.memory-mode {
-    font-size: 1.75rem;
+    font-size: 1.5em;
     letter-spacing: 0.75em;
     color: #9ca3af;
     font-family: monospace;
@@ -1685,6 +1712,6 @@
   }
   
   .practice-wrapper.with-settings {
-    padding-right: 0;
+    padding-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- add chapter navigation header on Flow page
- drop keyboard shortcuts and HostListener logic
- reposition memorization modal settings to the left and add gear emoji
- include Flow layout options and plain text mode in modal
- adjust font sizing and highlight styles
- fix star popup flashing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c1d8e0b483319947d10f0de8c82e