### PR TITLE
Add practice session state management

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -14,6 +14,8 @@ import { bibleTrackerReducer } from './state/bible-tracker/reducers/bible-tracke
 import { BibleTrackerEffects } from './state/bible-tracker/effects/bible-tracker.effects';
 import { decksReducer } from './state/decks/reducers/deck.reducer';
 import { DeckEffects } from './state/decks/effects/deck.effects';
+import { practiceSessionReducer } from './state/practice-session/reducers/practice-session.reducer';
+import { PracticeSessionEffects } from './state/practice-session/effects/practice-session.effects';
 import { ConfigService } from './core/services/config.service';
 
 export const appConfig: ApplicationConfig = {
@@ -35,6 +37,7 @@ export const appConfig: ApplicationConfig = {
         router: routerReducer,
         bibleTracker: bibleTrackerReducer,
         decks: decksReducer,
+        practiceSession: practiceSessionReducer,
       },
       {
         metaReducers: isDevMode() ? metaReducers : [],
@@ -53,6 +56,7 @@ export const appConfig: ApplicationConfig = {
     provideEffects([
       BibleTrackerEffects,
       DeckEffects,
+      PracticeSessionEffects,
     ]),
 
     // Router Store

--- a/frontend/src/app/core/services/audio.service.ts
+++ b/frontend/src/app/core/services/audio.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AudioService {
+  private sounds: Map<string, HTMLAudioElement> = new Map();
+  
+  play(url: string): void {
+    const audio = new Audio(url);
+    audio.play().catch(error => console.error('Error playing audio:', error));
+  }
+  
+  playSound(soundName: string): void {
+    const soundMap: Record<string, string> = {
+      'session-complete': '/assets/sounds/complete.mp3',
+      'correct': '/assets/sounds/correct.mp3',
+      'incorrect': '/assets/sounds/incorrect.mp3'
+    };
+    
+    const soundUrl = soundMap[soundName];
+    if (soundUrl) {
+      this.play(soundUrl);
+    }
+  }
+}

--- a/frontend/src/app/core/services/practice.service.ts
+++ b/frontend/src/app/core/services/practice.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import {
+  StartSessionRequest,
+  ActiveSession,
+  SubmitResponseRequest,
+  CardResponse,
+  SessionSummary,
+  CompletedSession,
+  SessionType,
+  SessionState,
+  ResponseQuality
+} from '../../state/practice-session/models/practice-session.model';
+
+@Injectable({ providedIn: 'root' })
+export class PracticeService {
+  
+  startSession(request: StartSessionRequest): Observable<ActiveSession> {
+    const mockSession: ActiveSession = {
+      id: 'session-' + Date.now(),
+      deckId: request.deckId,
+      deckName: 'Mock Deck',
+      type: request.settings?.sessionType || SessionType.REVIEW,
+      cards: this.generateMockCards(request.settings?.cardLimit || 20),
+      currentIndex: 0,
+      responses: [],
+      startTime: new Date(),
+      settings: {
+        sessionType: SessionType.REVIEW,
+        cardLimit: 20,
+        timeLimit: null,
+        newCardsPerSession: 5,
+        reviewOrder: 'due_date' as any,
+        prioritizeDue: true,
+        includeNewCards: true,
+        showHints: true,
+        autoPlayAudio: false,
+        flipAnimation: true,
+        fontSize: 'medium',
+        immediateAnswerFeedback: true,
+        requireTypedAnswer: false,
+        caseSensitive: false,
+        showProgress: true,
+        easyBonus: 1.3,
+        intervalModifier: 1.0,
+        lapseMultiplier: 0.5,
+        minimumInterval: 1,
+        ...request.settings
+      },
+      state: SessionState.IN_PROGRESS
+    };
+    
+    return of(mockSession).pipe(delay(500));
+  }
+
+  submitResponse(request: SubmitResponseRequest): Observable<CardResponse> {
+    const response: CardResponse = {
+      cardId: request.cardId,
+      quality: request.quality,
+      responseTime: request.responseTime,
+      hintsUsed: request.hintsUsed,
+      audioPlayed: false,
+      timestamp: new Date(),
+      correct: request.quality >= ResponseQuality.GOOD,
+      newInterval: this.calculateNewInterval(request.quality),
+      newEaseFactor: this.calculateNewEaseFactor(request.quality)
+    };
+    
+    return of(response).pipe(delay(300));
+  }
+
+  completeSession(sessionId: string): Observable<SessionSummary> {
+    const mockSummary: SessionSummary = {
+      session: {
+        id: sessionId,
+        deckId: 1,
+        type: SessionType.REVIEW,
+        startTime: new Date(Date.now() - 15 * 60 * 1000),
+        endTime: new Date(),
+        duration: 900,
+        cardsStudied: 20,
+        correctCount: 18,
+        accuracy: 90,
+        averageResponseTime: 3.5,
+        masteryChange: 5,
+        streakMaintained: true
+      },
+      cardUpdates: [],
+      achievements: [],
+      nextReviewSummary: {
+        today: 5,
+        tomorrow: 10,
+        thisWeek: 25,
+        thisMonth: 50
+      }
+    };
+    
+    return of(mockSummary).pipe(delay(500));
+  }
+
+  getSessionHistory(): Observable<CompletedSession[]> {
+    return of([]).pipe(delay(300));
+  }
+
+  private generateMockCards(count: number): any[] {
+    return Array.from({ length: count }, (_, i) => ({
+      id: i + 1,
+      deckId: 1,
+      front: `Question ${i + 1}`,
+      back: `Answer ${i + 1}`,
+      hint: `Hint for question ${i + 1}`,
+      easeFactor: 2.5,
+      interval: 1,
+      repetitions: 0,
+      order: i,
+      seen: false
+    }));
+  }
+
+  private calculateNewInterval(quality: ResponseQuality): number {
+    switch (quality) {
+      case ResponseQuality.AGAIN: return 1;
+      case ResponseQuality.HARD: return 2;
+      case ResponseQuality.GOOD: return 4;
+      case ResponseQuality.EASY: return 7;
+      default: return 1;
+    }
+  }
+
+  private calculateNewEaseFactor(quality: ResponseQuality): number {
+    switch (quality) {
+      case ResponseQuality.AGAIN: return 1.3;
+      case ResponseQuality.HARD: return 2.0;
+      case ResponseQuality.GOOD: return 2.5;
+      case ResponseQuality.EASY: return 2.8;
+      default: return 2.5;
+    }
+  }
+}

--- a/frontend/src/app/state/app.state.ts
+++ b/frontend/src/app/state/app.state.ts
@@ -1,13 +1,14 @@
 import { RouterReducerState } from '@ngrx/router-store';
 import { BibleTrackerState } from './bible-tracker/models/bible-tracker.model';
 import { DecksState } from './decks/models/deck.model';
+import { PracticeSessionState } from './practice-session/models/practice-session.model';
 
 // Root state interface - all feature states will be added here
 export interface AppState {
   router: RouterReducerState;
   bibleTracker: BibleTrackerState;
   decks: DecksState;
-  // practiceSession: PracticeSessionState;
+  practiceSession: PracticeSessionState;
 }
 
 // Shared state interfaces used across features

--- a/frontend/src/app/state/index.ts
+++ b/frontend/src/app/state/index.ts
@@ -17,3 +17,4 @@ export * from './core/reducers/router.reducer';
 // Bible Tracker feature exports
 export * from './bible-tracker';
 export * from './decks';
+export * from './practice-session';

--- a/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
+++ b/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
@@ -1,0 +1,84 @@
+import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import {
+  StartSessionRequest,
+  ActiveSession,
+  CardResponse,
+  ResponseQuality,
+  PracticeSettings,
+  SessionSummary,
+  CompletedSession
+} from '../models/practice-session.model';
+
+export const PracticeSessionActions = createActionGroup({
+  source: 'Practice Session',
+  events: {
+    // Session Lifecycle
+    'Start Session': props<{ request: StartSessionRequest }>(),
+    'Start Session Success': props<{ session: ActiveSession }>(),
+    'Start Session Failure': props<{ error: string }>(),
+    
+    'Pause Session': emptyProps(),
+    'Resume Session': emptyProps(),
+    'End Session': emptyProps(),
+    'Abandon Session': emptyProps(),
+    
+    'Complete Session': emptyProps(),
+    'Complete Session Success': props<{ summary: SessionSummary }>(),
+    'Complete Session Failure': props<{ error: string }>(),
+    
+    // Card Actions
+    'Show Next Card': emptyProps(),
+    'Show Previous Card': emptyProps(),
+    'Flip Card': emptyProps(),
+    'Show Hint': emptyProps(),
+    'Play Audio': emptyProps(),
+    
+    // Response Submission
+    'Submit Response': props<{
+      cardId: number;
+      quality: ResponseQuality;
+      responseTime: number;
+      hintsUsed: number;
+    }>(),
+    'Submit Response Success': props<{ response: CardResponse }>(),
+    'Submit Response Failure': props<{ error: string }>(),
+    
+    // Skip Card
+    'Skip Card': props<{ cardId: number }>(),
+    'Skip Card Success': emptyProps(),
+    
+    // Settings
+    'Update Settings': props<{ settings: Partial<PracticeSettings> }>(),
+    'Save Settings': emptyProps(),
+    'Reset Settings': emptyProps(),
+    
+    // History
+    'Load Session History': emptyProps(),
+    'Load Session History Success': props<{ sessions: CompletedSession[] }>(),
+    'Load Session History Failure': props<{ error: string }>(),
+    
+    // UI Actions
+    'Toggle Stats': emptyProps(),
+    'Toggle Settings': emptyProps(),
+    'Show Feedback': props<{ message: string; level: 'success' | 'error' | 'info' }>(),
+    'Hide Feedback': emptyProps(),
+    
+    // Performance Updates
+    'Update Performance Metrics': emptyProps(),
+    'Calculate Session Stats': emptyProps(),
+  }
+});
+
+// Separate action group for keyboard shortcuts
+export const PracticeKeyboardActions = createActionGroup({
+  source: 'Practice Keyboard',
+  events: {
+    'Press Space': emptyProps(),      // Flip card
+    'Press Enter': emptyProps(),      // Submit/Next
+    'Press Number': props<{ key: number }>(), // Quality rating 1-4
+    'Press H': emptyProps(),          // Show hint
+    'Press S': emptyProps(),          // Skip card
+    'Press P': emptyProps(),          // Play audio
+    'Press Escape': emptyProps(),     // Pause/Settings
+  }
+});

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.spec.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.spec.ts
@@ -1,0 +1,658 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable, of, throwError, ReplaySubject } from 'rxjs';
+import { Store, StoreModule } from '@ngrx/store';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestScheduler } from 'rxjs/testing';
+import { take } from 'rxjs/operators';
+
+import { PracticeSessionEffects } from './practice-session.effects';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+import { practiceSessionReducer } from '../reducers/practice-session.reducer';
+import {
+  ActiveSession,
+  SessionType,
+  SessionState,
+  ResponseQuality,
+  CardResponse,
+  SessionSummary
+} from '../models/practice-session.model';
+import { PracticeService } from '@app/app/core/services/practice.service';
+import { AudioService } from '@app/app/core/services/audio.service';
+import { NotificationService } from '@app/app/core/services/notification.service';
+
+describe('PracticeSessionEffects', () => {
+  let actions$: ReplaySubject<any>;
+  let effects: PracticeSessionEffects;
+  let practiceService: jasmine.SpyObj<PracticeService>;
+  let audioService: jasmine.SpyObj<AudioService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+  let store: Store;
+  let testScheduler: TestScheduler;
+
+  const mockSession: ActiveSession = {
+    id: 'test-session-123',
+    deckId: 1,
+    deckName: 'Test Deck',
+    type: SessionType.REVIEW,
+    cards: [
+      {
+        id: 1,
+        deckId: 1,
+        front: 'Question 1',
+        back: 'Answer 1',
+        hint: 'Hint 1',
+        audioUrl: '/audio/card1.mp3',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 0,
+        seen: false
+      }
+    ],
+    currentIndex: 0,
+    responses: [],
+    startTime: new Date('2024-01-15T10:00:00'),
+    settings: {
+      sessionType: SessionType.REVIEW,
+      cardLimit: 20,
+      timeLimit: 30,
+      newCardsPerSession: 5,
+      reviewOrder: 'due_date' as any,
+      prioritizeDue: true,
+      includeNewCards: true,
+      showHints: true,
+      autoPlayAudio: true,
+      flipAnimation: true,
+      fontSize: 'medium',
+      immediateAnswerFeedback: true,
+      requireTypedAnswer: false,
+      caseSensitive: false,
+      showProgress: true,
+      easyBonus: 1.3,
+      intervalModifier: 1.0,
+      lapseMultiplier: 0.5,
+      minimumInterval: 1
+    },
+    state: SessionState.IN_PROGRESS
+  };
+
+  beforeEach(() => {
+    const practiceServiceSpy = jasmine.createSpyObj('PracticeService', [
+      'startSession',
+      'submitResponse',
+      'completeSession',
+      'getSessionHistory'
+    ]);
+
+    const audioServiceSpy = jasmine.createSpyObj('AudioService', [
+      'play',
+      'playSound'
+    ]);
+
+    const notificationServiceSpy = jasmine.createSpyObj('NotificationService', [
+      'success',
+      'error',
+      'warning',
+      'info'
+    ]);
+
+    actions$ = new ReplaySubject(1);
+
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({ practiceSession: practiceSessionReducer })
+      ],
+      providers: [
+        PracticeSessionEffects,
+        provideMockActions(() => actions$),
+        { provide: PracticeService, useValue: practiceServiceSpy },
+        { provide: AudioService, useValue: audioServiceSpy },
+        { provide: NotificationService, useValue: notificationServiceSpy }
+      ]
+    });
+
+    effects = TestBed.inject(PracticeSessionEffects);
+    practiceService = TestBed.inject(PracticeService) as jasmine.SpyObj<PracticeService>;
+    audioService = TestBed.inject(AudioService) as jasmine.SpyObj<AudioService>;
+    notificationService = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
+    store = TestBed.inject(Store);
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('startSession$', () => {
+    it('should return startSessionSuccess and show notification on success', (done) => {
+      const request = {
+        deckId: 1,
+        settings: { cardLimit: 20 }
+      };
+
+      practiceService.startSession.and.returnValue(of(mockSession));
+
+      actions$.next(PracticeSessionActions.startSession({ request }));
+
+      effects.startSession$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+        expect(practiceService.startSession).toHaveBeenCalledWith(request);
+        expect(notificationService.info).toHaveBeenCalledWith('Session started! Good luck!');
+        done();
+      });
+    });
+
+    it('should return startSessionFailure on API error', (done) => {
+      const error = new HttpErrorResponse({
+        error: { message: 'Deck not found' },
+        status: 404
+      });
+
+      practiceService.startSession.and.returnValue(throwError(() => error));
+
+      actions$.next(PracticeSessionActions.startSession({ request: { deckId: 999, settings: {} } }));
+
+      effects.startSession$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.startSessionFailure({
+          error: 'Resource not found'
+        }));
+        done();
+      });
+    });
+  });
+
+  describe('autoPlayAudio$', () => {
+    it('should play audio when card is flipped and auto-play is enabled', (done) => {
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+
+      actions$.next(PracticeSessionActions.flipCard());
+
+      effects.autoPlayAudio$.pipe(take(1)).subscribe(() => {
+        expect(audioService.play).toHaveBeenCalledWith('/audio/card1.mp3');
+        done();
+      });
+    });
+
+    it('should not play audio when auto-play is disabled', (done) => {
+      const sessionWithoutAutoPlay = {
+        ...mockSession,
+        settings: {
+          ...mockSession.settings,
+          autoPlayAudio: false
+        }
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: sessionWithoutAutoPlay }));
+
+      actions$.next(PracticeSessionActions.flipCard());
+
+      setTimeout(() => {
+        expect(audioService.play).not.toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+
+    it('should not play audio when card has no audio URL', (done) => {
+      const sessionWithoutAudio = {
+        ...mockSession,
+        cards: [{
+          ...mockSession.cards[0],
+          audioUrl: undefined
+        }]
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: sessionWithoutAudio }));
+
+      actions$.next(PracticeSessionActions.flipCard());
+
+      setTimeout(() => {
+        expect(audioService.play).not.toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+  });
+
+  describe('submitResponse$', () => {
+    it('should submit response and show success notification for correct answer', (done) => {
+      const mockResponse: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+      practiceService.submitResponse.and.returnValue(of(mockResponse));
+
+      actions$.next(PracticeSessionActions.submitResponse({
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0
+      }));
+
+      effects.submitResponse$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.submitResponseSuccess({ response: mockResponse }));
+        expect(notificationService.success).toHaveBeenCalledWith('Correct! 🎉', 1000);
+        done();
+      });
+    });
+
+    it('should show error notification for incorrect answer', (done) => {
+      const mockResponse: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.AGAIN,
+        responseTime: 3000,
+        hintsUsed: 1,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: false,
+        newInterval: 1,
+        newEaseFactor: 1.3
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+      practiceService.submitResponse.and.returnValue(of(mockResponse));
+
+      actions$.next(PracticeSessionActions.submitResponse({
+        cardId: 1,
+        quality: ResponseQuality.AGAIN,
+        responseTime: 3000,
+        hintsUsed: 1
+      }));
+
+      effects.submitResponse$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.submitResponseSuccess({ response: mockResponse }));
+        expect(notificationService.error).toHaveBeenCalledWith('Try again next time', 1000);
+        done();
+      });
+    });
+
+    it('should handle no active session', (done) => {
+      actions$.next(PracticeSessionActions.submitResponse({
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0
+      }));
+
+      effects.submitResponse$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.submitResponseFailure({
+          error: 'No active session'
+        }));
+        expect(practiceService.submitResponse).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('autoAdvance$', () => {
+    it('should complete session when no cards remain', (done) => {
+      const sessionLastCard = {
+        ...mockSession,
+        cards: [{
+          ...mockSession.cards[0],
+          seen: true
+        }]
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: sessionLastCard }));
+
+      const mockResponse: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      actions$.next(PracticeSessionActions.submitResponseSuccess({ response: mockResponse }));
+
+      setTimeout(() => {
+        effects.autoAdvance$.pipe(take(1)).subscribe(result => {
+          expect(result.type).toBe('[Practice Session] Complete Session');
+          done();
+        });
+      }, 1600);
+    });
+
+    it('should not auto-advance when immediate feedback is disabled', (done) => {
+      const sessionNoFeedback = {
+        ...mockSession,
+        settings: {
+          ...mockSession.settings,
+          immediateAnswerFeedback: false
+        }
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: sessionNoFeedback }));
+
+      const mockResponse: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      actions$.next(PracticeSessionActions.submitResponseSuccess({ response: mockResponse }));
+
+      let emitted = false;
+      effects.autoAdvance$.subscribe(() => {
+        emitted = true;
+      });
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 2000);
+    });
+  });
+
+  describe('completeSession$', () => {
+    it('should complete session and show notifications', (done) => {
+      const mockSummary: SessionSummary = {
+        session: {
+          id: 'test-session-123',
+          deckId: 1,
+          type: SessionType.REVIEW,
+          startTime: new Date('2024-01-15T10:00:00'),
+          endTime: new Date('2024-01-15T10:15:00'),
+          duration: 900,
+          cardsStudied: 20,
+          correctCount: 18,
+          accuracy: 90,
+          averageResponseTime: 3.5,
+          masteryChange: 5,
+          streakMaintained: true
+        },
+        cardUpdates: [],
+        achievements: [
+          {
+            id: 'first-perfect',
+            title: 'Perfect Session',
+            description: 'Complete a session with 100% accuracy',
+            icon: 'trophy',
+            unlockedAt: new Date()
+          }
+        ],
+        nextReviewSummary: {
+          today: 5,
+          tomorrow: 10,
+          thisWeek: 25,
+          thisMonth: 50
+        }
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+      practiceService.completeSession.and.returnValue(of(mockSummary));
+
+      actions$.next(PracticeSessionActions.completeSession());
+
+      effects.completeSession$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.completeSessionSuccess({ summary: mockSummary }));
+        expect(notificationService.success).toHaveBeenCalledWith(
+          'Session complete! 18/20 correct (90%)'
+        );
+        expect(audioService.playSound).toHaveBeenCalledWith('session-complete');
+        expect(notificationService.info).toHaveBeenCalledWith(
+          '🏆 Achievement Unlocked: Perfect Session',
+          5000
+        );
+        done();
+      });
+    });
+
+    it('should handle no active session', (done) => {
+      actions$.next(PracticeSessionActions.completeSession());
+
+      effects.completeSession$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.completeSessionFailure({
+          error: 'No active session'
+        }));
+        done();
+      });
+    });
+  });
+
+  describe('sessionTimer$', () => {
+    it('should complete session when time limit is reached', (done) => {
+      const sessionWithShortLimit = {
+        ...mockSession,
+        settings: {
+          ...mockSession.settings,
+          timeLimit: 0.01
+        }
+      };
+
+      actions$.next(PracticeSessionActions.startSessionSuccess({ session: sessionWithShortLimit }));
+
+      effects.sessionTimer$.pipe(take(1)).subscribe(result => {
+        expect(result.type).toBe('[Practice Session] Complete Session');
+        expect(notificationService.warning).toHaveBeenCalledWith('Time limit reached!');
+        done();
+      });
+    });
+
+    it('should not set timer when no time limit', (done) => {
+      const sessionNoLimit = {
+        ...mockSession,
+        settings: {
+          ...mockSession.settings,
+          timeLimit: null
+        }
+      };
+
+      actions$.next(PracticeSessionActions.startSessionSuccess({ session: sessionNoLimit }));
+
+      let emitted = false;
+      effects.sessionTimer$.subscribe(() => {
+        emitted = true;
+      });
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 100);
+    });
+
+    it('should cancel timer when session is completed', (done) => {
+      const sessionWithLimit = {
+        ...mockSession,
+        settings: {
+          ...mockSession.settings,
+          timeLimit: 1
+        }
+      };
+
+      actions$.next(PracticeSessionActions.startSessionSuccess({ session: sessionWithLimit }));
+
+      setTimeout(() => {
+        actions$.next(PracticeSessionActions.completeSession());
+      }, 100);
+
+      let timerEmitted = false;
+      effects.sessionTimer$.subscribe(() => {
+        timerEmitted = true;
+      });
+
+      setTimeout(() => {
+        expect(timerEmitted).toBe(false);
+        done();
+      }, 200);
+    });
+  });
+
+  describe('updateMetrics$', () => {
+    it('should periodically update performance metrics', (done) => {
+      actions$.next(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+
+      let updateCount = 0;
+      effects.updateMetrics$.pipe(take(2)).subscribe(result => {
+        expect(result.type).toBe('[Practice Session] Update Performance Metrics');
+        updateCount++;
+
+        if (updateCount === 2) {
+          done();
+        }
+      });
+    });
+
+    it('should stop updating when session is completed', (done) => {
+      actions$.next(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+
+      let updateCount = 0;
+      effects.updateMetrics$.subscribe(() => {
+        updateCount++;
+      });
+
+      setTimeout(() => {
+        actions$.next(PracticeSessionActions.completeSession());
+      }, 6000);
+
+      setTimeout(() => {
+        expect(updateCount).toBe(1);
+        done();
+      }, 12000);
+    });
+  });
+
+  describe('keyboardShortcuts$', () => {
+    it('should flip card when Enter pressed and card not flipped', (done) => {
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+
+      actions$.next(PracticeKeyboardActions.pressEnter());
+
+      effects.keyboardShortcuts$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.flipCard());
+        done();
+      });
+    });
+
+    it('should submit response when Enter pressed and card is flipped', (done) => {
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+      store.dispatch(PracticeSessionActions.flipCard());
+
+      actions$.next(PracticeKeyboardActions.pressEnter());
+
+      effects.keyboardShortcuts$.subscribe(result => {
+        expect(result.type).toBe('[Practice Session] Submit Response');
+        const action = result as any;
+        expect(action.cardId).toBe(1);
+        expect(action.quality).toBe(ResponseQuality.GOOD);
+        expect(action.hintsUsed).toBe(0);
+        done();
+      });
+    });
+
+    it('should count hints used when submitting response', (done) => {
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: mockSession }));
+      store.dispatch(PracticeSessionActions.flipCard());
+      store.dispatch(PracticeSessionActions.showHint());
+
+      actions$.next(PracticeKeyboardActions.pressEnter());
+
+      effects.keyboardShortcuts$.subscribe(result => {
+        const action = result as any;
+        expect(action.hintsUsed).toBe(1);
+        done();
+      });
+    });
+
+    it('should go to next card when Enter pressed and card already seen', (done) => {
+      const sessionWithSeenCard = {
+        ...mockSession,
+        cards: [{
+          ...mockSession.cards[0],
+          seen: true
+        }]
+      };
+
+      store.dispatch(PracticeSessionActions.startSessionSuccess({ session: sessionWithSeenCard }));
+      store.dispatch(PracticeSessionActions.flipCard());
+
+      actions$.next(PracticeKeyboardActions.pressEnter());
+
+      effects.keyboardShortcuts$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.showNextCard());
+        done();
+      });
+    });
+
+    it('should not emit when no session or card', (done) => {
+      actions$.next(PracticeKeyboardActions.pressEnter());
+
+      let emitted = false;
+      effects.keyboardShortcuts$.subscribe(() => {
+        emitted = true;
+      });
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 100);
+    });
+  });
+
+  describe('loadHistory$', () => {
+    it('should load session history successfully', (done) => {
+      const mockHistory = [
+        {
+          id: 'session-1',
+          deckId: 1,
+          type: SessionType.REVIEW,
+          startTime: new Date('2024-01-14'),
+          endTime: new Date('2024-01-14'),
+          duration: 600,
+          cardsStudied: 10,
+          correctCount: 8,
+          accuracy: 80,
+          averageResponseTime: 3,
+          masteryChange: 2,
+          streakMaintained: true
+        }
+      ];
+
+      practiceService.getSessionHistory.and.returnValue(of(mockHistory));
+
+      actions$.next(PracticeSessionActions.loadSessionHistory());
+
+      effects.loadHistory$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.loadSessionHistorySuccess({ sessions: mockHistory }));
+        expect(practiceService.getSessionHistory).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should handle error loading history', (done) => {
+      const error = new HttpErrorResponse({
+        error: { message: 'Failed to load history' },
+        status: 500
+      });
+
+      practiceService.getSessionHistory.and.returnValue(throwError(() => error));
+
+      actions$.next(PracticeSessionActions.loadSessionHistory());
+
+      effects.loadHistory$.subscribe(result => {
+        expect(result).toEqual(PracticeSessionActions.loadSessionHistoryFailure({
+          error: 'Server error. Please try again later'
+        }));
+        done();
+      });
+    });
+  });
+});

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -1,0 +1,272 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { of, interval, timer } from 'rxjs';
+import { 
+  map, 
+  mergeMap, 
+  catchError, 
+  withLatestFrom, 
+  tap, 
+  takeUntil,
+  filter 
+} from 'rxjs/operators';
+
+import { PracticeService } from '../../../core/services/practice.service';
+import { AudioService } from '../../../core/services/audio.service';
+import { NotificationService } from '../../../core/services/notification.service';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+import { 
+  selectActiveSession, 
+  selectCurrentCard,
+  selectSettings,
+  selectSessionProgress 
+} from '../selectors/practice-session.selectors';
+import { BaseEffect } from '../../core/effects/base.effect';
+import { ResponseQuality } from '../models/practice-session.model';
+
+@Injectable()
+export class PracticeSessionEffects extends BaseEffect {
+  
+  startSession$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSession),
+      mergeMap(({ request }) =>
+        this.practiceService.startSession(request).pipe(
+          map((session) => PracticeSessionActions.startSessionSuccess({ session })),
+          tap(() => {
+            this.notificationService.info('Session started! Good luck!');
+          }),
+          this.handleHttpError((error) => 
+            PracticeSessionActions.startSessionFailure({ error })
+          )
+        )
+      )
+    )
+  );
+
+  // Auto-play audio when card is flipped (if enabled)
+  autoPlayAudio$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.flipCard),
+      withLatestFrom(
+        this.store.select(selectCurrentCard),
+        this.store.select(selectSettings)
+      ),
+      filter(([_, card, settings]) => 
+        settings.autoPlayAudio && !!card?.audioUrl
+      ),
+      tap(([_, card]) => {
+        if (card?.audioUrl) {
+          this.audioService.play(card.audioUrl);
+        }
+      })
+    ),
+    { dispatch: false }
+  );
+
+  submitResponse$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.submitResponse),
+      withLatestFrom(this.store.select(selectActiveSession)),
+      mergeMap(([action, session]) => {
+        if (!session) {
+          return of(PracticeSessionActions.submitResponseFailure({ 
+            error: 'No active session' 
+          }));
+        }
+
+        return this.practiceService.submitResponse({
+          sessionId: session.id,
+          cardId: action.cardId,
+          quality: action.quality,
+          responseTime: action.responseTime,
+          hintsUsed: action.hintsUsed,
+        }).pipe(
+          map((response) => PracticeSessionActions.submitResponseSuccess({ response })),
+          tap((successAction) => {
+            // Show immediate feedback
+            if (successAction.response.correct) {
+              this.notificationService.success('Correct! 🎉', 1000);
+            } else {
+              this.notificationService.error('Try again next time', 1000);
+            }
+          }),
+          this.handleHttpError((error) => 
+            PracticeSessionActions.submitResponseFailure({ error })
+          )
+        );
+      })
+    )
+  );
+
+  // Auto-advance to next card after response
+  autoAdvance$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.submitResponseSuccess),
+      withLatestFrom(
+        this.store.select(selectSettings),
+        this.store.select(selectSessionProgress)
+      ),
+      filter(([_, settings]) => settings.immediateAnswerFeedback),
+      mergeMap(([_, __, progress]) => {
+        // Wait 1.5 seconds then advance
+        return timer(1500).pipe(
+          map(() => {
+            if (progress.remainingCards > 0) {
+              return PracticeSessionActions.showNextCard();
+            } else {
+              return PracticeSessionActions.completeSession();
+            }
+          })
+        );
+      })
+    )
+  );
+
+  completeSession$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.completeSession),
+      withLatestFrom(this.store.select(selectActiveSession)),
+      mergeMap(([_, session]) => {
+        if (!session) {
+          return of(PracticeSessionActions.completeSessionFailure({ 
+            error: 'No active session' 
+          }));
+        }
+
+        return this.practiceService.completeSession(session.id).pipe(
+          map((summary) => PracticeSessionActions.completeSessionSuccess({ summary })),
+          tap((action) => {
+            const { session } = action.summary;
+            
+            // Show completion notification
+            const message = `Session complete! ${session.correctCount}/${session.cardsStudied} correct (${Math.round(session.accuracy)}%)`;
+            this.notificationService.success(message);
+            
+            // Play completion sound
+            this.audioService.playSound('session-complete');
+            
+            // Check for achievements
+            action.summary.achievements.forEach(achievement => {
+              this.notificationService.info(
+                `🏆 Achievement Unlocked: ${achievement.title}`,
+                5000
+              );
+            });
+          }),
+          this.handleHttpError((error) => 
+            PracticeSessionActions.completeSessionFailure({ error })
+          )
+        );
+      })
+    )
+  );
+
+  // Session timer
+  sessionTimer$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSessionSuccess),
+      mergeMap(({ session }) => {
+        if (!session.settings.timeLimit) {
+          return of(); // No time limit
+        }
+
+        const timeLimit = session.settings.timeLimit * 60 * 1000; // Convert to ms
+        
+        return timer(timeLimit).pipe(
+          takeUntil(
+            this.actions$.pipe(
+              ofType(
+                PracticeSessionActions.completeSession,
+                PracticeSessionActions.abandonSession
+              )
+            )
+          ),
+          tap(() => {
+            this.notificationService.warning('Time limit reached!');
+          }),
+          map(() => PracticeSessionActions.completeSession())
+        );
+      })
+    )
+  );
+
+  // Update performance metrics periodically
+  updateMetrics$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSessionSuccess),
+      mergeMap(() =>
+        interval(5000).pipe( // Every 5 seconds
+          takeUntil(
+            this.actions$.pipe(
+              ofType(
+                PracticeSessionActions.completeSession,
+                PracticeSessionActions.abandonSession
+              )
+            )
+          ),
+          map(() => PracticeSessionActions.updatePerformanceMetrics())
+        )
+      )
+    )
+  );
+
+  // Keyboard shortcut handling
+  keyboardShortcuts$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeKeyboardActions.pressEnter),
+      withLatestFrom(
+        this.store.select(selectActiveSession),
+        this.store.select(selectCurrentCard),
+        this.store.select((state: any) => state.practiceSession.ui)
+      ),
+      map(([_, session, card, ui]) => {
+        if (!session || !card) return { type: 'NO_OP' } as any;
+
+        if (!ui.currentCardFlipped) {
+          return PracticeSessionActions.flipCard();
+        }
+
+        if (!card.seen) {
+          return PracticeSessionActions.submitResponse({
+            cardId: card.id,
+            quality: ResponseQuality.GOOD,
+            responseTime: Date.now() - session.startTime.getTime(),
+            hintsUsed: ui.showingHint ? 1 : 0,
+          });
+        }
+
+        return PracticeSessionActions.showNextCard();
+      }),
+      filter(action => action.type !== 'NO_OP')
+    )
+  );
+
+  // Load session history on init
+  loadHistory$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.loadSessionHistory),
+      mergeMap(() =>
+        this.practiceService.getSessionHistory().pipe(
+          map((sessions) => 
+            PracticeSessionActions.loadSessionHistorySuccess({ sessions })
+          ),
+          this.handleHttpError((error) => 
+            PracticeSessionActions.loadSessionHistoryFailure({ error })
+          )
+        )
+      )
+    )
+  );
+
+  constructor(
+    private actions$: Actions,
+    private store: Store,
+    private practiceService: PracticeService,
+    private audioService: AudioService,
+    private notificationService: NotificationService
+  ) {
+    super();
+  }
+}

