### PR TITLE
Handle ESV API limit

### DIFF
--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -31,7 +31,7 @@
         <button
           class="action-btn primary"
           (click)="startMemorization()"
-          [disabled]="retryCountdown !== null"
+          [disabled]="retryCountdown !== null || isLoading"
         >
           <svg
             width="20"
@@ -284,7 +284,7 @@
       </div>
 
       <!-- Title with navigation for all views -->
-      <div class="passage-header" *ngIf="!isLoading && verses.length > 0">
+      <div class="passage-header" *ngIf="!isLoading && (verses.length > 0 || retryCountdown !== null)">
         <button
           class="nav-btn"
           (click)="navigateToPreviousChapter()"

--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -28,7 +28,11 @@
 
       <!-- Start Button -->
       <div class="sidebar-section actions" *ngIf="verses.length > 0">
-        <button class="action-btn primary" (click)="startMemorization()">
+        <button
+          class="action-btn primary"
+          (click)="startMemorization()"
+          [disabled]="retryCountdown !== null"
+        >
           <svg
             width="20"
             height="20"
@@ -320,8 +324,10 @@
         </button>
       </div>
 
-      <div *ngIf="retryCountdown !== null" class="countdown-timer">
-        ESV API limit reached. Retrying in {{ retryCountdown }}s...
+      <div *ngIf="retryCountdown !== null" class="countdown-overlay">
+        <div class="countdown-timer">
+          ESV API limit reached. Retrying in {{ retryCountdown }}s...
+        </div>
       </div>
 
       <!-- Grid View -->

--- a/frontend/src/app/features/memorize/flow/flow.component.html
+++ b/frontend/src/app/features/memorize/flow/flow.component.html
@@ -320,6 +320,10 @@
         </button>
       </div>
 
+      <div *ngIf="retryCountdown !== null" class="countdown-timer">
+        ESV API limit reached. Retrying in {{ retryCountdown }}s...
+      </div>
+
       <!-- Grid View -->
       <div
         *ngIf="

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -719,15 +719,25 @@
 }
 
 // Countdown timer when API rate limit is hit
+.countdown-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 5;
+}
+
 .countdown-timer {
-  margin: 1rem 0;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 1rem;
   background: #fef3c7;
   color: #92400e;
   border: 1px solid #fde68a;
   border-radius: 0.375rem;
   text-align: center;
   font-size: 0.875rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 // Animations

--- a/frontend/src/app/features/memorize/flow/flow.component.scss
+++ b/frontend/src/app/features/memorize/flow/flow.component.scss
@@ -718,6 +718,18 @@
   }
 }
 
+// Countdown timer when API rate limit is hit
+.countdown-timer {
+  margin: 1rem 0;
+  padding: 0.5rem 0.75rem;
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fde68a;
+  border-radius: 0.375rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+
 // Animations
 @keyframes spin {
   to {

--- a/frontend/src/app/features/memorize/flow/flow.component.ts
+++ b/frontend/src/app/features/memorize/flow/flow.component.ts
@@ -209,11 +209,19 @@ export class FlowComponent implements OnInit, OnDestroy {
     // Clear warning for valid selections
     this.warningMessage = null;
     this.loadVersesCancel$.next();
+    if (this.retryCountdown !== null) {
+      this.isLoading = false;
+      this.verses = [];
+      this.gridRows = [];
+      return;
+    }
+
     this.loadVerses();
   }
 
   async loadVerses() {
     if (!this.currentSelection) return;
+    if (this.retryCountdown !== null) return;
 
     this.isLoading = true;
     this.verses = [];


### PR DESCRIPTION
## Summary
- expose rate limit events from `BibleService`
- track API countdown in Flow component
- restore verse numbers after retry
- display countdown notice in Flow view
- style countdown banner

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671440d94c8331916c6252d79918a4