### PR TITLE
Add missionary journeys map with OpenLayers

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -36,7 +36,8 @@
               }
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "node_modules/ol/ol.css"
             ],
             "scripts": [],
             "server": "src/main.server.ts",
@@ -114,6 +115,7 @@
             ],
             "styles": [
               "src/styles.css",
+              "node_modules/ol/ol.css",
               "node_modules/@progress/kendo-theme-default/dist/all.css"
             ],
             "scripts": []

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "chart.js": "^4.4.0",
     "express": "^4.18.2",
     "hammerjs": "^2.0.8",
+    "ol": "^9.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
@@ -60,6 +61,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "prettier": "^3.5.3",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "@types/ol": "^9.0.0"
   }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { FeatureRequestComponent } from './features/feature-request/feature-requ
 import { CourseListComponent } from './features/memorize/courses/course-list.component';
 import { CourseBuilderComponent } from './features/memorize/courses/course-builder.component';
 import { LessonPracticeComponent } from './features/memorize/courses/lesson-practice/lesson-practice.component';
+import { MissionaryJourneysMapComponent } from './components/missionary-journeys-map/missionary-journeys-map.component';
 
 // Routing configuration
 export const routes: Routes = [
@@ -32,6 +33,7 @@ export const routes: Routes = [
   },
   { path: 'courses/create', component: CourseBuilderComponent },
   { path: 'courses', component: CourseListComponent },
+  { path: 'missionary-journeys', component: MissionaryJourneysMapComponent },
   { path: 'flow', component: FlowComponent },
   { path: '**', redirectTo: '' },
 ];

--- a/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.html
+++ b/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.html
@@ -1,0 +1,16 @@
+<div class="map-container">
+  <div class="map-header">
+    <h2>Paul's Missionary Journeys</h2>
+    <p>Starting with Antioch (Syria) - Acts 13:1-3</p>
+  </div>
+  
+  <div id="map" class="map"></div>
+  
+  <div class="map-legend">
+    <h3>Legend</h3>
+    <div class="legend-item">
+      <span class="dot"></span>
+      <span>City Location</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.scss
+++ b/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.scss
@@ -1,0 +1,55 @@
+.map-container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+}
+
+.map-header {
+  background: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+
+  h2 {
+    margin: 0 0 5px 0;
+    color: #333;
+  }
+
+  p {
+    margin: 0;
+    color: #666;
+  }
+}
+
+.map {
+  flex: 1;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  min-height: 500px;
+}
+
+.map-legend {
+  background: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  margin-top: 20px;
+
+  h3 {
+    margin: 0 0 10px 0;
+    font-size: 16px;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+
+    .dot {
+      width: 12px;
+      height: 12px;
+      background: #8B4513;
+      border-radius: 50%;
+    }
+  }
+}

--- a/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
+++ b/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import Map from 'ol/Map';
-import View from 'ol/View';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import OSM from 'ol/source/OSM';
-import VectorSource from 'ol/source/Vector';
-import Feature from 'ol/Feature';
-import Point from 'ol/geom/Point';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import VectorLayer from 'ol/layer/Vector.js';
+import OSM from 'ol/source/OSM.js';
+import VectorSource from 'ol/source/Vector.js';
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
 import { fromLonLat } from 'ol/proj';
 import { Icon, Style, Text, Fill, Stroke } from 'ol/style';
 
@@ -88,8 +88,8 @@ export class MissionaryJourneysMapComponent implements OnInit, AfterViewInit {
     });
 
     // Add click handler to show info