--- a/frontend/src/app/state/practice-session/index.ts
+++ b/frontend/src/app/state/practice-session/index.ts
@@ -1,0 +1,5 @@
+export * from './models/practice-session.model';
+export * from './actions/practice-session.actions';
+export * from './selectors/practice-session.selectors';
+export { practiceSessionReducer } from './reducers/practice-session.reducer';
+export { PracticeSessionEffects } from './effects/practice-session.effects';

--- a/frontend/src/app/state/practice-session/models/practice-session.model.ts
+++ b/frontend/src/app/state/practice-session/models/practice-session.model.ts
@@ -1,0 +1,204 @@
+export interface PracticeSessionState {
+  activeSession: ActiveSession | null;
+  sessionHistory: CompletedSession[];
+  settings: PracticeSettings;
+  performance: PerformanceMetrics;
+  ui: PracticeUIState;
+}
+
+// Active Session
+export interface ActiveSession {
+  id: string;
+  deckId: number;
+  deckName: string;
+  type: SessionType;
+  cards: StudyCard[];
+  currentIndex: number;
+  responses: CardResponse[];
+  startTime: Date;
+  settings: PracticeSettings;
+  state: SessionState;
+}
+
+export interface StudyCard {
+  id: number;
+  deckId: number;
+  front: string;
+  back: string;
+  hint?: string;
+  verseReference?: string;
+  audioUrl?: string;
+  
+  // SR Algorithm Data
+  easeFactor: number;
+  interval: number;
+  repetitions: number;
+  
+  // Session-specific
+  order: number;
+  seen: boolean;
+  lastResponseQuality?: number;
+  nextReview?: Date;
+}
+
+export interface CardResponse {
+  cardId: number;
+  quality: ResponseQuality;
+  responseTime: number; // milliseconds
+  hintsUsed: number;
+  audioPlayed: boolean;
+  timestamp: Date;
+  
+  // Calculated fields
+  correct: boolean;
+  newInterval: number;
+  newEaseFactor: number;
+}
+
+export enum SessionType {
+  REVIEW = 'review',
+  LEARN = 'learn',
+  CRAM = 'cram',
+  QUIZ = 'quiz'
+}
+
+export enum SessionState {
+  NOT_STARTED = 'not_started',
+  IN_PROGRESS = 'in_progress',
+  PAUSED = 'paused',
+  COMPLETED = 'completed',
+  ABANDONED = 'abandoned'
+}
+
+export enum ResponseQuality {
+  AGAIN = 0,      // Complete blackout
+  HARD = 1,       // Difficult recall
+  GOOD = 2,       // Normal recall
+  EASY = 3,       // Perfect recall
+  SKIP = -1       // Skipped card
+}
+
+// Completed Session
+export interface CompletedSession {
+  id: string;
+  deckId: number;
+  type: SessionType;
+  startTime: Date;
+  endTime: Date;
+  duration: number; // seconds
+  cardsStudied: number;
+  correctCount: number;
+  accuracy: number;
+  averageResponseTime: number;
+  masteryChange: number;
+  streakMaintained: boolean;
+}
+
+// Settings
+export interface PracticeSettings {
+  // Session Configuration
+  sessionType: SessionType;
+  cardLimit: number;
+  timeLimit: number | null; // minutes
+  
+  // Card Selection
+  newCardsPerSession: number;
+  reviewOrder: ReviewOrder;
+  prioritizeDue: boolean;
+  includeNewCards: boolean;
+  
+  // Display Options
+  showHints: boolean;
+  autoPlayAudio: boolean;
+  flipAnimation: boolean;
+  fontSize: 'small' | 'medium' | 'large';
+  
+  // Behavior
+  immediateAnswerFeedback: boolean;
+  requireTypedAnswer: boolean;
+  caseSensitive: boolean;
+  showProgress: boolean;
+  
+  // Spaced Repetition
+  easyBonus: number;        // 1.3 default
+  intervalModifier: number; // 1.0 default
+  lapseMultiplier: number;  // 0.5 default
+  minimumInterval: number;  // 1 day
+}
+
+export enum ReviewOrder {
+  DUE_DATE = 'due_date',
+  RANDOM = 'random',
+  DIFFICULTY = 'difficulty',
+  CREATED = 'created'
+}
+
+// Performance Metrics
+export interface PerformanceMetrics {
+  // Current Session
+  currentStreak: number;
+  longestStreak: number;
+  totalTime: number;
+  cardsPerMinute: number;
+  
+  // Historical
+  dailyAverage: number;
+  weeklyProgress: number;
+  monthlyRetention: number;
+  overallAccuracy: number;
+}
+
+// UI State
+export interface PracticeUIState {
+  currentCardFlipped: boolean;
+  showingHint: boolean;
+  answerRevealed: boolean;
+  feedbackVisible: boolean;
+  statsVisible: boolean;
+  settingsOpen: boolean;
+}
+
+// API Models
+export interface StartSessionRequest {
+  deckId: number;
+  settings: Partial<PracticeSettings>;
+}
+
+export interface SubmitResponseRequest {
+  sessionId: string;
+  cardId: number;
+  quality: ResponseQuality;
+  responseTime: number;
+  hintsUsed: number;
+}
+
+export interface SessionSummary {
+  session: CompletedSession;
+  cardUpdates: CardUpdate[];
+  achievements: Achievement[];
+  nextReviewSummary: NextReviewSummary;
+}
+
+export interface CardUpdate {
+  cardId: number;
+  oldInterval: number;
+  newInterval: number;
+  oldEaseFactor: number;
+  newEaseFactor: number;
+  nextReview: Date;
+}
+
+export interface Achievement {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  unlockedAt: Date;
+}
+
+export interface NextReviewSummary {
+  today: number;
+  tomorrow: number;
+  thisWeek: number;
+  thisMonth: number;
+}

