### PR TITLE
Improve memorization modal UX

### DIFF
--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.html
@@ -338,15 +338,14 @@
                       class="verse-text"
                       [class.memory-mode]="currentStepIndex === 2"
                       >{{ getVerseDisplay(v) }}</span
-                    >
-                    <span *ngIf="idx < currentVerses.length - 1"> </span>
+                    >&nbsp;
                   </span>
                 </p>
               </div>
             </div>
           </div>
           <div class="memory-message" *ngIf="currentStepIndex === 2">
-            You're doing great! Recite it from memory!
+            Now recite verse {{ currentVerseRange }} out loud!
           </div>
         </div>
         <div class="nav-buttons">

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
@@ -336,6 +336,8 @@
   left: 0;
   width: 100%;
   height: 100%;
+  z-index: 20;
+  pointer-events: none;
 }
 
 .marker {

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
@@ -308,6 +308,14 @@ export class MemorizationModalComponent implements OnInit, OnDestroy, AfterViewC
     return this.currentStage.groups[this.currentSubStageIndex] || [];
   }
 
+  get currentVerseRange(): string {
+    const verses = this.currentVerses;
+    if (!verses.length) return '';
+    const start = verses[0].verse;
+    const end = verses[verses.length - 1].verse;
+    return start === end ? `${start}` : `${start} to ${end}`;
+  }
+
   get progressDetail(): string {
     if (this.setup || this.promptSave || !this.currentStage) {
       return '';


### PR DESCRIPTION
## Summary
- keep space between verses in paragraph mode
- overlay phase markers above modal content
- show dynamic verse range when prompting to recite

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ff25931483318d17613614631cbc