### PR TITLE
Refactor scripture atlas into components

### DIFF
--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
@@ -89,7 +89,14 @@
       <div class="timeline-markers">
         <ng-content select="[timeline-markers]"></ng-content>
       </div>
-      <input type="range" class="timeline-slider" min="0" [max]="citiesLength - 1" [value]="currentCityIndex" (input)="timelineChange.emit(($event.target as HTMLInputElement).valueAsNumber)" />
+      <input
+        type="range"
+        class="timeline-slider"
+        min="0"
+        [max]="citiesLength - 1"
+        [value]="currentCityIndex"
+        (input)="timelineChange.emit($any($event.target).valueAsNumber)"
+      />
     </div>
   </div>
 </header>

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
@@ -1,0 +1,95 @@
+<header class="atlas-header">
+  <div class="header-content">
+    <div class="header-left">
+      <h1 class="main-title">
+        <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <select class="journey-select" name="journey" [(ngModel)]="selectedJourneyId" [ngModelOptions]="{standalone: true}" (change)="journeyChange.emit(selectedJourneyId!)">
+          <option *ngFor="let j of journeys" [ngValue]="j.id">{{ j.name }}</option>
+        </select>
+      </h1>
+      <div class="journey-info">
+        <span class="info-badge">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          {{ formatYearRange(selectedJourney?.start_year, selectedJourney?.end_year) }}
+        </span>
+        <span class="info-badge">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          {{ selectedJourney?.scripture_refs }}
+        </span>
+        <span class="info-badge highlight">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+          </svg>
+          <strong>{{ currentDistance }}</strong> miles
+        </span>
+      </div>
+    </div>
+
+    <div class="header-right">
+      <div class="header-stats">
+        <div class="stat-item">
+          <span class="stat-value">{{ currentCityIndex + 1 }}</span>
+          <span class="stat-label">of {{ citiesLength }}</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">{{ memorizedCount }}</span>
+          <span class="stat-label">memorized</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">{{ progressPercentage }}%</span>
+          <span class="stat-label">complete</span>
+        </div>
+      </div>
+
+      <div class="header-controls">
+        <button class="control-btn" [class.active]="isPlaying" (click)="togglePlayback.emit()" title="Play Journey">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path *ngIf="!isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+            <path *ngIf="!isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <path *ngIf="isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="btn-label">{{ isPlaying ? 'Pause' : 'Play' }}</span>
+        </button>
+
+        <button class="control-btn" [class.active]="terrainView" (click)="toggleTerrain.emit()" title="Toggle Terrain">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <span class="btn-label">Terrain</span>
+        </button>
+
+        <button class="control-btn" [class.active]="splitView" (click)="toggleSplit.emit()" title="Split View">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
+          </svg>
+          <span class="btn-label">Split</span>
+        </button>
+
+        <button class="control-btn" [class.active]="sidebarOpen" (click)="toggleSidebar.emit()" title="Info Panel">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="btn-label">Info</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="timeline-bar">
+    <div class="timeline-track">
+      <div class="timeline-progress" [style.width.%]="timelineProgress"></div>
+      <div class="timeline-markers">
+        <ng-content select="[timeline-markers]"></ng-content>
+      </div>
+      <input type="range" class="timeline-slider" min="0" [max]="citiesLength - 1" [value]="currentCityIndex" (input)="timelineChange.emit(($event.target as HTMLInputElement).valueAsNumber)" />
+    </div>
+  </div>
+</header>

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.html
@@ -2,7 +2,7 @@
   <div class="header-content">
     <div class="header-left">
       <h1 class="main-title">
-        <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" width="24" height="24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <select class="journey-select" name="journey" [(ngModel)]="selectedJourneyId" [ngModelOptions]="{standalone: true}" (change)="journeyChange.emit(selectedJourneyId!)">
@@ -11,19 +11,19 @@
       </h1>
       <div class="journey-info">
         <span class="info-badge">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
           {{ formatYearRange(selectedJourney?.start_year, selectedJourney?.end_year) }}
         </span>
         <span class="info-badge">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
           </svg>
           {{ selectedJourney?.scripture_refs }}
         </span>
         <span class="info-badge highlight">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
           </svg>
           <strong>{{ currentDistance }}</strong> miles
