### PR TITLE
Implement practice session state

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -14,6 +14,8 @@ import { bibleTrackerReducer } from './state/bible-tracker/reducers/bible-tracke
 import { BibleTrackerEffects } from './state/bible-tracker/effects/bible-tracker.effects';
 import { decksReducer } from './state/decks/reducers/deck.reducer';
 import { DeckEffects } from './state/decks/effects/deck.effects';
+import { practiceSessionReducer } from './state/practice-session/reducers/practice-session.reducer';
+import { PracticeSessionEffects } from './state/practice-session/effects/practice-session.effects';
 import { ConfigService } from './core/services/config.service';
 
 export const appConfig: ApplicationConfig = {
@@ -35,6 +37,7 @@ export const appConfig: ApplicationConfig = {
         router: routerReducer,
         bibleTracker: bibleTrackerReducer,
         decks: decksReducer,
+        practiceSession: practiceSessionReducer,
       },
       {
         metaReducers: isDevMode() ? metaReducers : [],
@@ -53,6 +56,7 @@ export const appConfig: ApplicationConfig = {
     provideEffects([
       BibleTrackerEffects,
       DeckEffects,
+      PracticeSessionEffects,
     ]),
 
     // Router Store

--- a/frontend/src/app/core/services/audio.service.ts
+++ b/frontend/src/app/core/services/audio.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AudioService {
+  play(url: string): void {
+    const audio = new Audio(url);
+    audio.play().catch((err) => console.error('Audio play error', err));
+  }
+
+  playSound(name: string): void {
+    console.log('Playing sound', name);
+  }
+}

--- a/frontend/src/app/core/services/practice.service.ts
+++ b/frontend/src/app/core/services/practice.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import {
+  StartSessionRequest,
+  ActiveSession,
+  CardResponse,
+  SessionSummary,
+} from '../../state/practice-session/models/practice-session.model';
+
+@Injectable({ providedIn: 'root' })
+export class PracticeService {
+  startSession(request: StartSessionRequest): Observable<ActiveSession> {
+    console.log('Starting practice session', request);
+    // Placeholder: should call backend API
+    const dummy: ActiveSession = {
+      id: 'local',
+      deckId: request.deckId,
+      deckName: 'Dummy',
+      type: request.settings.sessionType || ('review' as any),
+      cards: [],
+      currentIndex: 0,
+      responses: [],
+      startTime: new Date(),
+      settings: request.settings as any,
+      state: 'in_progress' as any,
+    };
+    return of(dummy);
+  }
+
+  submitResponse(payload: {
+    sessionId: string;
+    cardId: number;
+    quality: number;
+    responseTime: number;
+    hintsUsed: number;
+  }): Observable<CardResponse> {
+    console.log('Submitting response', payload);
+    return of({
+      cardId: payload.cardId,
+      quality: payload.quality as any,
+      responseTime: payload.responseTime,
+      hintsUsed: payload.hintsUsed,
+      audioPlayed: false,
+      timestamp: new Date(),
+      correct: true,
+      newInterval: 1,
+      newEaseFactor: 2.5,
+    });
+  }
+
+  completeSession(sessionId: string): Observable<SessionSummary> {
+    console.log('Completing session', sessionId);
+    return of({
+      session: {
+        id: sessionId,
+        deckId: 0,
+        type: 'review' as any,
+        startTime: new Date(),
+        endTime: new Date(),
+        duration: 0,
+        cardsStudied: 0,
+        correctCount: 0,
+        accuracy: 0,
+        averageResponseTime: 0,
+        masteryChange: 0,
+        streakMaintained: true,
+      },
+      cardUpdates: [],
+      achievements: [],
+      nextReviewSummary: { today: 0, tomorrow: 0, thisWeek: 0, thisMonth: 0 },
+    });
+  }
+
+  getSessionHistory(): Observable<any[]> {
+    console.log('Loading session history');
+    return of([]);
+  }
+}

--- a/frontend/src/app/state/app.state.ts
+++ b/frontend/src/app/state/app.state.ts
@@ -1,13 +1,14 @@
 import { RouterReducerState } from '@ngrx/router-store';
 import { BibleTrackerState } from './bible-tracker/models/bible-tracker.model';
 import { DecksState } from './decks/models/deck.model';
+import { PracticeSessionState } from './practice-session/models/practice-session.model';
 
 // Root state interface - all feature states will be added here
 export interface AppState {
   router: RouterReducerState;
   bibleTracker: BibleTrackerState;
   decks: DecksState;
-  // practiceSession: PracticeSessionState;
+  practiceSession: PracticeSessionState;
 }
 
 // Shared state interfaces used across features

--- a/frontend/src/app/state/index.ts
+++ b/frontend/src/app/state/index.ts
@@ -17,3 +17,4 @@ export * from './core/reducers/router.reducer';
 // Bible Tracker feature exports
 export * from './bible-tracker';
 export * from './decks';
+export * from './practice-session';

--- a/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
+++ b/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
@@ -1,0 +1,84 @@
+import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import {
+  StartSessionRequest,
+  ActiveSession,
+  CardResponse,
+  ResponseQuality,
+  PracticeSettings,
+  SessionSummary,
+  CompletedSession
+} from '../models/practice-session.model';
+
+export const PracticeSessionActions = createActionGroup({
+  source: 'Practice Session',
+  events: {
+    // Session Lifecycle
+    'Start Session': props<{ request: StartSessionRequest }>(),
+    'Start Session Success': props<{ session: ActiveSession }>(),
+    'Start Session Failure': props<{ error: string }>(),
+    
+    'Pause Session': emptyProps(),
+    'Resume Session': emptyProps(),
+    'End Session': emptyProps(),
+    'Abandon Session': emptyProps(),
+    
+    'Complete Session': emptyProps(),
+    'Complete Session Success': props<{ summary: SessionSummary }>(),
+    'Complete Session Failure': props<{ error: string }>(),
+    
+    // Card Actions
+    'Show Next Card': emptyProps(),
+    'Show Previous Card': emptyProps(),
+    'Flip Card': emptyProps(),
+    'Show Hint': emptyProps(),
+    'Play Audio': emptyProps(),
+    
+    // Response Submission
+    'Submit Response': props<{
+      cardId: number;
+      quality: ResponseQuality;
+      responseTime: number;
+      hintsUsed: number;
+    }>(),
+    'Submit Response Success': props<{ response: CardResponse }>(),
+    'Submit Response Failure': props<{ error: string }>(),
+    
+    // Skip Card
+    'Skip Card': props<{ cardId: number }>(),
+    'Skip Card Success': emptyProps(),
+    
+    // Settings
+    'Update Settings': props<{ settings: Partial<PracticeSettings> }>(),
+    'Save Settings': emptyProps(),
+    'Reset Settings': emptyProps(),
+    
+    // History
+    'Load Session History': emptyProps(),
+    'Load Session History Success': props<{ sessions: CompletedSession[] }>(),
+    'Load Session History Failure': props<{ error: string }>(),
+    
+    // UI Actions
+    'Toggle Stats': emptyProps(),
+    'Toggle Settings': emptyProps(),
+    'Show Feedback': props<{ message: string; type: 'success' | 'error' | 'info' }>(),
+    'Hide Feedback': emptyProps(),
+    
+    // Performance Updates
+    'Update Performance Metrics': emptyProps(),
+    'Calculate Session Stats': emptyProps(),
+  }
+});
+
+// Separate action group for keyboard shortcuts
+export const PracticeKeyboardActions = createActionGroup({
+  source: 'Practice Keyboard',
+  events: {
+    'Press Space': emptyProps(),      // Flip card
+    'Press Enter': emptyProps(),      // Submit/Next
+    'Press Number': props<{ key: number }>(), // Quality rating 1-4
+    'Press H': emptyProps(),          // Show hint
+    'Press S': emptyProps(),          // Skip card
+    'Press P': emptyProps(),          // Play audio
+    'Press Escape': emptyProps(),     // Pause/Settings
+  }
+});

--- a/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
+++ b/frontend/src/app/state/practice-session/actions/practice-session.actions.ts
@@ -6,7 +6,7 @@ import {
   ResponseQuality,
   PracticeSettings,
   SessionSummary,
-  CompletedSession
+  CompletedSession,
 } from '../models/practice-session.model';
 
 export const PracticeSessionActions = createActionGroup({
@@ -16,23 +16,23 @@ export const PracticeSessionActions = createActionGroup({
     'Start Session': props<{ request: StartSessionRequest }>(),
     'Start Session Success': props<{ session: ActiveSession }>(),
     'Start Session Failure': props<{ error: string }>(),
-    
+
     'Pause Session': emptyProps(),
     'Resume Session': emptyProps(),
     'End Session': emptyProps(),
     'Abandon Session': emptyProps(),
-    
+
     'Complete Session': emptyProps(),
     'Complete Session Success': props<{ summary: SessionSummary }>(),
     'Complete Session Failure': props<{ error: string }>(),
-    
+
     // Card Actions
     'Show Next Card': emptyProps(),
     'Show Previous Card': emptyProps(),
     'Flip Card': emptyProps(),
     'Show Hint': emptyProps(),
     'Play Audio': emptyProps(),
-    
+
     // Response Submission
     'Submit Response': props<{
       cardId: number;
@@ -42,43 +42,46 @@ export const PracticeSessionActions = createActionGroup({
     }>(),
     'Submit Response Success': props<{ response: CardResponse }>(),
     'Submit Response Failure': props<{ error: string }>(),
-    
+
     // Skip Card
     'Skip Card': props<{ cardId: number }>(),
     'Skip Card Success': emptyProps(),
-    
+
     // Settings
     'Update Settings': props<{ settings: Partial<PracticeSettings> }>(),
     'Save Settings': emptyProps(),
     'Reset Settings': emptyProps(),
-    
+
     // History
     'Load Session History': emptyProps(),
     'Load Session History Success': props<{ sessions: CompletedSession[] }>(),
     'Load Session History Failure': props<{ error: string }>(),
-    
+
     // UI Actions
     'Toggle Stats': emptyProps(),
     'Toggle Settings': emptyProps(),
-    'Show Feedback': props<{ message: string; type: 'success' | 'error' | 'info' }>(),
+    'Show Feedback': props<{
+      message: string;
+      messageType: 'success' | 'error' | 'info';
+    }>(),
     'Hide Feedback': emptyProps(),
-    
+
     // Performance Updates
     'Update Performance Metrics': emptyProps(),
     'Calculate Session Stats': emptyProps(),
-  }
+  },
 });
 
 // Separate action group for keyboard shortcuts
 export const PracticeKeyboardActions = createActionGroup({
   source: 'Practice Keyboard',
   events: {
-    'Press Space': emptyProps(),      // Flip card
-    'Press Enter': emptyProps(),      // Submit/Next
+    'Press Space': emptyProps(), // Flip card
+    'Press Enter': emptyProps(), // Submit/Next
     'Press Number': props<{ key: number }>(), // Quality rating 1-4
-    'Press H': emptyProps(),          // Show hint
-    'Press S': emptyProps(),          // Skip card
-    'Press P': emptyProps(),          // Play audio
-    'Press Escape': emptyProps(),     // Pause/Settings
-  }
+    'Press H': emptyProps(), // Show hint
+    'Press S': emptyProps(), // Skip card
+    'Press P': emptyProps(), // Play audio
+    'Press Escape': emptyProps(), // Pause/Settings
+  },
 });

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../app.state';
@@ -13,9 +13,6 @@ import {
   filter,
 } from 'rxjs/operators';
 
-import { PracticeService } from '@app/app/core/services/practice.service';
-import { AudioService } from '@app/app/core/services/audio.service';
-import { NotificationService } from '@app/app/core/services/notification.service';
 import {
   PracticeSessionActions,
   PracticeKeyboardActions,
@@ -28,9 +25,19 @@ import {
 } from '../selectors/practice-session.selectors';
 import { BaseEffect } from '../../core/effects/base.effect';
 import { ResponseQuality } from '../models/practice-session.model';
+import { PracticeService } from '@app/app/core/services/practice.service';
+import { AudioService } from '@app/app/core/services/audio.service';
+import { NotificationService } from '@app/app/core/services/notification.service';
 
 @Injectable()
 export class PracticeSessionEffects extends BaseEffect {
+
+  private actions$ = inject(Actions);
+  private store = inject(Store);
+  private audioService = inject(AudioService);
+  private practiceService = inject(PracticeService);
+  private notificationService = inject(NotificationService);
+
   startSession$ = createEffect(() =>
     this.actions$.pipe(
       ofType(PracticeSessionActions.startSession),
@@ -244,7 +251,7 @@ export class PracticeSessionEffects extends BaseEffect {
         this.store.select((state) => state.practiceSession.ui),
       ),
       map(([_, session, card, ui]) => {
-        if (!session || !card) return { type: 'NO_OP' };
+        if (!session || !card) return { type: 'NO_OP' } as any;
         if (!ui.currentCardFlipped) {
           return PracticeSessionActions.flipCard();
         }
@@ -258,7 +265,7 @@ export class PracticeSessionEffects extends BaseEffect {
         }
         return PracticeSessionActions.showNextCard();
       }),
-      filter((action) => action.type !== 'NO_OP'),
+      filter((action) => (action as any).type !== 'NO_OP'),
     ),
   );
 
@@ -280,12 +287,8 @@ export class PracticeSessionEffects extends BaseEffect {
   );
 
   constructor(
-    private actions$: Actions,
-    private store: Store<AppState>,
-    private practiceService: PracticeService,
-    private audioService: AudioService,
-    private notificationService: NotificationService,
   ) {
     super();
   }
 }
+

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -1,0 +1,252 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { of, interval, timer } from 'rxjs';
+import {
+  map,
+  mergeMap,
+  catchError,
+  withLatestFrom,
+  tap,
+  takeUntil,
+  filter,
+} from 'rxjs/operators';
+
+import { PracticeService } from '@app/core/services/practice.service';
+import { AudioService } from '@app/core/services/audio.service';
+import { NotificationService } from '@app/core/services/notification.service';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+import {
+  selectActiveSession,
+  selectCurrentCard,
+  selectSettings,
+  selectSessionProgress,
+} from '../selectors/practice-session.selectors';
+import { BaseEffect } from '../../core/effects/base.effect';
+import { ResponseQuality } from '../models/practice-session.model';
+
+@Injectable()
+export class PracticeSessionEffects extends BaseEffect {
+  startSession$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSession),
+      mergeMap(({ request }) =>
+        this.practiceService.startSession(request).pipe(
+          map((session) => PracticeSessionActions.startSessionSuccess({ session })),
+          tap(() => {
+            this.notificationService.info('Session started! Good luck!');
+          }),
+          this.handleHttpError((error) =>
+            PracticeSessionActions.startSessionFailure({ error })
+          )
+        )
+      )
+    )
+  );
+
+  // Auto-play audio when card is flipped (if enabled)
+  autoPlayAudio$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(PracticeSessionActions.flipCard),
+        withLatestFrom(
+          this.store.select(selectCurrentCard),
+          this.store.select(selectSettings)
+        ),
+        filter(([_, card, settings]) => settings.autoPlayAudio && !!card?.audioUrl),
+        tap(([_, card]) => {
+          if (card?.audioUrl) {
+            this.audioService.play(card.audioUrl);
+          }
+        })
+      ),
+    { dispatch: false }
+  );
+
+  submitResponse$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.submitResponse),
+      withLatestFrom(this.store.select(selectActiveSession)),
+      mergeMap(([action, session]) => {
+        if (!session) {
+          return of(
+            PracticeSessionActions.submitResponseFailure({ error: 'No active session' })
+          );
+        }
+
+        return this.practiceService
+          .submitResponse({
+            sessionId: session.id,
+            cardId: action.cardId,
+            quality: action.quality,
+            responseTime: action.responseTime,
+            hintsUsed: action.hintsUsed,
+          })
+          .pipe(
+            map((response) => PracticeSessionActions.submitResponseSuccess({ response })),
+            tap((successAction) => {
+              if (successAction.response.correct) {
+                this.notificationService.success('Correct! 🎉', { duration: 1000 });
+              } else {
+                this.notificationService.error('Try again next time', { duration: 1000 });
+              }
+            }),
+            this.handleHttpError((error) =>
+              PracticeSessionActions.submitResponseFailure({ error })
+            )
+          );
+      })
+    )
+  );
+
+  // Auto-advance to next card after response
+  autoAdvance$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.submitResponseSuccess),
+      withLatestFrom(
+        this.store.select(selectSettings),
+        this.store.select(selectSessionProgress)
+      ),
+      filter(([_, settings]) => settings.immediateAnswerFeedback),
+      mergeMap(([_, __, progress]) => {
+        return timer(1500).pipe(
+          map(() => {
+            if (progress.remainingCards > 0) {
+              return PracticeSessionActions.showNextCard();
+            } else {
+              return PracticeSessionActions.completeSession();
+            }
+          })
+        );
+      })
+    )
+  );
+
+  completeSession$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.completeSession),
+      withLatestFrom(this.store.select(selectActiveSession)),
+      mergeMap(([_, session]) => {
+        if (!session) {
+          return of(
+            PracticeSessionActions.completeSessionFailure({ error: 'No active session' })
+          );
+        }
+
+        return this.practiceService.completeSession(session.id).pipe(
+          map((summary) => PracticeSessionActions.completeSessionSuccess({ summary })),
+          tap((action) => {
+            const { session } = action.summary;
+            const message = `Session complete! ${session.correctCount}/${session.cardsStudied} correct (${Math.round(
+              session.accuracy
+            )}%)`;
+            this.notificationService.success(message);
+            this.audioService.playSound('session-complete');
+            action.summary.achievements.forEach((achievement) => {
+              this.notificationService.info(`🏆 Achievement Unlocked: ${achievement.title}`, {
+                duration: 5000,
+              });
+            });
+          }),
+          this.handleHttpError((error) =>
+            PracticeSessionActions.completeSessionFailure({ error })
+          )
+        );
+      })
+    )
+  );
+
+  // Session timer
+  sessionTimer$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSessionSuccess),
+      mergeMap(({ session }) => {
+        if (!session.settings.timeLimit) {
+          return of();
+        }
+
+        const timeLimit = session.settings.timeLimit * 60 * 1000;
+
+        return timer(timeLimit).pipe(
+          takeUntil(
+            this.actions$.pipe(
+              ofType(PracticeSessionActions.completeSession, PracticeSessionActions.abandonSession)
+            )
+          ),
+          tap(() => {
+            this.notificationService.warning('Time limit reached!');
+          }),
+          map(() => PracticeSessionActions.completeSession())
+        );
+      })
+    )
+  );
+
+  // Update performance metrics periodically
+  updateMetrics$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.startSessionSuccess),
+      mergeMap(() =>
+        interval(5000).pipe(
+          takeUntil(
+            this.actions$.pipe(
+              ofType(PracticeSessionActions.completeSession, PracticeSessionActions.abandonSession)
+            )
+          ),
+          map(() => PracticeSessionActions.updatePerformanceMetrics())
+        )
+      )
+    )
+  );
+
+  // Keyboard shortcut handling
+  keyboardShortcuts$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeKeyboardActions.pressEnter),
+      withLatestFrom(
+        this.store.select(selectActiveSession),
+        this.store.select(selectCurrentCard),
+        this.store.select((state) => state.practiceSession.ui)
+      ),
+      map(([_, session, card, ui]) => {
+        if (!session || !card) return { type: 'NO_OP' };
+        if (!ui.currentCardFlipped) {
+          return PracticeSessionActions.flipCard();
+        }
+        if (!card.seen) {
+          return PracticeSessionActions.submitResponse({
+            cardId: card.id,
+            quality: ResponseQuality.GOOD,
+            responseTime: Date.now() - session.startTime.getTime(),
+            hintsUsed: ui.showingHint ? 1 : 0,
+          });
+        }
+        return PracticeSessionActions.showNextCard();
+      }),
+      filter((action) => action.type !== 'NO_OP')
+    )
+  );
+
+  // Load session history on init
+  loadHistory$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PracticeSessionActions.loadSessionHistory),
+      mergeMap(() =>
+        this.practiceService.getSessionHistory().pipe(
+          map((sessions) => PracticeSessionActions.loadSessionHistorySuccess({ sessions })),
+          this.handleHttpError((error) => PracticeSessionActions.loadSessionHistoryFailure({ error }))
+        )
+      )
+    )
+  );
+
+  constructor(
+    private actions$: Actions,
+    private store: Store,
+    private practiceService: PracticeService,
+    private audioService: AudioService,
+    private notificationService: NotificationService
+  ) {
+    super();
+  }
+}

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -13,9 +13,9 @@ import {
   filter,
 } from 'rxjs/operators';
 