--- a/frontend/src/app/state/practice-session/reducers/practice-session.reducer.spec.ts
+++ b/frontend/src/app/state/practice-session/reducers/practice-session.reducer.spec.ts
@@ -1,0 +1,692 @@
+import { practiceSessionReducer, initialState } from './practice-session.reducer';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+import {
+  PracticeSessionState,
+  SessionType,
+  SessionState,
+  ResponseQuality,
+  ActiveSession,
+  CardResponse
+} from '../models/practice-session.model';
+
+describe('PracticeSessionReducer', () => {
+  describe('unknown action', () => {
+    it('should return the initial state', () => {
+      const action = { type: 'Unknown' } as any;
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state).toBe(initialState);
+    });
+  });
+
+  describe('Session lifecycle', () => {
+    const mockSession: ActiveSession = {
+      id: 'test-session-123',
+      deckId: 1,
+      deckName: 'Test Deck',
+      type: SessionType.REVIEW,
+      cards: [
+        {
+          id: 1,
+          deckId: 1,
+          front: 'Question 1',
+          back: 'Answer 1',
+          hint: 'Hint 1',
+          easeFactor: 2.5,
+          interval: 1,
+          repetitions: 0,
+          order: 0,
+          seen: false
+        },
+        {
+          id: 2,
+          deckId: 1,
+          front: 'Question 2',
+          back: 'Answer 2',
+          easeFactor: 2.5,
+          interval: 1,
+          repetitions: 0,
+          order: 1,
+          seen: false
+        }
+      ],
+      currentIndex: 0,
+      responses: [],
+      startTime: new Date('2024-01-15T10:00:00'),
+      settings: initialState.settings,
+      state: SessionState.IN_PROGRESS
+    };
+
+    it('should start a session successfully', () => {
+      const action = PracticeSessionActions.startSessionSuccess({ session: mockSession });
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.activeSession).toEqual(mockSession);
+      expect(state.ui).toEqual(initialState.ui);
+    });
+
+    it('should pause a session', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.pauseSession();
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.activeSession?.state).toBe(SessionState.PAUSED);
+    });
+
+    it('should resume a paused session', () => {
+      const stateWithPausedSession = {
+        ...initialState,
+        activeSession: {
+          ...mockSession,
+          state: SessionState.PAUSED
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.resumeSession();
+      const state = practiceSessionReducer(stateWithPausedSession, action);
+
+      expect(state.activeSession?.state).toBe(SessionState.IN_PROGRESS);
+    });
+
+    it('should not crash when pausing without active session', () => {
+      const action = PracticeSessionActions.pauseSession();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.activeSession).toBeNull();
+    });
+
+    it('should complete session and update history', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession
+      } as PracticeSessionState;
+
+      const summary = {
+        session: {
+          id: 'test-session-123',
+          deckId: 1,
+          type: SessionType.REVIEW,
+          startTime: new Date('2024-01-15T10:00:00'),
+          endTime: new Date('2024-01-15T10:15:00'),
+          duration: 900,
+          cardsStudied: 20,
+          correctCount: 18,
+          accuracy: 90,
+          averageResponseTime: 3.5,
+          masteryChange: 5,
+          streakMaintained: true
+        },
+        cardUpdates: [],
+        achievements: [],
+        nextReviewSummary: {
+          today: 5,
+          tomorrow: 10,
+          thisWeek: 25,
+          thisMonth: 50
+        }
+      };
+
+      const action = PracticeSessionActions.completeSessionSuccess({ summary });
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.activeSession).toBeNull();
+      expect(state.sessionHistory).toContain(summary.session);
+      expect(state.sessionHistory.length).toBe(1);
+    });
+
+    it('should limit session history to 50 entries', () => {
+      const existingSessions = Array.from({ length: 50 }, (_, i) => ({
+        id: `session-${i}`,
+        deckId: 1,
+        type: SessionType.REVIEW,
+        startTime: new Date(),
+        endTime: new Date(),
+        duration: 600,
+        cardsStudied: 10,
+        correctCount: 8,
+        accuracy: 80,
+        averageResponseTime: 3,
+        masteryChange: 2,
+        streakMaintained: true
+      }));
+
+      const stateWithFullHistory = {
+        ...initialState,
+        sessionHistory: existingSessions
+      } as PracticeSessionState;
+
+      const newSummary = {
+        session: {
+          id: 'new-session',
+          deckId: 1,
+          type: SessionType.REVIEW,
+          startTime: new Date(),
+          endTime: new Date(),
+          duration: 300,
+          cardsStudied: 5,
+          correctCount: 5,
+          accuracy: 100,
+          averageResponseTime: 2,
+          masteryChange: 3,
+          streakMaintained: true
+        },
+        cardUpdates: [],
+        achievements: [],
+        nextReviewSummary: {
+          today: 0,
+          tomorrow: 0,
+          thisWeek: 0,
+          thisMonth: 0
+        }
+      };
+
+      const action = PracticeSessionActions.completeSessionSuccess({ summary: newSummary });
+      const state = practiceSessionReducer(stateWithFullHistory, action);
+
+      expect(state.sessionHistory.length).toBe(50);
+      expect(state.sessionHistory[0]).toEqual(newSummary.session);
+      expect(state.sessionHistory[49]).toEqual(existingSessions[48]);
+    });
+  });
+
+  describe('Card navigation', () => {
+    const mockSession: ActiveSession = {
+      id: 'test-session',
+      deckId: 1,
+      deckName: 'Test Deck',
+      type: SessionType.REVIEW,
+      cards: Array.from({ length: 5 }, (_, i) => ({
+        id: i + 1,
+        deckId: 1,
+        front: `Question ${i + 1}`,
+        back: `Answer ${i + 1}`,
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: i,
+        seen: false
+      })),
+      currentIndex: 2,
+      responses: [],
+      startTime: new Date(),
+      settings: initialState.settings,
+      state: SessionState.IN_PROGRESS
+    };
+
+    it('should navigate to next card and reset UI state', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession,
+        ui: {
+          ...initialState.ui,
+          currentCardFlipped: true,
+          showingHint: true,
+          answerRevealed: true,
+          feedbackVisible: true
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.showNextCard();
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.activeSession?.currentIndex).toBe(3);
+      expect(state.ui.currentCardFlipped).toBe(false);
+      expect(state.ui.showingHint).toBe(false);
+      expect(state.ui.answerRevealed).toBe(false);
+      expect(state.ui.feedbackVisible).toBe(false);
+    });
+
+    it('should not navigate past last card', () => {
+      const stateAtLastCard = {
+        ...initialState,
+        activeSession: {
+          ...mockSession,
+          currentIndex: 4
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.showNextCard();
+      const state = practiceSessionReducer(stateAtLastCard, action);
+
+      expect(state.activeSession?.currentIndex).toBe(4);
+    });
+
+    it('should navigate to previous card', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.showPreviousCard();
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.activeSession?.currentIndex).toBe(1);
+    });
+
+    it('should not navigate before first card', () => {
+      const stateAtFirstCard = {
+        ...initialState,
+        activeSession: {
+          ...mockSession,
+          currentIndex: 0
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeSessionActions.showPreviousCard();
+      const state = practiceSessionReducer(stateAtFirstCard, action);
+
+      expect(state.activeSession?.currentIndex).toBe(0);
+    });
+  });
+
+  describe('Card interactions', () => {
+    it('should flip card and reveal answer', () => {
+      const action = PracticeSessionActions.flipCard();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.currentCardFlipped).toBe(true);
+      expect(state.ui.answerRevealed).toBe(true);
+    });
+
+    it('should toggle card flip state', () => {
+      const flippedState: PracticeSessionState = {
+        ...initialState,
+        ui: {
+          ...initialState.ui,
+          currentCardFlipped: true,
+          answerRevealed: true
+        }
+      };
+
+      const action = PracticeSessionActions.flipCard();
+      const state = practiceSessionReducer(flippedState, action);
+
+      expect(state.ui.currentCardFlipped).toBe(false);
+      expect(state.ui.answerRevealed).toBe(true);
+    });
+
+    it('should show hint', () => {
+      const action = PracticeSessionActions.showHint();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.showingHint).toBe(true);
+    });
+
+    it('should handle space key to flip card', () => {
+      const action = PracticeKeyboardActions.pressSpace();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.currentCardFlipped).toBe(true);
+      expect(state.ui.answerRevealed).toBe(true);
+    });
+
+    it('should handle H key to show hint', () => {
+      const action = PracticeKeyboardActions.pressH();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.showingHint).toBe(true);
+    });
+  });
+
+  describe('Response submission', () => {
+    const mockSession: ActiveSession = {
+      id: 'test-session',
+      deckId: 1,
+      deckName: 'Test Deck',
+      type: SessionType.REVIEW,
+      cards: [
+        {
+          id: 1,
+          deckId: 1,
+          front: 'Question 1',
+          back: 'Answer 1',
+          easeFactor: 2.5,
+          interval: 1,
+          repetitions: 0,
+          order: 0,
+          seen: false
+        }
+      ],
+      currentIndex: 0,
+      responses: [],
+      startTime: new Date(),
+      settings: initialState.settings,
+      state: SessionState.IN_PROGRESS
+    };
+
+    it('should record response and update card state', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.activeSession?.responses).toContain(response);
+      expect(state.activeSession?.cards[0].seen).toBe(true);
+      expect(state.activeSession?.cards[0].lastResponseQuality).toBe(ResponseQuality.GOOD);
+    });
+
+    it('should update streak on correct response', () => {
+      const stateWithStreak = {
+        ...initialState,
+        activeSession: mockSession,
+        performance: {
+          ...initialState.performance,
+          currentStreak: 5,
+          longestStreak: 10
+        }
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithStreak, action);
+
+      expect(state.performance.currentStreak).toBe(6);
+      expect(state.performance.longestStreak).toBe(10);
+    });
+
+    it('should reset streak on incorrect response', () => {
+      const stateWithStreak = {
+        ...initialState,
+        activeSession: mockSession,
+        performance: {
+          ...initialState.performance,
+          currentStreak: 5,
+          longestStreak: 10
+        }
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.AGAIN,
+        responseTime: 3000,
+        hintsUsed: 1,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: false,
+        newInterval: 1,
+        newEaseFactor: 1.3
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithStreak, action);
+
+      expect(state.performance.currentStreak).toBe(0);
+      expect(state.performance.longestStreak).toBe(10);
+    });
+
+    it('should update longest streak when current exceeds it', () => {
+      const stateWithStreak = {
+        ...initialState,
+        activeSession: mockSession,
+        performance: {
+          ...initialState.performance,
+          currentStreak: 10,
+          longestStreak: 10
+        }
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.EASY,
+        responseTime: 2000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 7,
+        newEaseFactor: 2.8
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithStreak, action);
+
+      expect(state.performance.currentStreak).toBe(11);
+      expect(state.performance.longestStreak).toBe(11);
+    });
+
+    it('should show feedback if immediate feedback is enabled', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession,
+        settings: {
+          ...initialState.settings,
+          immediateAnswerFeedback: true
+        }
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.ui.feedbackVisible).toBe(true);
+    });
+
+    it('should not show feedback if immediate feedback is disabled', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession,
+        settings: {
+          ...initialState.settings,
+          immediateAnswerFeedback: false
+        }
+      } as PracticeSessionState;
+
+      const response: CardResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      };
+
+      const action = PracticeSessionActions.submitResponseSuccess({ response });
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state.ui.feedbackVisible).toBe(false);
+    });
+  });
+
+  describe('Settings management', () => {
+    it('should update settings partially', () => {
+      const settingsUpdate = {
+        cardLimit: 30,
+        showHints: false,
+        fontSize: 'large' as const
+      };
+
+      const action = PracticeSessionActions.updateSettings({ settings: settingsUpdate });
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.settings.cardLimit).toBe(30);
+      expect(state.settings.showHints).toBe(false);
+      expect(state.settings.fontSize).toBe('large');
+      expect(state.settings.autoPlayAudio).toBe(initialState.settings.autoPlayAudio);
+      expect(state.settings.easyBonus).toBe(initialState.settings.easyBonus);
+    });
+  });
+
+  describe('UI state management', () => {
+    it('should toggle stats visibility', () => {
+      const action = PracticeSessionActions.toggleStats();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.statsVisible).toBe(true);
+
+      const state2 = practiceSessionReducer(state, action);
+      expect(state2.ui.statsVisible).toBe(false);
+    });
+
+    it('should toggle settings visibility', () => {
+      const action = PracticeSessionActions.toggleSettings();
+      const state = practiceSessionReducer(initialState, action);
+
+      expect(state.ui.settingsOpen).toBe(true);
+
+      const state2 = practiceSessionReducer(state, action);
+      expect(state2.ui.settingsOpen).toBe(false);
+    });
+  });
+
+  describe('Keyboard shortcuts', () => {
+    const mockSession: ActiveSession = {
+      id: 'test-session',
+      deckId: 1,
+      deckName: 'Test Deck',
+      type: SessionType.REVIEW,
+      cards: [
+        {
+          id: 1,
+          deckId: 1,
+          front: 'Question 1',
+          back: 'Answer 1',
+          easeFactor: 2.5,
+          interval: 1,
+          repetitions: 0,
+          order: 0,
+          seen: false
+        }
+      ],
+      currentIndex: 0,
+      responses: [],
+      startTime: new Date(),
+      settings: initialState.settings,
+      state: SessionState.IN_PROGRESS
+    };
+
+    it('should handle number key only when card is flipped', () => {
+      const stateWithSession = {
+        ...initialState,
+        activeSession: mockSession,
+        ui: {
+          ...initialState.ui,
+          currentCardFlipped: false
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeKeyboardActions.pressNumber({ key: 3 });
+      const state = practiceSessionReducer(stateWithSession, action);
+
+      expect(state).toEqual(stateWithSession);
+    });
+
+    it('should map number keys to quality ratings when card is flipped', () => {
+      const stateWithFlippedCard = {
+        ...initialState,
+        activeSession: mockSession,
+        ui: {
+          ...initialState.ui,
+          currentCardFlipped: true
+        }
+      } as PracticeSessionState;
+
+      [1, 2, 3, 4].forEach(key => {
+        const action = PracticeKeyboardActions.pressNumber({ key });
+        const state = practiceSessionReducer(stateWithFlippedCard, action);
+        expect(state).toEqual(stateWithFlippedCard);
+      });
+    });
+
+    it('should ignore invalid number keys', () => {
+      const stateWithFlippedCard = {
+        ...initialState,
+        activeSession: mockSession,
+        ui: {
+          ...initialState.ui,
+          currentCardFlipped: true
+        }
+      } as PracticeSessionState;
+
+      const action = PracticeKeyboardActions.pressNumber({ key: 5 });
+      const state = practiceSessionReducer(stateWithFlippedCard, action);
+
+      expect(state).toEqual(stateWithFlippedCard);
+    });
+  });
+
+  describe('Performance calculations', () => {
+    it('should calculate new accuracy with weighted average', () => {
+      const stateWithAccuracy = {
+        ...initialState,
+        performance: {
+          ...initialState.performance,
+          overallAccuracy: 85.0
+        }
+      } as PracticeSessionState;
+
+      const summary = {
+        session: {
+          id: 'test-session',
+          deckId: 1,
+          type: SessionType.REVIEW,
+          startTime: new Date(),
+          endTime: new Date(),
+          duration: 600,
+          cardsStudied: 20,
+          correctCount: 19,
+          accuracy: 95.0,
+          averageResponseTime: 3,
+          masteryChange: 3,
+          streakMaintained: true
+        },
+        cardUpdates: [],
+        achievements: [],
+        nextReviewSummary: {
+          today: 0,
+          tomorrow: 0,
+          thisWeek: 0,
+          thisMonth: 0
+        }
+      };
+
+      const action = PracticeSessionActions.completeSessionSuccess({ summary });
+      const state = practiceSessionReducer(stateWithAccuracy, action);
+
+      expect(state.performance.overallAccuracy).toBe(86);
+    });
+  });
+});

