### PR TITLE
Limit ESV cache by chapter

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -89,7 +89,8 @@ ESV responses are cached in memory with an eviction policy that follows
 Crossway's public guidelines:
 
 - No more than **500 verses** are stored at once.
-- The cache also ensures no more than half of any single book is kept.
+- The cache stores at most half the chapters of any single book.
+  Single chapter books are never cached.
 - Entries expire after 24 hours so the cache is periodically cleared.
 
 ### Database migration


### PR DESCRIPTION
## Summary
- restrict ESV API cache to half the chapters of a book
- evict oldest chapter when limit is reached
- document chapter-based caching rules

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6867104f4f6083319a3bec7e7840f2a1