### PR TITLE
Add Scripture Atlas map page

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -112,10 +112,11 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.css",
-              "node_modules/@progress/kendo-theme-default/dist/all.css"
-            ],
+              "styles": [
+                "src/styles.css",
+                "node_modules/@progress/kendo-theme-default/dist/all.css",
+                "node_modules/leaflet/dist/leaflet.css"
+              ],
             "scripts": []
           }
         }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "chart.js": "^4.4.0",
     "express": "^4.18.2",
     "hammerjs": "^2.0.8",
+    "leaflet": "^1.9.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
@@ -60,6 +61,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "prettier": "^3.5.3",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "@types/leaflet": "^1.9.3"
   }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { FeatureRequestComponent } from './features/feature-request/feature-requ
 import { CourseListComponent } from './features/memorize/courses/course-list.component';
 import { CourseBuilderComponent } from './features/memorize/courses/course-builder.component';
 import { LessonPracticeComponent } from './features/memorize/courses/lesson-practice/lesson-practice.component';
+import { ScriptureAtlasComponent } from './features/scripture-atlas/scripture-atlas.component';
 
 // Routing configuration
 export const routes: Routes = [
@@ -32,6 +33,7 @@ export const routes: Routes = [
   },
   { path: 'courses/create', component: CourseBuilderComponent },
   { path: 'courses', component: CourseListComponent },
+  { path: 'atlas', component: ScriptureAtlasComponent },
   { path: 'flow', component: FlowComponent },
   { path: '**', redirectTo: '' },
 ];

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
@@ -1,0 +1,88 @@
+<div class="h-screen flex flex-col bg-gray-50">
+  <div class="bg-white shadow-md p-4">
+    <div class="max-w-7xl mx-auto">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-gray-800">
+            Paul's First Missionary Journey
+          </h1>
+          <p class="text-gray-600 text-sm">46-48 AD • Acts 13-14 • ~1,400 miles</p>
+        </div>
+        <div class="flex gap-6 text-center">
+          <div>
+            <div class="text-2xl font-bold text-blue-600">{{ cities.length }}</div>
+            <div class="text-xs text-gray-600">Cities</div>
+          </div>
+          <div>
+            <div class="text-2xl font-bold text-green-600">{{ memorized.size }}</div>
+            <div class="text-xs text-gray-600">Memorized</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex-1 flex">
+    <div class="w-96 bg-white shadow-lg overflow-y-auto">
+      <div class="p-4">
+        <h2 class="font-semibold text-lg mb-4 flex items-center gap-2">
+          Journey Stops
+        </h2>
+
+        <div class="space-y-2">
+          <div *ngFor="let city of cities; index as i" (click)="selectCity(city)"
+               [ngClass]="{'border-blue-500 bg-blue-50': selectedCity?.id === city.id,
+                            'border-green-500 bg-green-50': memorized.has(city.id) && selectedCity?.id !== city.id,
+                            'border-gray-200 hover:border-gray-300': selectedCity?.id !== city.id && !memorized.has(city.id)}"
+               class="p-3 rounded-lg border cursor-pointer transition-all">
+            <div class="flex items-start justify-between">
+              <div class="flex-1">
+                <h3 class="font-semibold flex items-center gap-2">
+                  <span class="text-xs bg-gray-200 px-2 py-1 rounded">{{ i + 1 }}</span>
+                  {{ city.name }}
+                </h3>
+                <p class="text-sm text-gray-600 mt-1">{{ city.modern }}</p>
+                <p class="text-xs text-gray-500 mt-1">
+                  {{ city.verses.join(', ') }}
+                </p>
+              </div>
+              <svg *ngIf="memorized.has(city.id)" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+            </div>
+
+            <div *ngIf="selectedCity?.id === city.id" class="mt-3 pt-3 border-t">
+              <p class="text-sm text-gray-700 mb-2">{{ city.description }}</p>
+              <div class="mb-3">
+                <h4 class="text-xs font-semibold text-gray-600 mb-1">Key Events:</h4>
+                <ul class="text-xs text-gray-600 space-y-1">
+                  <li *ngFor="let event of city.events" class="flex items-start gap-1">• {{ event }}</li>
+                </ul>
+              </div>
+              <div class="bg-amber-50 p-2 rounded text-xs">
+                <strong class="text-amber-800">Did you know?</strong>
+                <p class="text-amber-700">{{ city.keyFact }}</p>
+              </div>
+              <button (click)="toggleMemorized(city.id); $event.stopPropagation();"
+                      [ngClass]="memorized.has(city.id) ? 'bg-green-600 text-white hover:bg-green-700' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'"
+                      class="w-full mt-3 py-2 px-3 rounded text-sm font-medium transition-colors">
+                {{ memorized.has(city.id) ? '✓ Memorized' : 'Mark as Memorized' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex-1 relative">
+      <div id="atlas-map" class="h-full"></div>
+      <div class="absolute bottom-4 right-4 bg-white p-3 rounded-lg shadow-lg text-xs">
+        <h3 class="font-semibold mb-2">Legend</h3>
+        <div class="space-y-1">
+          <div class="flex items-center gap-2"><div class="w-4 h-4 bg-blue-500 rounded-full"></div><span>Unvisited City</span></div>
+          <div class="flex items-center gap-2"><div class="w-4 h-4 bg-blue-500 rounded-full ring-2 ring-green-500"></div><span>Memorized City</span></div>
+          <div class="flex items-center gap-2"><div class="w-4 h-4 bg-red-500 rounded-full"></div><span>Selected City</span></div>
+          <div class="flex items-center gap-2"><div class="w-8 h-0.5 bg-red-500" style="border-top: 2px dashed #dc2626"></div><span>Journey Route</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
@@ -1,0 +1,3 @@
+#atlas-map {
+  height: 100%;
+}

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
@@ -1,0 +1,219 @@
+import { Component, OnInit, AfterViewInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import * as L from 'leaflet';
+
+interface City {
+  id: string;
+  name: string;
+  modern: string;
+  position: [number, number];
+  description: string;
+  verses: string[];
+  events: string[];
+  keyFact: string;
+}
+
+@Component({
+  selector: 'app-scripture-atlas',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './scripture-atlas.component.html',
+  styleUrls: ['./scripture-atlas.component.scss']
+})
+export class ScriptureAtlasComponent implements OnInit, AfterViewInit {
+  cities: City[] = [
+    {
+      id: 'antioch-syria',
+      name: 'Antioch (Syria)',
+      modern: 'Antakya, Turkey',
+      position: [36.2, 36.16],
+      description: 'Starting point where Paul and Barnabas were commissioned',
+      verses: ['Acts 13:1-3'],
+      events: [
+        'Church fasted and prayed',
+        'Holy Spirit said "Set apart Barnabas and Saul"',
+        'Laid hands and sent them off'
+      ],
+      keyFact: 'Third largest city in the Roman Empire at the time'
+    },
+    {
+      id: 'seleucia',
+      name: 'Seleucia',
+      modern: 'Port of Antioch',
+      position: [36.12, 35.93],
+      description: 'Port city where they sailed to Cyprus',
+      verses: ['Acts 13:4'],
+      events: ['Departed by ship to Cyprus'],
+      keyFact: 'Located 16 miles from Antioch, at the mouth of the Orontes River'
+    },
+    {
+      id: 'salamis',
+      name: 'Salamis',
+      modern: 'Eastern Cyprus',
+      position: [35.18, 33.9],
+      description: 'First stop in Cyprus, proclaimed in synagogues',
+      verses: ['Acts 13:5'],
+      events: [
+        'Proclaimed the word in Jewish synagogues',
+        'John Mark was their assistant'
+      ],
+      keyFact: 'Largest city and commercial center of Cyprus'
+    },
+    {
+      id: 'paphos',
+      name: 'Paphos',
+      modern: 'Western Cyprus',
+      position: [34.77, 32.42],
+      description: 'Capital of Cyprus, encountered the proconsul',
+      verses: ['Acts 13:6-12'],
+      events: [
+        'Met Bar-Jesus (Elymas) the sorcerer',
+        'Proconsul Sergius Paulus believed',
+        'Paul struck Elymas blind'
+      ],
+      keyFact: 'First recorded conversion of a Roman government official'
+    },
+    {
+      id: 'perga',
+      name: 'Perga',
+      modern: 'Antalya region, Turkey',
+      position: [36.89, 30.85],
+      description: 'First mainland stop where John Mark left',
+      verses: ['Acts 13:13'],
+      events: [
+        'John Mark departed to Jerusalem',
+        'Paul and Barnabas continued inland'
+      ],
+      keyFact: 'John Mark\'s departure later caused conflict between Paul and Barnabas'
+    },
+    {
+      id: 'pisidian-antioch',
+      name: 'Pisidian Antioch',
+      modern: 'Yalvaç, Turkey',
+      position: [38.3, 31.2],
+      description: "Location of Paul's first recorded sermon",
+      verses: ['Acts 13:14-52'],
+      events: [
+        "Paul's powerful synagogue sermon",
+        'Many Gentiles believed',
+        'Jews stirred up persecution',
+        'Shook dust off their feet'
+      ],
+      keyFact: "Contains Paul's longest recorded sermon in Acts"
+    },
+    {
+      id: 'iconium',
+      name: 'Iconium',
+      modern: 'Konya, Turkey',
+      position: [37.87, 32.49],
+      description: 'Spent considerable time with great success',
+      verses: ['Acts 14:1-7'],
+      events: [
+        'Great number believed',
+        'City was divided',
+        'Fled from stoning attempt',
+        'Performed signs and wonders'
+      ],
+      keyFact: "Modern Konya is Turkey's 7th largest city"
+    },
+    {
+      id: 'lystra',
+      name: 'Lystra',
+      modern: 'Near Konya, Turkey',
+      position: [37.58, 32.45],
+      description: 'Paul healed a lame man and was stoned',
+      verses: ['Acts 14:8-20'],
+      events: [
+        'Healed man lame from birth',
+        'Mistaken for gods (Zeus and Hermes)',
+        'Paul stoned and left for dead',
+        'Disciples gathered, Paul rose up'
+      ],
+      keyFact: "Timothy's hometown (met on 2nd journey)"
+    },
+    {
+      id: 'derbe',
+      name: 'Derbe',
+      modern: 'Near Karaman, Turkey',
+      position: [37.35, 33.25],
+      description: 'Easternmost point, made many disciples',
+      verses: ['Acts 14:20-21'],
+      events: [
+        'Preached the gospel',
+        'Made many disciples',
+        'No recorded persecution',
+        'Began return journey'
+      ],
+      keyFact: 'Only city without recorded opposition'
+    }
+  ];
+
+  memorized = new Set<string>();
+  selectedCity: City | null = null;
+  map!: L.Map;
+  markers: { [id: string]: L.Marker } = {};
+
+  ngOnInit() {}
+
+  ngAfterViewInit() {
+    this.map = L.map('atlas-map').setView([36.5, 33], 7);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(this.map);
+
+    const route = this.cities.map(c => c.position);
+    L.polyline(route, {
+      color: '#dc2626',
+      weight: 3,
+      opacity: 0.6,
+      dashArray: '10,5'
+    }).addTo(this.map);
+
+    this.cities.forEach((city, idx) => {
+      const icon = this.createIcon('#3b82f6');
+      const marker = L.marker(city.position, { icon }).addTo(this.map);
+      marker.on('click', () => this.selectCity(city));
+      marker.bindTooltip(`${idx + 1}. ${city.name}`, { permanent: true, direction: 'top', offset: [0, -20] });
+      this.markers[city.id] = marker;
+    });
+  }
+
+  selectCity(city: City) {
+    this.selectedCity = city;
+    Object.entries(this.markers).forEach(([id, marker]) => {
+      marker.setIcon(this.createIcon(id === city.id ? '#dc2626' : '#3b82f6', this.memorized.has(id)));
+    });
+  }
+
+  toggleMemorized(cityId: string) {
+    if (this.memorized.has(cityId)) {
+      this.memorized.delete(cityId);
+    } else {
+      this.memorized.add(cityId);
+    }
+    this.selectCity(this.cities.find(c => c.id === cityId)!);
+  }
+
+  createIcon(color: string, isMemorized = false): L.DivIcon {
+    const styles = `
+      background-color: ${color};
+      width: 2rem;
+      height: 2rem;
+      display: block;
+      left: -1rem;
+      top: -1rem;
+      position: relative;
+      border-radius: 2rem 2rem 0;
+      transform: rotate(45deg);
+      border: 2px solid ${isMemorized ? '#10b981' : '#FFFFFF'};
+      box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    `;
+    return L.divIcon({
+      className: 'custom-pin',
+      iconAnchor: [16, 32],
+      labelAnchor: [-6, 0],
+      popupAnchor: [0, -32],
+      html: `<span style="${styles}" />`
+    });
+  }
+}

--- a/frontend/src/app/shared/components/navigation/navigation.component.html
+++ b/frontend/src/app/shared/components/navigation/navigation.component.html
@@ -127,6 +127,14 @@
           >
             🎓 Courses
           </a>
+          <a
+            routerLink="/atlas"
+            class="dropdown-item"
+            routerLinkActive="active"
+            (click)="closeMenu()"
+          >
+            🗺️ Scripture Atlas
+          </a>
         </div>
       </div>
 

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -4,7 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": ["leaflet"]
   },
   "files": ["src/main.ts", "src/main.server.ts", "src/server.ts"],
   "include": ["src/**/*.d.ts"],


### PR DESCRIPTION
## Summary
- add new Scripture Atlas component based on Paul's first missionary journey
- register `/atlas` route and link it under the Learning menu
- include Leaflet styles and types
- add Leaflet dependency

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686731c7a9c48331afa1065e56ef106c