### PR TITLE
Improve atlas layout columns

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -12,9 +12,9 @@
 // Main Content Area
 .app-content {
   flex: 1;
-  max-width: 1200px;
   width: 100%;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   padding: 20px;
   
   // Smooth page transitions

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
@@ -155,46 +155,6 @@
         </div>
       </div>
 
-      <!-- City Info Overlay -->
-      <div class="city-info-overlay" *ngIf="selectedCity" [@slideIn]>
-        <div class="city-header">
-          <h2>{{ selectedCity.name }}</h2>
-          <p class="city-modern">{{ selectedCity.modern }}</p>
-        </div>
-        
-        <div class="city-content">
-          <p class="city-description">{{ selectedCity.description }}</p>
-          
-          <div class="city-events" *ngIf="selectedCity.events.length">
-            <h4>Key Events</h4>
-            <ul>
-              <li *ngFor="let event of selectedCity.events">{{ event }}</li>
-            </ul>
-          </div>
-
-          <div class="city-fact">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-            </svg>
-            <p>{{ selectedCity.keyFact }}</p>
-          </div>
-        </div>
-
-        <div class="city-footer">
-          <button class="action-btn primary" (click)="toggleMemorized(selectedCity.id)" [class.completed]="memorized.has(selectedCity.id)">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-            </svg>
-            {{ memorized.has(selectedCity.id) ? 'Memorized' : 'Memorize' }}
-          </button>
-          <button class="action-btn" (click)="nextCity()">
-            Next
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-        </div>
-      </div>
 
       <!-- Playback Progress -->
       <div class="playback-progress" *ngIf="isPlaying">
@@ -213,5 +173,48 @@
         <span class="progress-text">{{ currentCityIndex + 1 }}/{{ cities.length }}</span>
       </div>
     </div>
+    <!-- Close map area -->
   </div>
+
+  <!-- Right Sidebar (City Info) -->
+  <aside class="city-info-panel" *ngIf="selectedCity" [@slideIn]>
+    <div class="city-header">
+      <h2>{{ selectedCity.name }}</h2>
+      <p class="city-modern">{{ selectedCity.modern }}</p>
+    </div>
+
+    <div class="city-content">
+      <p class="city-description">{{ selectedCity.description }}</p>
+
+      <div class="city-events" *ngIf="selectedCity.events.length">
+        <h4>Key Events</h4>
+        <ul>
+          <li *ngFor="let event of selectedCity.events">{{ event }}</li>
+        </ul>
+      </div>
+
+      <div class="city-fact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+        </svg>
+        <p>{{ selectedCity.keyFact }}</p>
+      </div>
+    </div>
+
+    <div class="city-footer">
+      <button class="action-btn primary" (click)="toggleMemorized(selectedCity.id)" [class.completed]="memorized.has(selectedCity.id)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+        {{ memorized.has(selectedCity.id) ? 'Memorized' : 'Memorize' }}
+      </button>
+      <button class="action-btn" (click)="nextCity()">
+        Next
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  </aside>
+</div>
 </div>

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.scss
@@ -301,22 +301,18 @@ $gray-900: #111827;
 
 // Left Sidebar (Scripture) - Overlay style
 .sidebar-left {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
   height: 100%;
-  width: $sidebar-width;
+  width: 0;
+  flex-shrink: 0;
   background: white;
   border-right: 1px solid $gray-200;
   box-shadow: 4px 0 6px 0 rgb(0 0 0 / 0.1);
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
   overflow: hidden;
-  // ensure scripture panel overlays the map
-  z-index: 1200;
-  
+  transition: width 0.3s ease;
+
   &.open {
-    transform: translateX(0);
+    width: $sidebar-width;
   }
 }
 
@@ -461,19 +457,16 @@ $gray-900: #111827;
   box-shadow: 0 2px 4px 0 rgb(0 0 0 / 0.1);
 }
 
-// City Info Overlay
-.city-info-overlay {
-  position: absolute;
-  bottom: 1.5rem;
-  right: 1.5rem;
+// Right Sidebar - City Info
+.city-info-panel {
+  position: relative;
+  height: 100%;
   width: 320px;
-  max-width: calc(100% - 3rem);
-  max-height: calc(100% - 3rem);
+  flex-shrink: 0;
   background: white;
-  border-radius: 0.75rem;
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+  border-left: 1px solid $gray-200;
+  box-shadow: -4px 0 6px 0 rgb(0 0 0 / 0.1);
   overflow: hidden;
-  z-index: 50;
   display: flex;
   flex-direction: column;
 }
@@ -660,7 +653,7 @@ $gray-900: #111827;
     gap: 1rem;
   }
   
-  .city-info-overlay {
+  .city-info-panel {
     width: 280px;
   }
 }
@@ -699,7 +692,8 @@ $gray-900: #111827;
     }
   }
   
-  .city-info-overlay {
+  .city-info-panel {
+    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
## Summary
- allocate left and right sidebars in scripture atlas
- remove overlay behavior so map isn't hidden
- let app content span full page width

## Testing
- `python3 services/test_api.py` *(fails: ModuleNotFoundError)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674cc2b5288331b236288af828594a