--- a/frontend/src/app/state/practice-session/reducers/practice-session.reducer.ts
+++ b/frontend/src/app/state/practice-session/reducers/practice-session.reducer.ts
@@ -1,0 +1,240 @@
+import { createReducer, on } from '@ngrx/store';
+import {
+  PracticeSessionState,
+  SessionState,
+  SessionType,
+  ReviewOrder,
+  ResponseQuality
+} from '../models/practice-session.model';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+
+export const initialState: PracticeSessionState = {
+  activeSession: null,
+  sessionHistory: [],
+  settings: {
+    sessionType: SessionType.REVIEW,
+    cardLimit: 20,
+    timeLimit: null,
+    newCardsPerSession: 5,
+    reviewOrder: ReviewOrder.DUE_DATE,
+    prioritizeDue: true,
+    includeNewCards: true,
+    showHints: true,
+    autoPlayAudio: false,
+    flipAnimation: true,
+    fontSize: 'medium',
+    immediateAnswerFeedback: true,
+    requireTypedAnswer: false,
+    caseSensitive: false,
+    showProgress: true,
+    easyBonus: 1.3,
+    intervalModifier: 1.0,
+    lapseMultiplier: 0.5,
+    minimumInterval: 1,
+  },
+  performance: {
+    currentStreak: 0,
+    longestStreak: 0,
+    totalTime: 0,
+    cardsPerMinute: 0,
+    dailyAverage: 0,
+    weeklyProgress: 0,
+    monthlyRetention: 0,
+    overallAccuracy: 0,
+  },
+  ui: {
+    currentCardFlipped: false,
+    showingHint: false,
+    answerRevealed: false,
+    feedbackVisible: false,
+    statsVisible: false,
+    settingsOpen: false,
+  },
+};
+
+export const practiceSessionReducer = createReducer(
+  initialState,
+  
+  // Start Session
+  on(PracticeSessionActions.startSessionSuccess, (state, { session }) => ({
+    ...state,
+    activeSession: session,
+    ui: {
+      ...initialState.ui,
+    },
+  })),
+  
+  // Pause/Resume
+  on(PracticeSessionActions.pauseSession, (state) => ({
+    ...state,
+    activeSession: state.activeSession ? {
+      ...state.activeSession,
+      state: SessionState.PAUSED,
+    } : null,
+  })),
+  
+  on(PracticeSessionActions.resumeSession, (state) => ({
+    ...state,
+    activeSession: state.activeSession ? {
+      ...state.activeSession,
+      state: SessionState.IN_PROGRESS,
+    } : null,
+  })),
+  
+  // Card Navigation
+  on(PracticeSessionActions.showNextCard, (state) => {
+    if (!state.activeSession) return state;
+
+    const nextIndex = Math.min(
+      state.activeSession.currentIndex + 1,
+      state.activeSession.cards.length - 1
+    );
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        currentIndex: nextIndex,
+      },
+      ui: {
+        ...state.ui,
+        currentCardFlipped: false,
+        showingHint: false,
+        answerRevealed: false,
+        feedbackVisible: false,
+      },
+    };
+  }),
+  
+  on(PracticeSessionActions.showPreviousCard, (state) => {
+    if (!state.activeSession) return state;
+
+    const prevIndex = Math.max(state.activeSession.currentIndex - 1, 0);
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        currentIndex: prevIndex,
+      },
+      ui: {
+        ...state.ui,
+        currentCardFlipped: false,
+        showingHint: false,
+        answerRevealed: false,
+      },
+    };
+  }),
+  
+  // Card Interaction
+  on(PracticeSessionActions.flipCard, PracticeKeyboardActions.pressSpace, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      currentCardFlipped: !state.ui.currentCardFlipped,
+      answerRevealed: true,
+    },
+  })),
+  
+  on(PracticeSessionActions.showHint, PracticeKeyboardActions.pressH, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      showingHint: true,
+    },
+  })),
+  
+  // Submit Response
+  on(PracticeSessionActions.submitResponseSuccess, (state, { response }) => {
+    if (!state.activeSession) return state;
+
+    const updatedResponses = [...state.activeSession.responses, response];
+    const currentStreak = response.correct 
+      ? state.performance.currentStreak + 1 
+      : 0;
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        responses: updatedResponses,
+        cards: state.activeSession.cards.map(card =>
+          card.id === response.cardId
+            ? { ...card, seen: true, lastResponseQuality: response.quality }
+            : card
+        ),
+      },
+      performance: {
+        ...state.performance,
+        currentStreak,
+        longestStreak: Math.max(currentStreak, state.performance.longestStreak),
+      },
+      ui: {
+        ...state.ui,
+        feedbackVisible: state.settings.immediateAnswerFeedback,
+      },
+    };
+  }),
+  
+  // Settings
+  on(PracticeSessionActions.updateSettings, (state, { settings }) => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      ...settings,
+    },
+  })),
+  
+  // UI State
+  on(PracticeSessionActions.toggleStats, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      statsVisible: !state.ui.statsVisible,
+    },
+  })),
+  
+  on(PracticeSessionActions.toggleSettings, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      settingsOpen: !state.ui.settingsOpen,
+    },
+  })),
+  
+  // Complete Session
+  on(PracticeSessionActions.completeSessionSuccess, (state, { summary }) => ({
+    ...state,
+    activeSession: null,
+    sessionHistory: [summary.session, ...state.sessionHistory].slice(0, 50),
+    performance: {
+      ...state.performance,
+      overallAccuracy: calculateNewAccuracy(
+        state.performance.overallAccuracy,
+        summary.session.accuracy
+      ),
+    },
+  })),
+  
+  // Keyboard Shortcuts
+  on(PracticeKeyboardActions.pressNumber, (state, { key }) => {
+    if (!state.activeSession || !state.ui.currentCardFlipped) return state;
+
+    const qualityMap: { [key: number]: ResponseQuality } = {
+      1: ResponseQuality.AGAIN,
+      2: ResponseQuality.HARD,
+      3: ResponseQuality.GOOD,
+      4: ResponseQuality.EASY,
+    };
+
+    const quality = qualityMap[key];
+    if (quality === undefined) return state;
+
+    return state;
+  }),
+);
+
+// Helper function
+function calculateNewAccuracy(currentAccuracy: number, sessionAccuracy: number): number {
+  return currentAccuracy * 0.9 + sessionAccuracy * 0.1;
+}

