### PR TITLE
Fix Bible dropdown fallback

### DIFF
--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -176,6 +176,38 @@ export class ProfileComponent implements OnInit {
         if (!language) {
           this.languages = [];
         }
+        // Attempt to load static fallback data
+        this.loadBiblesFromAssets(language);
+      }
+    });
+  }
+
+  private loadBiblesFromAssets(language?: string): void {
+    this.http.get<any>('assets/data/bible-versions.json').subscribe({
+      next: data => {
+        const versions = Array.isArray(data.versions) ? data.versions : [];
+
+        const langOption: LanguageOption = { id: 'eng', name: 'English', nameLocal: 'English' };
+        if (!language) {
+          this.languages = [langOption];
+        }
+
+        const mapped: BibleVersion[] = versions.map((v: any) => ({
+          id: v.id,
+          name: v.name,
+          abbreviation: v.abbreviation,
+          abbreviationLocal: v.abbreviation,
+          language: v.language,
+          languageId: 'eng',
+          description: v.description
+        }));
+
+        this.availableBibles = mapped.filter(b => !language || b.languageId === language);
+        this.matchCurrentBible();
+        this.loadingBibles = false;
+      },
+      error: () => {
+        console.error('Failed to load local Bible data');
         this.loadingBibles = false;
       }
     });

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: '/api'
+  apiUrl: '/api',
   mapboxToken: 'YOUR_MAPBOX_TOKEN_HERE'
 };


### PR DESCRIPTION
## Summary
- add fallback to load local bible versions if API request fails
- fix JSON syntax in production environment config

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `python3 services/test_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c300fa9e88331a37f4249b7a757a2