### PR TITLE
Fix FLOW UI width and verse picker sync

### DIFF
--- a/frontend/src/app/features/memorize/flow/components/flow-sidebar/flow-sidebar.component.scss
+++ b/frontend/src/app/features/memorize/flow/components/flow-sidebar/flow-sidebar.component.scss
@@ -66,6 +66,7 @@
       overflow-y: auto;
       overflow-x: hidden;
       padding-right: 0.5rem;
+      scrollbar-gutter: stable;
 
       &::-webkit-scrollbar {
         width: 4px;

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.scss
@@ -95,10 +95,12 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: 0;
   position: relative;
   min-height: 0;
+  scrollbar-gutter: stable;
 }
 
 .floating-notification {

--- a/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
+++ b/frontend/src/app/shared/components/verse-range-picker/verse-range-picker.component.ts
@@ -366,6 +366,15 @@ export class VersePickerComponent implements OnInit, OnChanges {
     if (!this.initialSelection || this.appliedInitial) return;
 
     const sel = this.initialSelection;
+    // Update the selected book and testament filter when initial selection changes
+    const newBook = this.allBooks.find(b => b.id === sel.startVerse.bookId);
+    if (newBook) {
+      this.testamentFilter = newBook.testament.isOld ? 'old' : 'new';
+      this.applyTestamentFilter();
+      this.selectedBook = this.books.find(b => b.id === newBook.id) || this.books[0];
+      this.loadChapters();
+    }
+
     this.mode = sel.mode;
     this.selectedChapter = sel.startVerse.chapter;
     this.selectedVerse = sel.startVerse.verse;


### PR DESCRIPTION
## Summary
- keep sidebar menu width stable by reserving scrollbar space
- allow modal body text to scroll
- sync verse picker book & chapter with Flow navigation

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681a06949c8331980e517c2d352d8c