--- a/frontend/src/app/state/practice-session/selectors/practice-session.selectors.spec.ts
+++ b/frontend/src/app/state/practice-session/selectors/practice-session.selectors.spec.ts
@@ -1,0 +1,464 @@
+import {
+  selectPracticeSessionState,
+  selectActiveSession,
+  selectIsSessionActive,
+  selectCurrentCard,
+  selectSessionProgress,
+  selectSessionStats,
+  selectSettings,
+  selectPerformance,
+  selectCurrentStreak,
+  selectCardsPerMinute,
+  selectSessionHistory,
+  selectRecentSessions,
+  selectTodaySessions,
+  selectIsCardFlipped,
+  selectSessionSummary
+} from './practice-session.selectors';
+import {
+  PracticeSessionState,
+  ActiveSession,
+  SessionType,
+  SessionState,
+  ResponseQuality
+} from '../models/practice-session.model';
+
+describe('PracticeSessionSelectors', () => {
+  const mockActiveSession: ActiveSession = {
+    id: 'test-session-123',
+    deckId: 1,
+    deckName: 'Test Deck',
+    type: SessionType.REVIEW,
+    cards: [
+      {
+        id: 1,
+        deckId: 1,
+        front: 'Question 1',
+        back: 'Answer 1',
+        hint: 'Hint 1',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 0,
+        seen: false
+      },
+      {
+        id: 2,
+        deckId: 1,
+        front: 'Question 2',
+        back: 'Answer 2',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 1,
+        seen: true
+      },
+      {
+        id: 3,
+        deckId: 1,
+        front: 'Question 3',
+        back: 'Answer 3',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 2,
+        seen: false
+      }
+    ],
+    currentIndex: 1,
+    responses: [
+      {
+        cardId: 2,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date('2024-01-15T10:01:00'),
+        correct: true,
+        newInterval: 4,
+        newEaseFactor: 2.5
+      }
+    ],
+    startTime: new Date('2024-01-15T10:00:00'),
+    settings: {
+      sessionType: SessionType.REVIEW,
+      cardLimit: 20,
+      timeLimit: 30,
+      newCardsPerSession: 5,
+      reviewOrder: 'due_date' as any,
+      prioritizeDue: true,
+      includeNewCards: true,
+      showHints: true,
+      autoPlayAudio: false,
+      flipAnimation: true,
+      fontSize: 'medium',
+      immediateAnswerFeedback: true,
+      requireTypedAnswer: false,
+      caseSensitive: false,
+      showProgress: true,
+      easyBonus: 1.3,
+      intervalModifier: 1.0,
+      lapseMultiplier: 0.5,
+      minimumInterval: 1
+    },
+    state: SessionState.IN_PROGRESS
+  };
+
+  const mockState: PracticeSessionState = {
+    activeSession: mockActiveSession,
+    sessionHistory: [
+      {
+        id: 'completed-1',
+        deckId: 1,
+        type: SessionType.REVIEW,
+        startTime: new Date('2024-01-15T08:00:00'),
+        endTime: new Date('2024-01-15T08:30:00'),
+        duration: 1800,
+        cardsStudied: 25,
+        correctCount: 23,
+        accuracy: 92,
+        averageResponseTime: 3.2,
+        masteryChange: 5,
+        streakMaintained: true
+      },
+      {
+        id: 'completed-2',
+        deckId: 2,
+        type: SessionType.LEARN,
+        startTime: new Date('2024-01-14T15:00:00'),
+        endTime: new Date('2024-01-14T15:20:00'),
+        duration: 1200,
+        cardsStudied: 15,
+        correctCount: 12,
+        accuracy: 80,
+        averageResponseTime: 4.5,
+        masteryChange: 3,
+        streakMaintained: false
+      }
+    ],
+    settings: {
+      sessionType: SessionType.REVIEW,
+      cardLimit: 20,
+      timeLimit: null,
+      newCardsPerSession: 5,
+      reviewOrder: 'due_date' as any,
+      prioritizeDue: true,
+      includeNewCards: true,
+      showHints: true,
+      autoPlayAudio: false,
+      flipAnimation: true,
+      fontSize: 'medium',
+      immediateAnswerFeedback: true,
+      requireTypedAnswer: false,
+      caseSensitive: false,
+      showProgress: true,
+      easyBonus: 1.3,
+      intervalModifier: 1.0,
+      lapseMultiplier: 0.5,
+      minimumInterval: 1
+    },
+    performance: {
+      currentStreak: 8,
+      longestStreak: 15,
+      totalTime: 3600,
+      cardsPerMinute: 2.5,
+      dailyAverage: 20,
+      weeklyProgress: 140,
+      monthlyRetention: 88,
+      overallAccuracy: 85
+    },
+    ui: {
+      currentCardFlipped: true,
+      showingHint: false,
+      answerRevealed: true,
+      feedbackVisible: false,
+      statsVisible: true,
+      settingsOpen: false
+    }
+  };
+
+  const rootState = { practiceSession: mockState } as any;
+
+  describe('Basic selectors', () => {
+    it('should select practice session state', () => {
+      const result = selectPracticeSessionState(rootState);
+      expect(result).toBe(mockState);
+    });
+
+    it('should select active session', () => {
+      const result = selectActiveSession(rootState);
+      expect(result).toBe(mockActiveSession);
+    });
+
+    it('should determine if session is active', () => {
+      const result = selectIsSessionActive(rootState);
+      expect(result).toBe(true);
+
+      const inactiveState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const inactiveResult = selectIsSessionActive(inactiveState);
+      expect(inactiveResult).toBe(false);
+    });
+
+    it('should select current card', () => {
+      const result = selectCurrentCard(rootState);
+      expect(result?.id).toBe(2);
+      expect(result?.seen).toBe(true);
+    });
+
+    it('should return null when no active session', () => {
+      const noSessionState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const result = selectCurrentCard(noSessionState);
+      expect(result).toBeNull();
+    });
+
+    it('should select settings', () => {
+      const result = selectSettings(rootState);
+      expect(result).toBe(mockState.settings);
+      expect(result.cardLimit).toBe(20);
+    });
+
+    it('should select performance metrics', () => {
+      const result = selectPerformance(rootState);
+      expect(result).toBe(mockState.performance);
+    });
+
+    it('should select current streak', () => {
+      const result = selectCurrentStreak(rootState);
+      expect(result).toBe(8);
+    });
+
+    it('should select UI state flags', () => {
+      expect(selectIsCardFlipped(rootState)).toBe(true);
+    });
+  });
+
+  describe('Session progress calculations', () => {
+    it('should calculate session progress correctly', () => {
+      const progress = selectSessionProgress(rootState);
+
+      expect(progress.totalCards).toBe(3);
+      expect(progress.seenCards).toBe(1);
+      expect(progress.remainingCards).toBe(2);
+      expect(progress.percentComplete).toBeCloseTo(33.33, 1);
+    });
+
+    it('should handle empty session', () => {
+      const noSessionState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const progress = selectSessionProgress(noSessionState);
+
+      expect(progress.totalCards).toBe(0);
+      expect(progress.seenCards).toBe(0);
+      expect(progress.remainingCards).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+    });
+
+    it('should handle session with all cards seen', () => {
+      const allSeenSession = {
+        ...mockActiveSession,
+        cards: mockActiveSession.cards.map(card => ({ ...card, seen: true }))
+      };
+      const stateAllSeen = {
+        practiceSession: {
+          ...mockState,
+          activeSession: allSeenSession
+        }
+      } as any;
+
+      const progress = selectSessionProgress(stateAllSeen);
+      expect(progress.percentComplete).toBe(100);
+      expect(progress.remainingCards).toBe(0);
+    });
+  });
+
+  describe('Session statistics', () => {
+    it('should calculate session stats from responses', () => {
+      const sessionWithMoreResponses = {
+        ...mockActiveSession,
+        responses: [
+          {
+            cardId: 1,
+            quality: ResponseQuality.GOOD,
+            responseTime: 3000,
+            hintsUsed: 0,
+            audioPlayed: false,
+            timestamp: new Date(),
+            correct: true,
+            newInterval: 4,
+            newEaseFactor: 2.5
+          },
+          {
+            cardId: 2,
+            quality: ResponseQuality.AGAIN,
+            responseTime: 5000,
+            hintsUsed: 1,
+            audioPlayed: false,
+            timestamp: new Date(),
+            correct: false,
+            newInterval: 1,
+            newEaseFactor: 1.3
+          },
+          {
+            cardId: 3,
+            quality: ResponseQuality.EASY,
+            responseTime: 2000,
+            hintsUsed: 0,
+            audioPlayed: true,
+            timestamp: new Date(),
+            correct: true,
+            newInterval: 7,
+            newEaseFactor: 2.8
+          }
+        ]
+      };
+
+      const stateWithResponses = {
+        practiceSession: {
+          ...mockState,
+          activeSession: sessionWithMoreResponses
+        }
+      } as any;
+
+      const stats = selectSessionStats(stateWithResponses);
+
+      expect(stats.correctCount).toBe(2);
+      expect(stats.incorrectCount).toBe(1);
+      expect(stats.accuracy).toBeCloseTo(66.67, 1);
+      expect(stats.averageResponseTime).toBe(3);
+      expect(stats.hintsUsed).toBe(1);
+    });
+
+    it('should handle session with no responses', () => {
+      const stats = selectSessionStats(rootState);
+
+      expect(stats.correctCount).toBe(1);
+      expect(stats.incorrectCount).toBe(0);
+      expect(stats.accuracy).toBe(100);
+    });
+
+    it('should handle no active session', () => {
+      const noSessionState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const stats = selectSessionStats(noSessionState);
+
+      expect(stats.correctCount).toBe(0);
+      expect(stats.incorrectCount).toBe(0);
+      expect(stats.accuracy).toBe(0);
+      expect(stats.averageResponseTime).toBe(0);
+      expect(stats.hintsUsed).toBe(0);
+    });
+  });
+
+  describe('Cards per minute calculation', () => {
+    it('should calculate cards per minute', () => {
+      spyOn(Date, 'now').and.returnValue(new Date('2024-01-15T10:05:00').getTime());
+
+      const stateWithResponses = {
+        practiceSession: {
+          ...mockState,
+          activeSession: {
+            ...mockActiveSession,
+            responses: [
+              { ...mockActiveSession.responses[0], correct: true },
+              { ...mockActiveSession.responses[0], correct: false }
+            ]
+          }
+        }
+      } as any;
+
+      const cpm = selectCardsPerMinute(stateWithResponses);
+      expect(cpm).toBe(0.4);
+
+      (Date.now as any).and.callThrough();
+    });
+
+    it('should return 0 when no cards studied', () => {
+      const cpm = selectCardsPerMinute(rootState);
+      expect(cpm).toBeGreaterThan(0);
+    });
+
+    it('should return 0 when no active session', () => {
+      const noSessionState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const cpm = selectCardsPerMinute(noSessionState);
+      expect(cpm).toBe(0);
+    });
+  });
+
+  describe('Session history selectors', () => {
+    it('should select all session history', () => {
+      const history = selectSessionHistory(rootState);
+      expect(history.length).toBe(2);
+      expect(history[0].id).toBe('completed-1');
+    });
+
+    it('should select recent sessions (last 10)', () => {
+      const manySessions = Array.from({ length: 15 }, (_, i) => ({
+        id: `session-${i}`,
+        deckId: 1,
+        type: SessionType.REVIEW,
+        startTime: new Date(`2024-01-${15 - i}T10:00:00`),
+        endTime: new Date(`2024-01-${15 - i}T10:30:00`),
+        duration: 1800,
+        cardsStudied: 20,
+        correctCount: 18,
+        accuracy: 90,
+        averageResponseTime: 3,
+        masteryChange: 2,
+        streakMaintained: true
+      }));
+
+      const stateWithManySessions = {
+        practiceSession: {
+          ...mockState,
+          sessionHistory: manySessions
+        }
+      } as any;
+
+      const recent = selectRecentSessions(stateWithManySessions);
+      expect(recent.length).toBe(10);
+      expect(recent[0].id).toBe('session-0');
+    });
+
+    it('should select today\'s sessions', () => {
+      const today = new Date();
+      const todaySession = {
+        ...mockState.sessionHistory[0],
+        startTime: today
+      };
+
+      const stateWithTodaySession = {
+        practiceSession: {
+          ...mockState,
+          sessionHistory: [todaySession, ...mockState.sessionHistory]
+        }
+      } as any;
+
+      const todaySessions = selectTodaySessions(stateWithTodaySession);
+      expect(todaySessions.length).toBe(1);
+      expect(todaySessions[0].startTime).toEqual(today);
+    });
+  });
+
+  describe('Session summary', () => {
+    it('should create comprehensive session summary', () => {
+      spyOn(Date, 'now').and.returnValue(new Date('2024-01-15T10:10:00').getTime());
+
+      const summary = selectSessionSummary(rootState);
+
+      expect(summary).not.toBeNull();
+      expect(summary?.deckName).toBe('Test Deck');
+      expect(summary?.sessionType).toBe(SessionType.REVIEW);
+      expect(summary?.duration).toBe(600);
+      expect(summary?.correctCount).toBe(1);
+      expect(summary?.totalCards).toBe(3);
+      expect(summary?.seenCards).toBe(1);
+      expect(summary?.percentComplete).toBeCloseTo(33.33, 1);
+
+      (Date.now as any).and.callThrough();
+    });
+
+    it('should return null when no active session', () => {
+      const noSessionState = { practiceSession: { ...mockState, activeSession: null } } as any;
+      const summary = selectSessionSummary(noSessionState);
+      expect(summary).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
+++ b/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
@@ -1,0 +1,207 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { PracticeSessionState, StudyCard } from '../models/practice-session.model';
+
+// Feature Selector
+export const selectPracticeSessionState = 
+  createFeatureSelector<PracticeSessionState>('practiceSession');
+
+// Active Session Selectors
+export const selectActiveSession = createSelector(
+  selectPracticeSessionState,
+  (state) => state.activeSession
+);
+
+export const selectIsSessionActive = createSelector(
+  selectActiveSession,
+  (session) => session !== null
+);
+
+export const selectSessionCards = createSelector(
+  selectActiveSession,
+  (session) => session?.cards || []
+);
+
+export const selectCurrentCardIndex = createSelector(
+  selectActiveSession,
+  (session) => session?.currentIndex || 0
+);
+
+export const selectCurrentCard = createSelector(
+  selectActiveSession,
+  selectCurrentCardIndex,
+  (session, index) => session?.cards[index] || null
+);
+
+export const selectSessionProgress = createSelector(
+  selectActiveSession,
+  (session) => {
+    if (!session) {
+      return {
+        totalCards: 0,
+        seenCards: 0,
+        remainingCards: 0,
+        percentComplete: 0,
+      };
+    }
+
+    const seenCards = session.cards.filter(card => card.seen).length;
+    const totalCards = session.cards.length;
+    const remainingCards = totalCards - seenCards;
+    const percentComplete = totalCards > 0 ? (seenCards / totalCards) * 100 : 0;
+
+    return {
+      totalCards,
+      seenCards,
+      remainingCards,
+      percentComplete,
+    };
+  }
+);
+
+export const selectSessionStats = createSelector(
+  selectActiveSession,
+  (session) => {
+    if (!session || session.responses.length === 0) {
+      return {
+        correctCount: 0,
+        incorrectCount: 0,
+        accuracy: 0,
+        averageResponseTime: 0,
+        hintsUsed: 0,
+      };
+    }
+
+    const correctCount = session.responses.filter(r => r.correct).length;
+    const incorrectCount = session.responses.length - correctCount;
+    const accuracy = (correctCount / session.responses.length) * 100;
+    const totalResponseTime = session.responses.reduce((sum, r) => sum + r.responseTime, 0);
+    const averageResponseTime = totalResponseTime / session.responses.length;
+    const hintsUsed = session.responses.reduce((sum, r) => sum + r.hintsUsed, 0);
+
+    return {
+      correctCount,
+      incorrectCount,
+      accuracy,
+      averageResponseTime: Math.round(averageResponseTime / 1000),
+      hintsUsed,
+    };
+  }
+);
+
+// Settings Selectors
+export const selectSettings = createSelector(
+  selectPracticeSessionState,
+  (state) => state.settings
+);
+
+export const selectSessionType = createSelector(
+  selectSettings,
+  (settings) => settings.sessionType
+);
+
+// Performance Selectors
+export const selectPerformance = createSelector(
+  selectPracticeSessionState,
+  (state) => state.performance
+);
+
+export const selectCurrentStreak = createSelector(
+  selectPerformance,
+  (performance) => performance.currentStreak
+);
+
+export const selectCardsPerMinute = createSelector(
+  selectActiveSession,
+  selectSessionStats,
+  (session, stats) => {
+    if (!session || stats.correctCount + stats.incorrectCount === 0) {
+      return 0;
+    }
+
+    const elapsedMinutes = (Date.now() - session.startTime.getTime()) / 60000;
+    return (stats.correctCount + stats.incorrectCount) / elapsedMinutes;
+  }
+);
+
+// History Selectors
+export const selectSessionHistory = createSelector(
+  selectPracticeSessionState,
+  (state) => state.sessionHistory
+);
+
+export const selectRecentSessions = createSelector(
+  selectSessionHistory,
+  (history) => history.slice(0, 10)
+);
+
+export const selectTodaySessions = createSelector(
+  selectSessionHistory,
+  (history) => {
+    const today = new Date().toDateString();
+    return history.filter(
+      session => new Date(session.startTime).toDateString() === today
+    );
+  }
+);
+
+// UI Selectors
+export const selectUI = createSelector(
+  selectPracticeSessionState,
+  (state) => state.ui
+);
+
+export const selectIsCardFlipped = createSelector(
+  selectUI,
+  (ui) => ui.currentCardFlipped
+);
+
+export const selectIsShowingHint = createSelector(
+  selectUI,
+  (ui) => ui.showingHint
+);
+
+export const selectIsStatsVisible = createSelector(
+  selectUI,
+  (ui) => ui.statsVisible
+);
+
+// Combined Selectors
+export const selectNextReviewTime = createSelector(
+  selectCurrentCard,
+  selectActiveSession,
+  (card, session) => {
+    if (!card || !session) return null;
+
+    const response = session.responses.find(r => r.cardId === card.id);
+    if (!response) return null;
+
+    return new Date(Date.now() + response.newInterval * 24 * 60 * 60 * 1000);
+  }
+);
+
+export const selectDueCardsInSession = createSelector(
+  selectSessionCards,
+  (cards) => {
+    const now = new Date();
+    return cards.filter(
+      card => card.nextReview && new Date(card.nextReview) <= now
+    );
+  }
+);
+
+export const selectSessionSummary = createSelector(
+  selectActiveSession,
+  selectSessionStats,
+  selectSessionProgress,
+  (session, stats, progress) => {
+    if (!session) return null;
+
+    return {
+      deckName: session.deckName,
+      sessionType: session.type,
+      duration: Math.round((Date.now() - session.startTime.getTime()) / 1000),
+      ...stats,
+      ...progress,
+    };
+  }
+);


### PR DESCRIPTION
## Summary
- add practice session models, actions, reducer, effects, selectors
- implement practice session services for mock API
- add audio service stub
- register practice session store and effects
- add extensive unit tests

## Testing
- `npx ng test --include='**/practice-session/**/*.spec.ts' --watch=false` *(fails: Cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6880d5dab8b08331a2b7505efbc34f7a