### PR TITLE
Improve memorization modal interactions

### DIFF
--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
@@ -5,13 +5,14 @@
 
     <div class="modal-header">
       <div class="header-row">
-        <h2>{{ displayChapterName }}</h2>
+        <h2>{{ currentBook }} {{ currentChapterNum }}</h2>
         <div class="progress-info">
           <span class="progress-text">{{ progressPercentage }}% Complete</span>
         </div>
         <div class="settings-container header-settings">
           <button
             class="step-circle settings-btn"
+            [class.spinning]="isGearSpinning"
             (click)="toggleSettingsDropdown()"
             title="Settings"
           >
@@ -121,6 +122,7 @@
                   <div
                     class="stage-dot"
                     [class.completed]="currentStepIndex > 0"
+                    [class.active]="currentStepIndex === 0"
                   ></div>
                   <div
                     class="stage-dot"
@@ -304,6 +306,7 @@
             <div
               class="verse-display"
               [style.font-size.px]="practiceSettings.fontSize"
+              *ngIf="currentStepIndex !== 2"
             >
               <div
                 *ngIf="practiceSettings.layoutMode === 'column'"
@@ -341,6 +344,9 @@
                 </p>
               </div>
             </div>
+          </div>
+          <div class="memory-message" *ngIf="currentStepIndex === 2">
+            You're doing great! Recite it from memory!
           </div>
         </div>
         <div class="nav-buttons">
@@ -384,7 +390,7 @@
             </div>
 
             <p class="completion-text">
-              You've successfully memorized {{ displayChapterName }}!
+              You've successfully memorized Book {{ currentChapterNum }}!
             </p>
 
             <!-- Special message for completing the Bible -->
@@ -466,50 +472,44 @@
               </svg>
             </div>
 
-            <!-- Navigation Options -->
-            <div
-              class="navigation-options"
-              *ngIf="showNavigationOptions"
-              @slideUp
-            >
-              <p class="nav-prompt">What would you like to do next?</p>
+            <!-- Navigation Options moved to bottom -->
+          </div>
+          <div class="nav-buttons" *ngIf="showNavigationOptions">
+            <div class="bottom-nav-options">
+              <button
+                class="nav-option-btn tracker-btn"
+                (click)="goToTracker()"
+              >
+                <span class="nav-icon">📊</span>
+                <div class="nav-text">
+                  <span class="nav-title">View Progress</span>
+                  <span class="nav-subtitle"
+                    >See your achievement in the tracker</span
+                  >
+                </div>
+              </button>
 
-              <div class="nav-buttons-group">
-                <button
-                  class="nav-option-btn tracker-btn"
-                  (click)="goToTracker()"
-                >
-                  <span class="nav-icon">📊</span>
-                  <div class="nav-text">
-                    <span class="nav-title">View Progress</span>
-                    <span class="nav-subtitle"
-                      >See your achievement in the tracker</span
-                    >
-                  </div>
-                </button>
+              <button
+                class="nav-option-btn flow-btn"
+                (click)="goToFlow()"
+                *ngIf="!isLastChapterOfBible"
+              >
+                <span class="nav-icon">📖</span>
+                <div class="nav-text">
+                  <span class="nav-title">Learn Next Chapter</span>
+                  <span class="nav-subtitle"
+                    >Continue with {{ nextChapterName }}</span
+                  >
+                </div>
+              </button>
 
-                <button
-                  class="nav-option-btn flow-btn"
-                  (click)="goToFlow()"
-                  *ngIf="!isLastChapterOfBible"
-                >
-                  <span class="nav-icon">📖</span>
-                  <div class="nav-text">
-                    <span class="nav-title">Learn Next Chapter</span>
-                    <span class="nav-subtitle"
-                      >Continue with {{ nextChapterName }}</span
-                    >
-                  </div>
-                </button>
-
-                <button class="nav-option-btn close-btn" (click)="closeModal()">
-                  <span class="nav-icon">✕</span>
-                  <div class="nav-text">
-                    <span class="nav-title">Close</span>
-                    <span class="nav-subtitle">Return to where you were</span>
-                  </div>
-                </button>
-              </div>
+              <button class="nav-option-btn close-btn" (click)="closeModal()">
+                <span class="nav-icon">✕</span>
+                <div class="nav-text">
+                  <span class="nav-title">Close</span>
+                  <span class="nav-subtitle">Return to where you were</span>
+                </div>
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
@@ -472,7 +472,6 @@
               </svg>
             </div>
 
-            <!-- Navigation Options moved to bottom -->
           </div>
           <div class="nav-buttons" *ngIf="showNavigationOptions">
             <div class="bottom-nav-options">

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
@@ -974,6 +974,18 @@
   }
 }
 
+.memory-message {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #4b5563;
+  text-align: center;
+  padding: 2rem;
+}
+
 .nav-buttons {
   display: flex;
   justify-content: space-between;
@@ -1007,6 +1019,10 @@
 
   &.settings-btn {
     z-index: 60;
+  }
+
+  &.spinning {
+    animation: gear-spin 0.6s ease;
   }
 
   &.active {
@@ -1309,6 +1325,15 @@
   }
 }
 
+@keyframes gear-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 // Success checkmark
 .success-check-container {
   margin: 1.5rem 0;
@@ -1554,7 +1579,18 @@
     font-size: 1.125rem;
   }
 
-  .nav-subtitle {
-    font-size: 0.875rem;
-  }
+.nav-subtitle {
+  font-size: 0.875rem;
+}
+
+.bottom-nav-options {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.bottom-nav-options .nav-option-btn {
+  width: auto;
+}
 }

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
@@ -265,6 +265,7 @@ export class MemorizationModalComponent implements OnInit, OnDestroy, AfterViewC
   starPopup: StarPopup | null = null;
   floatingMessage = '';
   showSettingsDropdown = false;
+  isGearSpinning = false;
   animatedStar: AnimatedStar = {
     show: false,
     startX: 0,
@@ -284,8 +285,8 @@ export class MemorizationModalComponent implements OnInit, OnDestroy, AfterViewC
 
   // Book chapter data
   private bookChapters = 0;
-  private currentBook = '';
-  private currentChapterNum = 0;
+  currentBook = '';
+  currentChapterNum = 0;
 
   // Utilities
   Math = Math;
@@ -522,12 +523,19 @@ export class MemorizationModalComponent implements OnInit, OnDestroy, AfterViewC
 
   toggleSettingsDropdown() {
     this.showSettingsDropdown = !this.showSettingsDropdown;
+    this.isGearSpinning = true;
+    setTimeout(() => (this.isGearSpinning = false), 600);
   }
 
   jumpToStep(stepIndex: number) {
     if (this.setup || this.promptSave) return;
-
+    const diff = stepIndex - this.currentStepIndex;
     this.currentStepIndex = stepIndex;
+    this.completedSteps = Math.min(
+      Math.max(this.completedSteps + diff, 0),
+      this.totalSteps
+    );
+    this.updateProgressMarkers();
   }
 
   updateActiveBorder() {


### PR DESCRIPTION
## Summary
- show chapter number alongside the book name in the modal header
- spin the settings gear on click
- highlight the first progress dot when starting a new group
- update the progress bar when jumping between Read/Flow/Memory steps
- replace the memory step dots with a centered encouragement message
- move completion navigation buttons to the bottom bar
- tweak styles for new elements

## Testing
- `npm test --silent` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866fa069a5c8331bba207b9dd0a8964