### PR TITLE
Handle ESV API throttle with user warning

### DIFF
--- a/backend/routers/user_verses.py
+++ b/backend/routers/user_verses.py
@@ -288,7 +288,7 @@ async def get_verse_texts(
 ) -> Dict[str, str]:
     """Get verse texts using the user's preferred provider"""
     from services.api_bible import APIBibleService
-    from services.esv_api import ESVService
+    from services.esv_api import ESVService, ESVRateLimitError
     from config import Config
 
     verse_codes = request.verse_codes
@@ -333,6 +333,9 @@ async def get_verse_texts(
         # Ensure all requested codes are present
         return {code: verse_texts.get(code, "") for code in verse_codes}
 
+    except ESVRateLimitError as e:
+        logger.warning(f"ESV API rate limited for {e.wait_seconds} seconds")
+        raise HTTPException(status_code=429, detail={"wait_seconds": e.wait_seconds})
     except Exception as e:
         logger.error(f"Error getting verse texts: {e}")
         return {code: "" for code in verse_codes}

--- a/backend/services/esv_api.py
+++ b/backend/services/esv_api.py
@@ -8,6 +8,14 @@ from typing import Dict
 
 import requests
 
+
+class ESVRateLimitError(Exception):
+    """Raised when the ESV API rate limit is hit."""
+
+    def __init__(self, wait_seconds: int):
+        self.wait_seconds = wait_seconds
+        super().__init__(f"ESV API rate limit. Try again in {wait_seconds} seconds")
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,6 +102,22 @@ class ESVService:
     def __init__(self, token: str):
         self.token = token
         self.headers = {"Authorization": f"Token {token}"}
+        # Track when the next request is allowed
+        self._next_allowed_time = 0.0
+
+    def _check_rate_limit(self) -> None:
+        """Raise if we are still within the throttle period."""
+        now = time.time()
+        if now < self._next_allowed_time:
+            wait = int(self._next_allowed_time - now)
+            raise ESVRateLimitError(wait)
+
+    def _parse_retry_after(self, detail: str) -> int:
+        """Parse the retry delay from the API's error message."""
+        match = re.search(r"in\s+(\d+)\s+second", detail)
+        if match:
+            return int(match.group(1))
+        return 1
 
     def get_verse_text(self, reference: str) -> str:
         cached = self._cache.get(reference)
@@ -109,8 +133,10 @@ class ESVService:
             "include-passage-references": False,
         }
         try:
+            self._check_rate_limit()
             response = requests.get(self.BASE_URL, params=params, headers=self.headers)
             if response.status_code == 200:
+                self._next_allowed_time = time.time()
                 data = response.json()
                 passages = data.get("passages", [])
                 if passages:
@@ -119,13 +145,25 @@ class ESVService:
                     self._cache.set(reference, text)
                     return text
                 logger.error("No passages returned for %s", reference)
-            else:
-                logger.error("ESV API error %s: %s", response.status_code, response.text)
+                return ""
+            if response.status_code == 429:
+                try:
+                    detail = response.json().get("detail", "")
+                except Exception:
+                    detail = response.text
+                wait = self._parse_retry_after(detail)
+                self._next_allowed_time = time.time() + wait
+                logger.warning("ESV API throttled; wait %s seconds", wait)
+                raise ESVRateLimitError(wait)
+            logger.error("ESV API error %s: %s", response.status_code, response.text)
+        except ESVRateLimitError:
+            raise
         except Exception as e:
             logger.error("Failed to fetch verse from ESV API: %s", e)
         return ""
 
     def get_verses_batch(self, references: Dict[str, str]) -> Dict[str, str]:
+        """Fetch multiple verses while respecting rate limits."""
         results: Dict[str, str] = {}
         for code, ref in references.items():
             results[code] = self.get_verse_text(ref)

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -15,4 +15,5 @@
 
   <!-- Global Modal Component -->
   <app-modal></app-modal>