-import { PracticeService } from '@app/core/services/practice.service';
-import { AudioService } from '@app/core/services/audio.service';
-import { NotificationService } from '@app/core/services/notification.service';
+import { PracticeService } from '@app/app/core/services/practice.service';
+import { AudioService } from '@app/app/core/services/audio.service';
+import { NotificationService } from '@app/app/core/services/notification.service';
 import {
   PracticeSessionActions,
   PracticeKeyboardActions,

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -13,9 +13,9 @@ import {
   filter,
 } from 'rxjs/operators';
 
-import { PracticeService } from '@app/app/core/services/practice.service';
-import { AudioService } from '@app/app/core/services/audio.service';
-import { NotificationService } from '@app/app/core/services/notification.service';
+import { PracticeService } from '@app/core/services/practice.service';
+import { AudioService } from '@app/core/services/audio.service';
+import { NotificationService } from '@app/core/services/notification.service';
 import {
   PracticeSessionActions,
   PracticeKeyboardActions,
@@ -103,13 +103,9 @@ export class PracticeSessionEffects extends BaseEffect {
                 >,
               ) => {
                 if (successAction.response.correct) {
-                  this.notificationService.success('Correct! 🎉', {
-                    duration: 1000,
-                  });
+                  this.notificationService.success('Correct! 🎉', 1000);
                 } else {
-                  this.notificationService.error('Try again next time', {
-                    duration: 1000,
-                  });
+                  this.notificationService.error('Try again next time', 1000);
                 }
               },
             ),
@@ -176,9 +172,7 @@ export class PracticeSessionEffects extends BaseEffect {
               action.summary.achievements.forEach((achievement: any) => {
                 this.notificationService.info(
                   `🏆 Achievement Unlocked: ${achievement.title}`,
-                  {
-                    duration: 5000,
-                  },
+                  5000,
                 );
               });
             },

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { AppState } from '../app.state';
+import { AppState } from '../../app.state';
 import { of, interval, timer } from 'rxjs';
 import {
   map,
@@ -13,9 +13,9 @@ import {
   filter,
 } from 'rxjs/operators';
 
-import { PracticeService } from '@app/core/services/practice.service';
-import { AudioService } from '@app/core/services/audio.service';
-import { NotificationService } from '@app/core/services/notification.service';
+import { PracticeService } from '@app/app/core/services/practice.service';
+import { AudioService } from '@app/app/core/services/audio.service';
+import { NotificationService } from '@app/app/core/services/notification.service';
 import {
   PracticeSessionActions,
   PracticeKeyboardActions,

--- a/frontend/src/app/state/practice-session/index.ts
+++ b/frontend/src/app/state/practice-session/index.ts
@@ -1,0 +1,5 @@
+export * from './actions/practice-session.actions';
+export * from './reducers/practice-session.reducer';
+export * from './effects/practice-session.effects';
+export * from './selectors/practice-session.selectors';
+export * from './models/practice-session.model';

--- a/frontend/src/app/state/practice-session/models/practice-session.model.ts
+++ b/frontend/src/app/state/practice-session/models/practice-session.model.ts
@@ -1,0 +1,203 @@
+export interface PracticeSessionState {
+  activeSession: ActiveSession | null;
+  sessionHistory: CompletedSession[];
+  settings: PracticeSettings;
+  performance: PerformanceMetrics;
+  ui: PracticeUIState;
+}
+
+// Active Session
+export interface ActiveSession {
+  id: string;
+  deckId: number;
+  deckName: string;
+  type: SessionType;
+  cards: StudyCard[];
+  currentIndex: number;
+  responses: CardResponse[];
+  startTime: Date;
+  settings: PracticeSettings;
+  state: SessionState;
+}
+
+export interface StudyCard {
+  id: number;
+  deckId: number;
+  front: string;
+  back: string;
+  hint?: string;
+  verseReference?: string;
+  audioUrl?: string;
+  
+  // SR Algorithm Data
+  easeFactor: number;
+  interval: number;
+  repetitions: number;
+  
+  // Session-specific
+  order: number;
+  seen: boolean;
+  lastResponseQuality?: number;
+}
+
+export interface CardResponse {
+  cardId: number;
+  quality: ResponseQuality;
+  responseTime: number; // milliseconds
+  hintsUsed: number;
+  audioPlayed: boolean;
+  timestamp: Date;
+  
+  // Calculated fields
+  correct: boolean;
+  newInterval: number;
+  newEaseFactor: number;
+}
+
+export enum SessionType {
+  REVIEW = 'review',
+  LEARN = 'learn',
+  CRAM = 'cram',
+  QUIZ = 'quiz'
+}
+
+export enum SessionState {
+  NOT_STARTED = 'not_started',
+  IN_PROGRESS = 'in_progress',
+  PAUSED = 'paused',
+  COMPLETED = 'completed',
+  ABANDONED = 'abandoned'
+}
+
+export enum ResponseQuality {
+  AGAIN = 0,      // Complete blackout
+  HARD = 1,       // Difficult recall
+  GOOD = 2,       // Normal recall
+  EASY = 3,       // Perfect recall
+  SKIP = -1       // Skipped card
+}
+
+// Completed Session
+export interface CompletedSession {
+  id: string;
+  deckId: number;
+  type: SessionType;
+  startTime: Date;
+  endTime: Date;
+  duration: number; // seconds
+  cardsStudied: number;
+  correctCount: number;
+  accuracy: number;
+  averageResponseTime: number;
+  masteryChange: number;
+  streakMaintained: boolean;
+}
+
+// Settings
+export interface PracticeSettings {
+  // Session Configuration
+  sessionType: SessionType;
+  cardLimit: number;
+  timeLimit: number | null; // minutes
+  
+  // Card Selection
+  newCardsPerSession: number;
+  reviewOrder: ReviewOrder;
+  prioritizeDue: boolean;
+  includeNewCards: boolean;
+  
+  // Display Options
+  showHints: boolean;
+  autoPlayAudio: boolean;
+  flipAnimation: boolean;
+  fontSize: 'small' | 'medium' | 'large';
+  
+  // Behavior
+  immediateAnswerFeedback: boolean;
+  requireTypedAnswer: boolean;
+  caseSensitive: boolean;
+  showProgress: boolean;
+  
+  // Spaced Repetition
+  easyBonus: number;        // 1.3 default
+  intervalModifier: number; // 1.0 default
+  lapseMultiplier: number;  // 0.5 default
+  minimumInterval: number;  // 1 day
+}
+
+export enum ReviewOrder {
+  DUE_DATE = 'due_date',
+  RANDOM = 'random',
+  DIFFICULTY = 'difficulty',
+  CREATED = 'created'
+}
+
+// Performance Metrics
+export interface PerformanceMetrics {
+  // Current Session
+  currentStreak: number;
+  longestStreak: number;
+  totalTime: number;
+  cardsPerMinute: number;
+  
+  // Historical
+  dailyAverage: number;
+  weeklyProgress: number;
+  monthlyRetention: number;
+  overallAccuracy: number;
+}
+
+// UI State
+export interface PracticeUIState {
+  currentCardFlipped: boolean;
+  showingHint: boolean;
+  answerRevealed: boolean;
+  feedbackVisible: boolean;
+  statsVisible: boolean;
+  settingsOpen: boolean;
+}
+
+// API Models
+export interface StartSessionRequest {
+  deckId: number;
+  settings: Partial<PracticeSettings>;
+}
+
+export interface SubmitResponseRequest {
+  sessionId: string;
+  cardId: number;
+  quality: ResponseQuality;
+  responseTime: number;
+  hintsUsed: number;
+}
+
+export interface SessionSummary {
+  session: CompletedSession;
+  cardUpdates: CardUpdate[];
+  achievements: Achievement[];
+  nextReviewSummary: NextReviewSummary;
+}
+
+export interface CardUpdate {
+  cardId: number;
+  oldInterval: number;
+  newInterval: number;
+  oldEaseFactor: number;
+  newEaseFactor: number;
+  nextReview: Date;
+}
+
+export interface Achievement {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  unlockedAt: Date;
+}
+
+export interface NextReviewSummary {
+  today: number;
+  tomorrow: number;
+  thisWeek: number;
+  thisMonth: number;
+}

--- a/frontend/src/app/state/practice-session/models/practice-session.model.ts
+++ b/frontend/src/app/state/practice-session/models/practice-session.model.ts
@@ -28,16 +28,17 @@ export interface StudyCard {
   hint?: string;
   verseReference?: string;
   audioUrl?: string;
-  
+
   // SR Algorithm Data
   easeFactor: number;
   interval: number;
   repetitions: number;
-  
+
   // Session-specific
   order: number;
   seen: boolean;
   lastResponseQuality?: number;
+  nextReview?: Date;
 }
 
 export interface CardResponse {
@@ -47,7 +48,7 @@ export interface CardResponse {
   hintsUsed: number;
   audioPlayed: boolean;
   timestamp: Date;
-  
+
   // Calculated fields
   correct: boolean;
   newInterval: number;
@@ -58,7 +59,7 @@ export enum SessionType {
   REVIEW = 'review',
   LEARN = 'learn',
   CRAM = 'cram',
-  QUIZ = 'quiz'
+  QUIZ = 'quiz',
 }
 
 export enum SessionState {
@@ -66,15 +67,15 @@ export enum SessionState {
   IN_PROGRESS = 'in_progress',
   PAUSED = 'paused',
   COMPLETED = 'completed',
-  ABANDONED = 'abandoned'
+  ABANDONED = 'abandoned',
 }
 
 export enum ResponseQuality {
-  AGAIN = 0,      // Complete blackout
-  HARD = 1,       // Difficult recall
-  GOOD = 2,       // Normal recall
-  EASY = 3,       // Perfect recall
-  SKIP = -1       // Skipped card
+  AGAIN = 0, // Complete blackout
+  HARD = 1, // Difficult recall
+  GOOD = 2, // Normal recall
+  EASY = 3, // Perfect recall
+  SKIP = -1, // Skipped card
 }
 
 // Completed Session
@@ -99,37 +100,37 @@ export interface PracticeSettings {
   sessionType: SessionType;
   cardLimit: number;
   timeLimit: number | null; // minutes
-  
+
   // Card Selection
   newCardsPerSession: number;
   reviewOrder: ReviewOrder;
   prioritizeDue: boolean;
   includeNewCards: boolean;
-  
+
   // Display Options
   showHints: boolean;
   autoPlayAudio: boolean;
   flipAnimation: boolean;
   fontSize: 'small' | 'medium' | 'large';
-  
+
   // Behavior
   immediateAnswerFeedback: boolean;
   requireTypedAnswer: boolean;
   caseSensitive: boolean;
   showProgress: boolean;
-  
+
   // Spaced Repetition
-  easyBonus: number;        // 1.3 default
+  easyBonus: number; // 1.3 default
   intervalModifier: number; // 1.0 default
-  lapseMultiplier: number;  // 0.5 default
-  minimumInterval: number;  // 1 day
+  lapseMultiplier: number; // 0.5 default
+  minimumInterval: number; // 1 day
 }
 
 export enum ReviewOrder {
   DUE_DATE = 'due_date',
   RANDOM = 'random',
   DIFFICULTY = 'difficulty',
-  CREATED = 'created'
+  CREATED = 'created',
 }
 
 // Performance Metrics
@@ -139,7 +140,7 @@ export interface PerformanceMetrics {
   longestStreak: number;
   totalTime: number;
   cardsPerMinute: number;
-  
+
   // Historical
   dailyAverage: number;
   weeklyProgress: number;

--- a/frontend/src/app/state/practice-session/reducers/practice-session.reducer.ts
+++ b/frontend/src/app/state/practice-session/reducers/practice-session.reducer.ts
@@ -1,0 +1,236 @@
+import { createReducer, on } from '@ngrx/store';
+import {
+  PracticeSessionState,
+  SessionState,
+  SessionType,
+  ReviewOrder,
+  ResponseQuality,
+} from '../models/practice-session.model';
+import { PracticeSessionActions, PracticeKeyboardActions } from '../actions/practice-session.actions';
+
+export const initialState: PracticeSessionState = {
+  activeSession: null,
+  sessionHistory: [],
+  settings: {
+    sessionType: SessionType.REVIEW,
+    cardLimit: 20,
+    timeLimit: null,
+    newCardsPerSession: 5,
+    reviewOrder: ReviewOrder.DUE_DATE,
+    prioritizeDue: true,
+    includeNewCards: true,
+    showHints: true,
+    autoPlayAudio: false,
+    flipAnimation: true,
+    fontSize: 'medium',
+    immediateAnswerFeedback: true,
+    requireTypedAnswer: false,
+    caseSensitive: false,
+    showProgress: true,
+    easyBonus: 1.3,
+    intervalModifier: 1.0,
+    lapseMultiplier: 0.5,
+    minimumInterval: 1,
+  },
+  performance: {
+    currentStreak: 0,
+    longestStreak: 0,
+    totalTime: 0,
+    cardsPerMinute: 0,
+    dailyAverage: 0,
+    weeklyProgress: 0,
+    monthlyRetention: 0,
+    overallAccuracy: 0,
+  },
+  ui: {
+    currentCardFlipped: false,
+    showingHint: false,
+    answerRevealed: false,
+    feedbackVisible: false,
+    statsVisible: false,
+    settingsOpen: false,
+  },
+};
+
+export const practiceSessionReducer = createReducer(
+  initialState,
+
+  // Start Session
+  on(PracticeSessionActions.startSessionSuccess, (state, { session }) => ({
+    ...state,
+    activeSession: session,
+    ui: {
+      ...initialState.ui,
+    },
+  })),
+
+  // Pause/Resume
+  on(PracticeSessionActions.pauseSession, (state) => ({
+    ...state,
+    activeSession: state.activeSession
+      ? { ...state.activeSession, state: SessionState.PAUSED }
+      : null,
+  })),
+
+  on(PracticeSessionActions.resumeSession, (state) => ({
+    ...state,
+    activeSession: state.activeSession
+      ? { ...state.activeSession, state: SessionState.IN_PROGRESS }
+      : null,
+  })),
+
+  // Card Navigation
+  on(PracticeSessionActions.showNextCard, (state) => {
+    if (!state.activeSession) return state;
+
+    const nextIndex = Math.min(
+      state.activeSession.currentIndex + 1,
+      state.activeSession.cards.length - 1
+    );
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        currentIndex: nextIndex,
+      },
+      ui: {
+        ...state.ui,
+        currentCardFlipped: false,
+        showingHint: false,
+        answerRevealed: false,
+        feedbackVisible: false,
+      },
+    };
+  }),
+
+  on(PracticeSessionActions.showPreviousCard, (state) => {
+    if (!state.activeSession) return state;
+
+    const prevIndex = Math.max(state.activeSession.currentIndex - 1, 0);
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        currentIndex: prevIndex,
+      },
+      ui: {
+        ...state.ui,
+        currentCardFlipped: false,
+        showingHint: false,
+        answerRevealed: false,
+      },
+    };
+  }),
+
+  // Card Interaction
+  on(PracticeSessionActions.flipCard, PracticeKeyboardActions.pressSpace, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      currentCardFlipped: !state.ui.currentCardFlipped,
+      answerRevealed: true,
+    },
+  })),
+
+  on(PracticeSessionActions.showHint, PracticeKeyboardActions.pressH, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      showingHint: true,
+    },
+  })),
+
+  // Submit Response
+  on(PracticeSessionActions.submitResponseSuccess, (state, { response }) => {
+    if (!state.activeSession) return state;
+
+    const updatedResponses = [...state.activeSession.responses, response];
+    const currentStreak = response.correct ? state.performance.currentStreak + 1 : 0;
+
+    return {
+      ...state,
+      activeSession: {
+        ...state.activeSession,
+        responses: updatedResponses,
+        cards: state.activeSession.cards.map((card) =>
+          card.id === response.cardId
+            ? { ...card, seen: true, lastResponseQuality: response.quality }
+            : card
+        ),
+      },
+      performance: {
+        ...state.performance,
+        currentStreak,
+        longestStreak: Math.max(currentStreak, state.performance.longestStreak),
+      },
+      ui: {
+        ...state.ui,
+        feedbackVisible: state.settings.immediateAnswerFeedback,
+      },
+    };
+  }),
+
+  // Settings
+  on(PracticeSessionActions.updateSettings, (state, { settings }) => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      ...settings,
+    },
+  })),
+
+  // UI State
+  on(PracticeSessionActions.toggleStats, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      statsVisible: !state.ui.statsVisible,
+    },
+  })),
+
+  on(PracticeSessionActions.toggleSettings, (state) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      settingsOpen: !state.ui.settingsOpen,
+    },
+  })),
+
+  // Complete Session
+  on(PracticeSessionActions.completeSessionSuccess, (state, { summary }) => ({
+    ...state,
+    activeSession: null,
+    sessionHistory: [summary.session, ...state.sessionHistory].slice(0, 50),
+    performance: {
+      ...state.performance,
+      overallAccuracy: calculateNewAccuracy(
+        state.performance.overallAccuracy,
+        summary.session.accuracy
+      ),
+    },
+  })),
+
+  // Keyboard Shortcuts
+  on(PracticeKeyboardActions.pressNumber, (state, { key }) => {
+    if (!state.activeSession || !state.ui.currentCardFlipped) return state;
+
+    const qualityMap: { [key: number]: ResponseQuality } = {
+      1: ResponseQuality.AGAIN,
+      2: ResponseQuality.HARD,
+      3: ResponseQuality.GOOD,
+      4: ResponseQuality.EASY,
+    };
+
+    const quality = qualityMap[key];
+    if (quality === undefined) return state;
+
+    return state;
+  })
+);
+
+// Helper function
+function calculateNewAccuracy(currentAccuracy: number, sessionAccuracy: number): number {
+  return currentAccuracy * 0.9 + sessionAccuracy * 0.1;
+}