-    this.map.on('click', (evt) => {
-      const feature = this.map.forEachFeatureAtPixel(evt.pixel, (f) => f);
+    this.map.on('click', (evt: any) => {
+      const feature = this.map.forEachFeatureAtPixel(evt.pixel, (f: any) => f);
       if (feature) {
         const properties = feature.getProperties();
         alert(`\n          ${properties.name}\n          Modern: ${properties.modernName}\n          ${properties.description}\n          Scripture: ${properties.verses}\n        `);

--- a/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
+++ b/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnInit, AfterViewInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import VectorLayer from 'ol/layer/Vector';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import { fromLonLat } from 'ol/proj';
+import { Icon, Style, Text, Fill, Stroke } from 'ol/style';
+
+@Component({
+  selector: 'app-missionary-journeys-map',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './missionary-journeys-map.component.html',
+  styleUrls: ['./missionary-journeys-map.component.scss']
+})
+export class MissionaryJourneysMapComponent implements OnInit, AfterViewInit {
+  map!: Map;
+
+  ngOnInit(): void {
+    // Component initialization
+  }
+
+  ngAfterViewInit(): void {
+    this.initializeMap();
+  }
+
+  initializeMap(): void {
+    // Antioch (Syria) - Starting point of Paul's first journey
+    const antiochCoordinates = fromLonLat([36.16, 36.2]); // [longitude, latitude]
+
+    // Create a feature for Antioch
+    const antiochFeature = new Feature({
+      geometry: new Point(antiochCoordinates),
+      name: 'Antioch (Syria)',
+      modernName: 'Antakya, Turkey',
+      description: 'Starting point of Paul\'s first missionary journey',
+      verses: 'Acts 13:1-3'
+    });
+
+    // Style for the point
+    antiochFeature.setStyle(new Style({
+      image: new Icon({
+        color: '#8B4513',
+        crossOrigin: 'anonymous',
+        src: 'https://openlayers.org/en/latest/examples/data/dot.png',
+        scale: 0.8
+      }),
+      text: new Text({
+        text: 'Antioch',
+        offsetY: -25,
+        fill: new Fill({
+          color: '#333'
+        }),
+        stroke: new Stroke({
+          color: '#fff',
+          width: 3
+        })
+      })
+    }));
+
+    // Create vector source and layer
+    const vectorSource = new VectorSource({
+      features: [antiochFeature]
+    });
+
+    const vectorLayer = new VectorLayer({
+      source: vectorSource
+    });
+
+    // Create the map
+    this.map = new Map({
+      target: 'map',
+      layers: [
+        new TileLayer({
+          source: new OSM()
+        }),
+        vectorLayer
+      ],
+      view: new View({
+        center: antiochCoordinates,
+        zoom: 7
+      })
+    });
+
+    // Add click handler to show info
+    this.map.on('click', (evt) => {
+      const feature = this.map.forEachFeatureAtPixel(evt.pixel, (f) => f);
+      if (feature) {
+        const properties = feature.getProperties();
+        alert(`\n          ${properties.name}\n          Modern: ${properties.modernName}\n          ${properties.description}\n          Scripture: ${properties.verses}\n        `);
+      }
+    });
+  }
+}

--- a/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
+++ b/frontend/src/app/components/missionary-journeys-map/missionary-journeys-map.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import Map from 'ol/Map.js';
-import View from 'ol/View.js';
-import TileLayer from 'ol/layer/Tile.js';
-import VectorLayer from 'ol/layer/Vector.js';
-import OSM from 'ol/source/OSM.js';
-import VectorSource from 'ol/source/Vector.js';
-import Feature from 'ol/Feature.js';
-import Point from 'ol/geom/Point.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import VectorLayer from 'ol/layer/Vector';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
 import { fromLonLat } from 'ol/proj';
 import { Icon, Style, Text, Fill, Stroke } from 'ol/style';
 

--- a/frontend/src/app/shared/components/navigation/navigation.component.html
+++ b/frontend/src/app/shared/components/navigation/navigation.component.html
@@ -27,6 +27,14 @@
         >Home</a
       >
 
+      <a
+        routerLink="/missionary-journeys"
+        class="nav-link"
+        routerLinkActive="active"
+        (click)="closeMenu()"
+        >Missionary Journeys</a
+      >
+
       <!-- Memorize dropdown menu -->
       <div class="nav-dropdown memorize">
         <button


### PR DESCRIPTION
## Summary
- add OpenLayers dependencies
- include OpenLayers CSS in Angular build
- create MissionaryJourneysMapComponent with an Antioch marker
- register new map route
- link to the map from the navigation menu

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686723dd2a988331806e0095b8c712d3