+  <app-notification></app-notification>
 </div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { NavigationComponent } from './shared/components/navigation/navigation.component';
 import { ModalComponent } from './shared/components/modal/modal.component';
+import { NotificationComponent } from './shared/components/notification/notification.component';
 
 @Component({
   selector: 'app-root',
@@ -12,7 +13,8 @@ import { ModalComponent } from './shared/components/modal/modal.component';
     CommonModule, 
     RouterOutlet, 
     NavigationComponent,
-    ModalComponent
+    ModalComponent,
+    NotificationComponent
   ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']

--- a/frontend/src/app/core/services/bible.service.ts
+++ b/frontend/src/app/core/services/bible.service.ts
@@ -182,9 +182,11 @@ export class BibleService {
       tap(texts => console.log(`Received texts for ${Object.keys(texts).length} verses`)),
       catchError((error: HttpErrorResponse) => {
         console.error('Error getting verse texts:', error);
-        if (error.status === 429 && error.error?.wait_seconds) {
-          const wait = error.error.wait_seconds;
-          this.notifications.warning(`ESV API limit reached. Try again in ${wait} seconds.`);
+        if (error.status === 429) {
+          const wait = error.error?.wait_seconds ?? error.error?.detail?.wait_seconds;
+          if (wait) {
+            this.notifications.warning(`ESV API limit reached. Try again in ${wait} seconds.`);
+          }
         }
         const emptyTexts: Record<string, string> = {};
         verseCodes.forEach(code => (emptyTexts[code] = ''));

--- a/frontend/src/app/core/services/notification.service.ts
+++ b/frontend/src/app/core/services/notification.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Subject, Observable } from 'rxjs';
+
+export interface NotificationMessage {
+  type: 'info' | 'success' | 'warning' | 'danger';
+  text: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private subject = new Subject<NotificationMessage>();
+  messages$: Observable<NotificationMessage> = this.subject.asObservable();
+
+  notify(message: NotificationMessage) {
+    this.subject.next(message);
+  }
+
+  warning(text: string) {
+    this.notify({ type: 'warning', text });
+  }
+}

--- a/frontend/src/app/shared/components/notification/notification.component.scss
+++ b/frontend/src/app/shared/components/notification/notification.component.scss
@@ -1,0 +1,21 @@
+.notification {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  background: #f59e0b;
+  color: white;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(-1rem);
+  transition: all 0.3s;
+  pointer-events: none;
+  z-index: 2000;
+}
+
+.notification.show {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/frontend/src/app/shared/components/notification/notification.component.ts
+++ b/frontend/src/app/shared/components/notification/notification.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { NotificationService, NotificationMessage } from '../../../core/services/notification.service';
+
+@Component({
+  selector: 'app-notification',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div
+      class="notification warning"
+      *ngIf="message"
+      [class.show]="visible"
+    >
+      {{ message }}
+    </div>
+  `,
+  styleUrls: ['./notification.component.scss']
+})
+export class NotificationComponent implements OnInit, OnDestroy {
+  message = '';
+  visible = false;
+  private sub?: Subscription;
+
+  constructor(private notifications: NotificationService) {}
+
+  ngOnInit() {
+    this.sub = this.notifications.messages$.subscribe((msg: NotificationMessage) => {
+      this.message = msg.text;
+      this.visible = true;
+      setTimeout(() => (this.visible = false), 3000);
+    });
+  }
+
+  ngOnDestroy() {
+    this.sub?.unsubscribe();
+  }
+}


### PR DESCRIPTION
## Summary
- raise `ESVRateLimitError` instead of retrying ESV requests
- report the throttle wait time via HTTP 429
- surface warnings in the Angular app via a global notification component
- notify when verse text retrieval is throttled

## Testing
- `pytest` *(fails: ModuleNotFoundError for requests)*

------
https://chatgpt.com/codex/tasks/task_e_6867057e7ef083318c5e12f7e8926442