@@ -49,7 +49,7 @@
 
       <div class="header-controls">
         <button class="control-btn" [class.active]="isPlaying" (click)="togglePlayback.emit()" title="Play Journey">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path *ngIf="!isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
             <path *ngIf="!isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             <path *ngIf="isPlaying" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -58,7 +58,7 @@
         </button>
 
         <button class="control-btn" [class.active]="terrainView" (click)="toggleTerrain.emit()" title="Toggle Terrain">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
@@ -66,7 +66,7 @@
         </button>
 
         <button class="control-btn" [class.active]="splitView" (click)="toggleSplit.emit()" title="Split View">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
           </svg>
@@ -74,7 +74,7 @@
         </button>
 
         <button class="control-btn" [class.active]="sidebarOpen" (click)="toggleSidebar.emit()" title="Info Panel">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <span class="btn-label">Info</span>

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.ts
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.ts
@@ -1,0 +1,50 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Journey } from '../../../core/services/atlas.service';
+
+@Component({
+  selector: 'app-scripture-atlas-header',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './scripture-atlas-header.component.html',
+})
+export class ScriptureAtlasHeaderComponent {
+  @Input() journeys: Journey[] = [];
+  @Input() selectedJourneyId: number | null = null;
+  @Input() selectedJourney: Journey | undefined;
+  @Input() isPlaying = false;
+  @Input() terrainView = false;
+  @Input() splitView = false;
+  @Input() sidebarOpen = true;
+  @Input() timelineProgress = 0;
+  @Input() currentCityIndex = 0;
+  @Input() citiesLength = 0;
+  @Input() memorizedCount = 0;
+  @Input() progressPercentage = 0;
+  @Input() currentDistance = 0;
+
+  @Output() journeyChange = new EventEmitter<number>();
+  @Output() togglePlayback = new EventEmitter<void>();
+  @Output() toggleTerrain = new EventEmitter<void>();
+  @Output() toggleSplit = new EventEmitter<void>();
+  @Output() toggleSidebar = new EventEmitter<void>();
+
+  @Output() timelineChange = new EventEmitter<number>();
+
+  formatYear(year: number | undefined): string {
+    if (year == null) {
+      return '';
+    }
+    return year < 0 ? `${Math.abs(year)} BC` : `${year} AD`;
+  }
+
+  formatYearRange(start?: number, end?: number): string {
+    if (start == null || end == null) {
+      return '';
+    }
+    const startStr = this.formatYear(start);
+    const endStr = this.formatYear(end);
+    return startStr === endStr ? startStr : `${startStr} - ${endStr}`;
+  }
+}

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.ts
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-header.component.ts
@@ -8,6 +8,7 @@ import { Journey } from '../../../core/services/atlas.service';
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './scripture-atlas-header.component.html',
+  styleUrls: ['../scripture-atlas.component.scss'],
 })
 export class ScriptureAtlasHeaderComponent {
   @Input() journeys: Journey[] = [];

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.html
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.html
@@ -1,0 +1,65 @@
+<aside class="sidebar" [class.collapsed]="!sidebarOpen" *ngIf="selectedCity">
+  <div class="sidebar-wrapper">
+    <div class="sidebar-tabs">
+      <button class="tab-btn" [class.active]="sidebarView === 'scripture'" (click)="sidebarViewChange.emit('scripture')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        </svg>
+        Scripture
+      </button>
+      <button class="tab-btn" [class.active]="sidebarView === 'city'" (click)="sidebarViewChange.emit('city')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+        </svg>
+        City Info
+      </button>
+      <button class="close-btn" (click)="close.emit()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="sidebar-content" *ngIf="sidebarView === 'scripture'">
+      <div class="content-header">
+        <h2>{{ selectedCity.name }}</h2>
+        <p class="verse-reference">{{ selectedCity.verses?.join(', ') }}</p>
+      </div>
+      <div class="verse-text" [innerHTML]="currentScriptureText"></div>
+      <div class="content-footer">
+        <button class="action-btn primary" (click)="toggleMemorized.emit(selectedCity!.id)" [class.completed]="memorized.has(selectedCity!.id)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          {{ memorized.has(selectedCity!.id) ? 'Memorized' : 'Memorize' }}
+        </button>
+        <button class="action-btn" (click)="markVersesAsRead.emit()" [class.completed]="versesRead.has(selectedCity!.id)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {{ versesRead.has(selectedCity!.id) ? 'Read ✓' : 'Mark as Read' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="sidebar-content" *ngIf="sidebarView === 'city'">
+      <div class="content-header">
+        <h2>{{ selectedCity.name }}</h2>
+        <p class="city-modern">{{ selectedCity.modern }}</p>
+      </div>
+      <div class="city-description">{{ selectedCity.description }}</div>
+      <div class="city-events" *ngIf="selectedCity.events?.length">
+        <h4>Key Events</h4>
+        <ul>
+          <li *ngFor="let event of selectedCity.events">{{ event }}</li>
+        </ul>
+      </div>
+      <div class="city-fact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+        </svg>
+        <p>{{ selectedCity.keyFact }}</p>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.html
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.html
@@ -2,19 +2,19 @@
   <div class="sidebar-wrapper">
     <div class="sidebar-tabs">
       <button class="tab-btn" [class.active]="sidebarView === 'scripture'" (click)="sidebarViewChange.emit('scripture')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
         </svg>
         Scripture
       </button>
       <button class="tab-btn" [class.active]="sidebarView === 'city'" (click)="sidebarViewChange.emit('city')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
         </svg>
         City Info
       </button>
       <button class="close-btn" (click)="close.emit()">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
@@ -28,13 +28,13 @@
       <div class="verse-text" [innerHTML]="currentScriptureText"></div>
       <div class="content-footer">
         <button class="action-btn primary" (click)="toggleMemorized.emit(selectedCity!.id)" [class.completed]="memorized.has(selectedCity!.id)">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
           </svg>
           {{ memorized.has(selectedCity!.id) ? 'Memorized' : 'Memorize' }}
         </button>
         <button class="action-btn" (click)="markVersesAsRead.emit()" [class.completed]="versesRead.has(selectedCity!.id)">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           {{ versesRead.has(selectedCity!.id) ? 'Read ✓' : 'Mark as Read' }}
@@ -55,7 +55,7 @@
         </ul>
       </div>
       <div class="city-fact">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="16" height="16">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
         </svg>
         <p>{{ selectedCity.keyFact }}</p>

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.ts
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { City } from '../../../core/services/atlas.service';
+
+@Component({
+  selector: 'app-scripture-atlas-sidebar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './scripture-atlas-sidebar.component.html',
+})
+export class ScriptureAtlasSidebarComponent {
+  @Input() sidebarOpen = true;
+  @Input() sidebarView: 'scripture' | 'city' = 'scripture';
+  @Input() selectedCity: City | null = null;
+  @Input() memorized = new Set<string>();
+  @Input() versesRead = new Set<string>();
+  @Input() currentScriptureText = '';
+
+  @Output() sidebarViewChange = new EventEmitter<'scripture' | 'city'>();
+  @Output() close = new EventEmitter<void>();
+  @Output() toggleMemorized = new EventEmitter<string>();
+  @Output() markVersesAsRead = new EventEmitter<void>();
+}

--- a/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.ts
+++ b/frontend/src/app/features/scripture-atlas/components/scripture-atlas-sidebar.component.ts
@@ -7,6 +7,7 @@ import { City } from '../../../core/services/atlas.service';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './scripture-atlas-sidebar.component.html',
+  styleUrls: ['../scripture-atlas.component.scss'],
 })
 export class ScriptureAtlasSidebarComponent {
   @Input() sidebarOpen = true;

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
@@ -18,7 +18,7 @@
     (toggleTerrain)="toggleTerrainView()"
     (toggleSplit)="toggleSplitView()"
     (toggleSidebar)="toggleSidebar()"
-    (timelineChange)="onTimelineChange({ target: { value: $event } } as any)"
+    (timelineChange)="onTimelineChange($event)"
   >
     <ng-container timeline-markers>
       <div

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.html
@@ -1,345 +1,56 @@
 <div class="atlas-container">
-  <!-- Fixed Header - Full Width -->
-  <header class="atlas-header">
-    <!-- Title and Meta Info -->
-    <div class="header-content">
-      <div class="header-left">
-        <h1 class="main-title">
-          <svg
-            class="title-icon"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          <select
-            class="journey-select"
-            name="journey"
-            [(ngModel)]="selectedJourneyId"
-            [ngModelOptions]="{standalone: true}"
-            (change)="loadJourney(selectedJourneyId!)"
-          >
-            <option *ngFor="let j of journeys" [ngValue]="j.id">
-              {{ j.name }}
-            </option>
-          </select>
-        </h1>
-        <div class="journey-info">
-          <span class="info-badge">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-            {{
-              formatYearRange(
-                selectedJourney?.start_year,
-                selectedJourney?.end_year
-              )
-            }}
-          </span>
-          <span class="info-badge">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-              />
-            </svg>
-            {{ selectedJourney?.scripture_refs }}
-          </span>
-          <span class="info-badge highlight">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-              />
-            </svg>
-            <strong>{{ currentDistance }}</strong> miles
-          </span>
-        </div>
+  <app-scripture-atlas-header
+    [journeys]="journeys"
+    [selectedJourneyId]="selectedJourneyId"
+    [selectedJourney]="selectedJourney"
+    [isPlaying]="isPlaying"
+    [terrainView]="terrainView"
+    [splitView]="splitView"
+    [sidebarOpen]="sidebarOpen"
+    [timelineProgress]="timelineProgress"
+    [currentCityIndex]="currentCityIndex"
+    [citiesLength]="cities.length"
+    [memorizedCount]="memorized.size"
+    [progressPercentage]="getProgressPercentage()"
+    [currentDistance]="currentDistance"
+    (journeyChange)="loadJourney($event)"
+    (togglePlayback)="toggleJourneyPlayback()"
+    (toggleTerrain)="toggleTerrainView()"
+    (toggleSplit)="toggleSplitView()"
+    (toggleSidebar)="toggleSidebar()"
+    (timelineChange)="onTimelineChange({ target: { value: $event } } as any)"
+  >
+    <ng-container timeline-markers>
+      <div
+        *ngFor="let city of cities; index as i"
+        class="timeline-marker"
+        [class.visited]="i <= currentCityIndex"
+        [class.active]="selectedCity?.id === city.id"
+        [class.memorized]="memorized.has(city.id)"
+        [style.left.%]="(i / (cities.length - 1)) * 100"
+        (click)="selectCity(city)"
+        [title]="city.name"
+      >
+        <div class="marker-dot"></div>
+        <div class="marker-label">{{ i + 1 }}</div>
       </div>
-
-      <div class="header-right">
-        <div class="header-stats">
-          <div class="stat-item">
-            <span class="stat-value">{{ currentCityIndex + 1 }}</span>
-            <span class="stat-label">of {{ cities.length }}</span>
-          </div>
-          <div class="stat-item">
-            <span class="stat-value">{{ memorized.size }}</span>
-            <span class="stat-label">memorized</span>
-          </div>
-          <div class="stat-item">
-            <span class="stat-value">{{ getProgressPercentage() }}%</span>
-            <span class="stat-label">complete</span>
-          </div>
-        </div>
-
-        <div class="header-controls">
-          <button
-            class="control-btn"
-            [class.active]="isPlaying"
-            (click)="toggleJourneyPlayback()"
-            title="Play Journey"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                *ngIf="!isPlaying"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-              />
-              <path
-                *ngIf="!isPlaying"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-              <path
-                *ngIf="isPlaying"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <span class="btn-label">{{ isPlaying ? "Pause" : "Play" }}</span>
-          </button>
-
-          <button
-            class="control-btn"
-            [class.active]="terrainView"
-            (click)="toggleTerrainView()"
-            title="Toggle Terrain"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-            <span class="btn-label">Terrain</span>
-          </button>
-
-          <button
-            class="control-btn"
-            [class.active]="splitView"
-            (click)="toggleSplitView()"
-            title="Split View"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"
-              />
-            </svg>
-            <span class="btn-label">Split</span>
-          </button>
-
-          <button
-            class="control-btn"
-            [class.active]="sidebarOpen"
-            (click)="toggleSidebar()"
-            title="Info Panel"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <span class="btn-label">Info</span>
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Timeline -->
-    <div class="timeline-bar">
-      <div class="timeline-track">
-        <div class="timeline-progress" [style.width.%]="timelineProgress"></div>
-        <div class="timeline-markers">
-          <div
-            *ngFor="let city of cities; index as i"
-            class="timeline-marker"
-            [class.visited]="i <= currentCityIndex"
-            [class.active]="selectedCity?.id === city.id"
-            [class.memorized]="memorized.has(city.id)"
-            [style.left.%]="(i / (cities.length - 1)) * 100"
-            (click)="selectCity(city)"
-            [title]="city.name"
-          >
-            <div class="marker-dot"></div>
-            <div class="marker-label">{{ i + 1 }}</div>
-          </div>
-        </div>
-        <input
-          type="range"
-          class="timeline-slider"
-          min="0"
-          [max]="cities.length - 1"
-          [value]="currentCityIndex"
-          (input)="onTimelineChange($event)"
-        />
-      </div>
-    </div>
-  </header>
+    </ng-container>
+  </app-scripture-atlas-header>
 
   <!-- Main Layout -->
   <div class="atlas-main">
-    <!-- Left Sidebar (Combined Scripture & City Info) -->
-    <aside class="sidebar" [class.collapsed]="!sidebarOpen">
-      <div class="sidebar-wrapper" *ngIf="selectedCity">
-        <!-- Toggle Buttons -->
-        <div class="sidebar-tabs">
-          <button
-            class="tab-btn"
-            [class.active]="sidebarView === 'scripture'"
-            (click)="sidebarView = 'scripture'"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-              />
-            </svg>
-            Scripture
-          </button>
-          <button
-            class="tab-btn"
-            [class.active]="sidebarView === 'city'"
-            (click)="sidebarView = 'city'"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-              />
-            </svg>
-            City Info
-          </button>
-          <button class="close-btn" (click)="sidebarOpen = false">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <!-- Scripture View -->
-        <div class="sidebar-content" *ngIf="sidebarView === 'scripture'">
-          <div class="content-header">
-            <h2>{{ selectedCity.name }}</h2>
-            <p class="verse-reference">{{ selectedCity.verses?.join(', ') }}</p>
-          </div>
-
-          <div class="verse-text" [innerHTML]="currentScriptureText"></div>
-
-          <div class="content-footer">
-            <button
-              class="action-btn primary"
-              (click)="toggleMemorized(selectedCity.id)"
-              [class.completed]="memorized.has(selectedCity.id)"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              {{ memorized.has(selectedCity.id) ? "Memorized" : "Memorize" }}
-            </button>
-            <button
-              class="action-btn"
-              (click)="markVersesAsRead()"
-              [class.completed]="versesRead.has(selectedCity.id)"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              {{ versesRead.has(selectedCity.id) ? "Read ✓" : "Mark as Read" }}
-            </button>
-          </div>
-        </div>
-
-        <!-- City Info View -->
-        <div class="sidebar-content" *ngIf="sidebarView === 'city'">
-          <div class="content-header">
-            <h2>{{ selectedCity.name }}</h2>
-            <p class="city-modern">{{ selectedCity.modern }}</p>
-          </div>
-
-          <div class="city-description">{{ selectedCity.description }}</div>
-
-          <div class="city-events" *ngIf="selectedCity.events?.length">
-            <h4>Key Events</h4>
-            <ul>
-              <li *ngFor="let event of selectedCity.events">{{ event }}</li>
-            </ul>
-          </div>
-
-          <div class="city-fact">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-              />
-            </svg>
-            <p>{{ selectedCity.keyFact }}</p>
-          </div>
-        </div>
-      </div>
-    </aside>
+    <app-scripture-atlas-sidebar
+      [sidebarOpen]="sidebarOpen"
+      [sidebarView]="sidebarView"
+      [selectedCity]="selectedCity"
+      [memorized]="memorized"
+      [versesRead]="versesRead"
+      [currentScriptureText]="currentScriptureText"
+      (sidebarViewChange)="sidebarView = $event"
+      (close)="sidebarOpen = false"
+      (toggleMemorized)="toggleMemorized($event)"
+      (markVersesAsRead)="markVersesAsRead()"
+    ></app-scripture-atlas-sidebar>
 
     <!-- Map Area (Full Width) -->
     <div class="map-area">

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
@@ -7,6 +7,8 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ScriptureAtlasHeaderComponent } from './components/scripture-atlas-header.component';
+import { ScriptureAtlasSidebarComponent } from './components/scripture-atlas-sidebar.component';
 import {
   trigger,
   style,
@@ -28,7 +30,12 @@ interface Particle {
 @Component({
   selector: 'app-scripture-atlas',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ScriptureAtlasHeaderComponent,
+    ScriptureAtlasSidebarComponent,
+  ],
   templateUrl: './scripture-atlas.component.html',
   styleUrls: ['./scripture-atlas.component.scss'],
   animations: [

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
@@ -582,9 +582,7 @@ export class ScriptureAtlasComponent
     }
   }
 
-  onTimelineChange(event: Event) {
-    const target = event.target as HTMLInputElement;
-    const index = parseInt(target.value);
+  onTimelineChange(index: number) {
     if (index >= 0 && index < this.cities.length) {
       this.selectCity(this.cities[index]);
     }

--- a/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
+++ b/frontend/src/app/features/scripture-atlas/scripture-atlas.component.ts
@@ -218,13 +218,15 @@ export class ScriptureAtlasComponent
       this.initializeAncientMap();
     }
 
-    // Add route and markers
-    this.drawJourneyRoute(this.modernMap, this.markers);
-    this.addCityMarkers(this.modernMap, this.markers);
+    if (this.cities.length) {
+      // Add route and markers
+      this.drawJourneyRoute(this.modernMap, this.markers);
+      this.addCityMarkers(this.modernMap, this.markers);
 
-    // Fit bounds
-    const bounds = L.latLngBounds(this.cities.map((c) => c.position));
-    this.modernMap.fitBounds(bounds.pad(0.1));
+      // Fit bounds
+      const bounds = L.latLngBounds(this.cities.map((c) => c.position));
+      this.modernMap.fitBounds(bounds.pad(0.1));
+    }
   }
 
   private initializeAncientMap() {
@@ -247,9 +249,11 @@ export class ScriptureAtlasComponent
       },
     ).addTo(this.ancientMap);
 
-    // Add route and markers
-    this.drawJourneyRoute(this.ancientMap, this.ancientMarkers, true);
-    this.addCityMarkers(this.ancientMap, this.ancientMarkers, true);
+    if (this.cities.length) {
+      // Add route and markers
+      this.drawJourneyRoute(this.ancientMap, this.ancientMarkers, true);
+      this.addCityMarkers(this.ancientMap, this.ancientMarkers, true);
+    }
 
     // Sync map movements
     this.modernMap.on('move', () => {
@@ -262,8 +266,10 @@ export class ScriptureAtlasComponent
       }
     });
 
-    const bounds = L.latLngBounds(this.cities.map((c) => c.position));
-    this.ancientMap.fitBounds(bounds.pad(0.1));
+    if (this.cities.length) {
+      const bounds = L.latLngBounds(this.cities.map((c) => c.position));
+      this.ancientMap.fitBounds(bounds.pad(0.1));
+    }
   }
 
   private drawJourneyRoute(map: any, markers: any, isAncient = false) {


### PR DESCRIPTION
## Summary
- break up Scripture Atlas page into header and sidebar components
- integrate new components into the main atlas page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7b36b0083318b9ae3fdc8c4b186