### PR TITLE
Add Scripture Atlas page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@progress/kendo-theme-default": "^11.0.2",
     "@types/chart.js": "^4.0.1",
     "chart.js": "^4.4.0",
+    "maplibre-gl": "^3.7.1",
     "express": "^4.18.2",
     "hammerjs": "^2.0.8",
     "rxjs": "~7.8.0",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { FeatureRequestComponent } from './features/feature-request/feature-requ
 import { CourseListComponent } from './features/memorize/courses/course-list.component';
 import { CourseBuilderComponent } from './features/memorize/courses/course-builder.component';
 import { LessonPracticeComponent } from './features/memorize/courses/lesson-practice/lesson-practice.component';
+import { ScriptureAtlasComponent } from './features/scripture-atlas/scripture-atlas.component';
 
 // Routing configuration
 export const routes: Routes = [
@@ -32,6 +33,7 @@ export const routes: Routes = [
   },
   { path: 'courses/create', component: CourseBuilderComponent },
   { path: 'courses', component: CourseListComponent },
+  { path: 'atlas', component: ScriptureAtlasComponent },
   { path: 'flow', component: FlowComponent },
   { path: '**', redirectTo: '' },
 ];

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
@@ -1,0 +1,5 @@
+<!-- frontend/src/app/features/scripture-atlas/scripture-atlas.component.html -->
+<div class="atlas-container">
+  <h2>Scripture Atlas: Paul's First Missionary Journey</h2>
+  <div id="map" class="map"></div>
+</div>

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
@@ -1,0 +1,10 @@
+/* frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss */
+.atlas-container {
+  padding: 1rem;
+}
+
+.map {
+  width: 100%;
+  height: 80vh;
+  border-radius: 8px;
+}

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
@@ -1,0 +1,89 @@
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import maplibregl, { Map } from 'maplibre-gl';
+
+@Component({
+  selector: 'app-scripture-atlas',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './scripture-atlas.component.html',
+  styleUrls: ['./scripture-atlas.component.scss'],
+})
+export class ScriptureAtlasComponent implements AfterViewInit, OnDestroy {
+  map: Map | null = null;
+
+  ngAfterViewInit(): void {
+    this.map = new maplibregl.Map({
+      container: 'map',
+      style: 'https://demotiles.maplibre.org/style.json',
+      center: [33.2, 37.0],
+      zoom: 5,
+    });
+
+    this.map.on('load', () => {
+      this.addRoute();
+      this.addMarkers();
+    });
+  }
+
+  addRoute() {
+    if (!this.map) return;
+    this.map.addSource('paulRoute', {
+      type: 'geojson',
+      data: {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [36.1, 36.2], // Antioch
+            [33.35, 35.17], // Salamis
+            [32.42, 34.77], // Paphos
+            [30.85, 36.87], // Perga
+            [31.17, 38.27], // Pisidian Antioch
+            [32.48, 37.87], // Iconium
+            [32.38, 37.58], // Lystra
+            [33.7, 37.8], // Derbe
+            [30.7, 36.9], // Attalia
+            [36.1, 36.2], // Back to Antioch
+          ],
+        },
+      },
+    });
+
+    this.map.addLayer({
+      id: 'paulRouteLine',
+      type: 'line',
+      source: 'paulRoute',
+      paint: {
+        'line-color': '#FF0000',
+        'line-width': 4,
+      },
+    });
+  }
+
+  addMarkers() {
+    if (!this.map) return;
+    const stops = [
+      { coords: [36.1, 36.2], name: 'Antioch' },
+      { coords: [33.35, 35.17], name: 'Salamis' },
+      { coords: [32.42, 34.77], name: 'Paphos' },
+      { coords: [30.85, 36.87], name: 'Perga' },
+      { coords: [31.17, 38.27], name: 'Pisidian Antioch' },
+      { coords: [32.48, 37.87], name: 'Iconium' },
+      { coords: [32.38, 37.58], name: 'Lystra' },
+      { coords: [33.7, 37.8], name: 'Derbe' },
+      { coords: [30.7, 36.9], name: 'Attalia' },
+    ];
+
+    for (const stop of stops) {
+      new maplibregl.Marker()
+        .setLngLat(stop.coords as [number, number])
+        .setPopup(new maplibregl.Popup().setHTML(`<h3>${stop.name}</h3>`))
+        .addTo(this.map!);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.map?.remove();
+  }
+}

--- a/frontend/src/app/shared/components/navigation/navigation.component.html
+++ b/frontend/src/app/shared/components/navigation/navigation.component.html
@@ -127,6 +127,14 @@
           >
             🎓 Courses
           </a>
+          <a
+            routerLink="/atlas"
+            class="dropdown-item"
+            routerLinkActive="active"
+            (click)="closeMenu()"
+          >
+            🗺️ Scripture Atlas
+          </a>
         </div>
       </div>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,5 +1,5 @@
 /* Base styles */
-@import 'maplibre-gl/dist/maplibre-gl.css';
+@import "~maplibre-gl/dist/maplibre-gl.css";
 * {
   margin: 0;
   padding: 0;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,4 +1,5 @@
 /* Base styles */
+@import 'maplibre-gl/dist/maplibre-gl.css';
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- add Scripture Atlas component with MapLibre map of Paul's first journey
- include the Atlas in navigation Learning menu
- route `/atlas` to the new component
- import MapLibre styles globally
- add `maplibre-gl` dependency

## Testing
- `npm run format`
- `npm test` *(fails: ng not found)*
- `pytest` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_68671e7897108331a0e46825be2ca9da