### PR TITLE
Implement ESV API cache limits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -84,6 +84,14 @@ own API token which is stored in the `esv_api_token` column.
 When enabled, verse text requests will be served from the ESV API instead of
 API.Bible.
 
+### Caching
+ESV responses are cached in memory with an eviction policy that follows
+Crossway's public guidelines:
+
+- No more than **500 verses** are stored at once.
+- The cache also ensures no more than half of any single book is kept.
+- Entries expire after 24 hours so the cache is periodically cleared.
+
 ### Database migration
 If you already have an existing database you will need to add the new columns:
 

--- a/backend/services/esv_api.py
+++ b/backend/services/esv_api.py
@@ -1,22 +1,105 @@
-import requests
+import json
 import logging
 import re
-from functools import lru_cache
+import time
+from collections import OrderedDict
+from pathlib import Path
 from typing import Dict
 
+import requests
+
 logger = logging.getLogger(__name__)
+
+
+class VerseCache:
+    """LRU cache with a hard limit of 500 verses and half-book caps."""
+
+    def __init__(self, max_size: int = 500, ttl: int = 60 * 60 * 24):
+        self.max_size = max_size
+        self.ttl = ttl
+        self.cache: "OrderedDict[str, tuple[str, float, str]]" = OrderedDict()
+        self.book_counts: Dict[str, int] = {}
+        self.book_limits = self._load_book_limits()
+
+    def _load_book_limits(self) -> Dict[str, int]:
+        """Load half-book verse limits from bible_base_data.json."""
+        limits: Dict[str, int] = {}
+        try:
+            path = Path(__file__).resolve().parents[2] / "sql_setup" / "bible_base_data.json"
+            with open(path) as f:
+                data = json.load(f)
+            for book in data.get("books", []):
+                total = sum(book.get("chapters", []))
+                limits[book.get("name")] = total // 2
+        except Exception as e:
+            logger.error("Failed to load book verse counts: %s", e)
+        return limits
+
+    def _parse_book(self, reference: str) -> str:
+        try:
+            book, _ = reference.rsplit(" ", 1)
+            return book
+        except ValueError:
+            return reference
+
+    def _evict(self, reference: str) -> None:
+        text, ts, book = self.cache.pop(reference)
+        count = self.book_counts.get(book, 1)
+        if count <= 1:
+            self.book_counts.pop(book, None)
+        else:
+            self.book_counts[book] = count - 1
+
+    def _prune_expired(self) -> None:
+        now = time.time()
+        to_remove = [ref for ref, (_, ts, _) in self.cache.items() if now - ts > self.ttl]
+        for ref in to_remove:
+            self._evict(ref)
+
+    def get(self, reference: str) -> str | None:
+        self._prune_expired()
+        entry = self.cache.get(reference)
+        if not entry:
+            return None
+        text, ts, book = entry
+        if time.time() - ts > self.ttl:
+            self._evict(reference)
+            return None
+        self.cache.move_to_end(reference)
+        return text
+
+    def set(self, reference: str, text: str) -> None:
+        self._prune_expired()
+        book = self._parse_book(reference)
+        limit = self.book_limits.get(book, self.max_size)
+        if self.book_counts.get(book, 0) >= limit:
+            return
+        if reference in self.cache:
+            self.cache.move_to_end(reference)
+            return
+        while len(self.cache) >= self.max_size:
+            self._evict(next(iter(self.cache)))
+        self.cache[reference] = (text, time.time(), book)
+        self.book_counts[book] = self.book_counts.get(book, 0) + 1
+
+
 
 class ESVService:
     """Simple wrapper around the ESV API"""
 
     BASE_URL = "https://api.esv.org/v3/passage/text/"
 
+    _cache = VerseCache()
+
     def __init__(self, token: str):
         self.token = token
         self.headers = {"Authorization": f"Token {token}"}
 
-    @lru_cache(maxsize=1000)
     def get_verse_text(self, reference: str) -> str:
+        cached = self._cache.get(reference)
+        if cached is not None:
+            return cached
+
         params = {
             "q": reference,
             "include-headings": False,
@@ -33,6 +116,7 @@ class ESVService:
                 if passages:
                     text = passages[0].strip()
                     text = re.sub(r"<[^>]+>", "", text).strip()
+                    self._cache.set(reference, text)
                     return text
                 logger.error("No passages returned for %s", reference)
             else:


### PR DESCRIPTION
## Summary
- implement an in-memory cache for ESV verses with 500 verse limit
- enforce half-book policy and 24 hour TTL
- document cache behaviour in backend README

## Testing
- `python3 backend/services/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666cefd85483318e738c0b13ae6baf