--- a/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
+++ b/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
@@ -1,0 +1,196 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { PracticeSessionState, StudyCard } from '../models/practice-session.model';
+
+export const selectPracticeSessionState =
+  createFeatureSelector<PracticeSessionState>('practiceSession');
+
+export const selectActiveSession = createSelector(
+  selectPracticeSessionState,
+  (state) => state.activeSession
+);
+
+export const selectIsSessionActive = createSelector(
+  selectActiveSession,
+  (session) => session !== null
+);
+
+export const selectSessionCards = createSelector(
+  selectActiveSession,
+  (session) => session?.cards || []
+);
+
+export const selectCurrentCardIndex = createSelector(
+  selectActiveSession,
+  (session) => session?.currentIndex || 0
+);
+
+export const selectCurrentCard = createSelector(
+  selectActiveSession,
+  selectCurrentCardIndex,
+  (session, index) => session?.cards[index] || null
+);
+
+export const selectSessionProgress = createSelector(
+  selectActiveSession,
+  (session) => {
+    if (!session) {
+      return {
+        totalCards: 0,
+        seenCards: 0,
+        remainingCards: 0,
+        percentComplete: 0,
+      };
+    }
+
+    const seenCards = session.cards.filter((card) => card.seen).length;
+    const totalCards = session.cards.length;
+    const remainingCards = totalCards - seenCards;
+    const percentComplete = totalCards > 0 ? (seenCards / totalCards) * 100 : 0;
+
+    return {
+      totalCards,
+      seenCards,
+      remainingCards,
+      percentComplete,
+    };
+  }
+);
+
+export const selectSessionStats = createSelector(
+  selectActiveSession,
+  (session) => {
+    if (!session || session.responses.length === 0) {
+      return {
+        correctCount: 0,
+        incorrectCount: 0,
+        accuracy: 0,
+        averageResponseTime: 0,
+        hintsUsed: 0,
+      };
+    }
+
+    const correctCount = session.responses.filter((r) => r.correct).length;
+    const incorrectCount = session.responses.length - correctCount;
+    const accuracy = (correctCount / session.responses.length) * 100;
+    const totalResponseTime = session.responses.reduce((sum, r) => sum + r.responseTime, 0);
+    const averageResponseTime = totalResponseTime / session.responses.length;
+    const hintsUsed = session.responses.reduce((sum, r) => sum + r.hintsUsed, 0);
+
+    return {
+      correctCount,
+      incorrectCount,
+      accuracy,
+      averageResponseTime: Math.round(averageResponseTime / 1000),
+      hintsUsed,
+    };
+  }
+);
+
+export const selectSettings = createSelector(
+  selectPracticeSessionState,
+  (state) => state.settings
+);
+
+export const selectSessionType = createSelector(
+  selectSettings,
+  (settings) => settings.sessionType
+);
+
+export const selectPerformance = createSelector(
+  selectPracticeSessionState,
+  (state) => state.performance
+);
+
+export const selectCurrentStreak = createSelector(
+  selectPerformance,
+  (performance) => performance.currentStreak
+);
+
+export const selectCardsPerMinute = createSelector(
+  selectActiveSession,
+  selectSessionStats,
+  (session, stats) => {
+    if (!session || stats.correctCount + stats.incorrectCount === 0) {
+      return 0;
+    }
+
+    const elapsedMinutes = (Date.now() - session.startTime.getTime()) / 60000;
+    return (stats.correctCount + stats.incorrectCount) / elapsedMinutes;
+  }
+);
+
+export const selectSessionHistory = createSelector(
+  selectPracticeSessionState,
+  (state) => state.sessionHistory
+);
+
+export const selectRecentSessions = createSelector(
+  selectSessionHistory,
+  (history) => history.slice(0, 10)
+);
+
+export const selectTodaySessions = createSelector(
+  selectSessionHistory,
+  (history) => {
+    const today = new Date().toDateString();
+    return history.filter((session) => new Date(session.startTime).toDateString() === today);
+  }
+);
+
+export const selectUI = createSelector(
+  selectPracticeSessionState,
+  (state) => state.ui
+);
+
+export const selectIsCardFlipped = createSelector(
+  selectUI,
+  (ui) => ui.currentCardFlipped
+);
+
+export const selectIsShowingHint = createSelector(
+  selectUI,
+  (ui) => ui.showingHint
+);
+
+export const selectIsStatsVisible = createSelector(
+  selectUI,
+  (ui) => ui.statsVisible
+);
+
+export const selectNextReviewTime = createSelector(
+  selectCurrentCard,
+  selectActiveSession,
+  (card, session) => {
+    if (!card || !session) return null;
+
+    const response = session.responses.find((r) => r.cardId === card.id);
+    if (!response) return null;
+
+    return new Date(Date.now() + response.newInterval * 24 * 60 * 60 * 1000);
+  }
+);
+
+export const selectDueCardsInSession = createSelector(
+  selectSessionCards,
+  (cards) => {
+    const now = new Date();
+    return cards.filter((card) => card.nextReview && new Date(card.nextReview) <= now);
+  }
+);
+
+export const selectSessionSummary = createSelector(
+  selectActiveSession,
+  selectSessionStats,
+  selectSessionProgress,
+  (session, stats, progress) => {
+    if (!session) return null;
+
+    return {
+      deckName: session.deckName,
+      sessionType: session.type,
+      duration: Math.round((Date.now() - session.startTime.getTime()) / 1000),
+      ...stats,
+      ...progress,
+    };
+  }
+);

--- a/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
+++ b/frontend/src/app/state/practice-session/selectors/practice-session.selectors.ts
@@ -1,8 +1,8 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { PracticeSessionState, StudyCard } from '../models/practice-session.model';
 
-export const selectPracticeSessionState =
-  createFeatureSelector<PracticeSessionState>('practiceSession');
+export const selectPracticeSessionState = createFeatureSelector<PracticeSessionState>('practiceSession');
+
 
 export const selectActiveSession = createSelector(
   selectPracticeSessionState,
@@ -40,7 +40,7 @@ export const selectSessionProgress = createSelector(
         remainingCards: 0,
         percentComplete: 0,
       };
-    }
+    } 
 
     const seenCards = session.cards.filter((card) => card.seen).length;
     const totalCards = session.cards.length;


### PR DESCRIPTION
## Summary
- add models to represent practice session state
- create NgRx actions, reducer, selectors and effects
- expose practice-session feature in state index
- register practice session feature in the Angular app config
- extend application state interface for practice sessions

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880dc80b84c8331a3fd4dace0131a4c