### PR TITLE
Rename BibleBook model

### DIFF
--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -7,7 +7,7 @@ import { Subscription } from 'rxjs';
 import Chart from 'chart.js/auto';
 
 // Import models
-import { BibleBook, BibleChapter, BibleData, BibleTestament, UserVerseDetail } from '../core/models/bible';
+import { BookProgress, BibleChapter, BibleData, BibleTestament, UserVerseDetail } from '../core/models/bible';
 import { BibleVerse } from '../core/models/bible/bible-verse.model';
 import { BibleGroup } from '../core/models/bible/bible-group.modle';
 
@@ -63,7 +63,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
 
   selectedTestament: BibleTestament | null = null;
   selectedGroup: BibleGroup | null = null;
-  selectedBook: BibleBook | null = null;
+  selectedBook: BookProgress | null = null;
   selectedChapter: BibleChapter | null = null;
 
   userVerses: UserVerseDetail[] = [];
@@ -296,7 +296,7 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
     }
   }
 
-  setBook(book: BibleBook): void {
+  setBook(book: BookProgress): void {
     this.selectedBook = book;
     const visibleChapters = this.getVisibleChapters(book);
     if (visibleChapters.length > 0) {
@@ -466,7 +466,7 @@ async selectAllChapters(): Promise<void> {
     return this.includeApocrypha || !chapter.isApocryphal;
   }
 
-  getVisibleChapters(book: BibleBook): BibleChapter[] {
+  getVisibleChapters(book: BookProgress): BibleChapter[] {
     return book.chapters.filter(chapter => this.isChapterVisible(chapter));
   }
 
@@ -515,7 +515,7 @@ async selectAllChapters(): Promise<void> {
     return this.defaultBook.group;
   }
 
-  get defaultBook(): BibleBook {
+  get defaultBook(): BookProgress {
     return this.bibleData.getBookByName("Genesis");
   }
 

--- a/frontend/src/app/bible-tracker/components/bible-tracker-book-grid/bible-tracker-book-grid.component.ts
+++ b/frontend/src/app/bible-tracker/components/bible-tracker-book-grid/bible-tracker-book-grid.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BibleBook } from '../../../core/models/bible';
+import { BookProgress } from '../../../core/models/bible';
 import { BibleGroup } from '../../../core/models/bible/bible-group.modle';
 
 @Component({
@@ -12,16 +12,16 @@ import { BibleGroup } from '../../../core/models/bible/bible-group.modle';
 })
 export class BibleTrackerBookGridComponent {
   @Input() selectedGroup: BibleGroup | null = null;
-  @Input() selectedBook: BibleBook | null = null;
-  @Output() bookSelected = new EventEmitter<BibleBook>();
+  @Input() selectedBook: BookProgress | null = null;
+  @Output() bookSelected = new EventEmitter<BookProgress>();
   
-  isApocryphalBook(book: BibleBook): boolean {
+  isApocryphalBook(book: BookProgress): boolean {
     return book.canonicalAffiliation !== 'All' &&
       (book.canonicalAffiliation === 'Catholic' ||
         book.canonicalAffiliation === 'Eastern Orthodox');
   }
   
-  getBookProgressColor(book: BibleBook): string {
+  getBookProgressColor(book: BookProgress): string {
     const percent = book.percentComplete;
     if (percent >= 80) return '#10b981';
     if (percent >= 50) return '#3b82f6';
@@ -29,7 +29,7 @@ export class BibleTrackerBookGridComponent {
     return '#f59e0b';
   }
   
-  selectBook(book: BibleBook): void {
+  selectBook(book: BookProgress): void {
     this.bookSelected.emit(book);
   }
 }

--- a/frontend/src/app/bible-tracker/components/bible-tracker-chapter-heatmap/bible-tracker-chapter-heatmap.component.ts
+++ b/frontend/src/app/bible-tracker/components/bible-tracker-chapter-heatmap/bible-tracker-chapter-heatmap.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BibleBook, BibleChapter } from '../../../core/models/bible';
+import { BookProgress, BibleChapter } from '../../../core/models/bible';
 
 @Component({
   selector: 'app-bible-tracker-chapter-heatmap',
@@ -10,7 +10,7 @@ import { BibleBook, BibleChapter } from '../../../core/models/bible';
   styleUrls: ['./bible-tracker-chapter-heatmap.component.scss']
 })
 export class BibleTrackerChapterHeatmapComponent {
-  @Input() selectedBook: BibleBook | null = null;
+  @Input() selectedBook: BookProgress | null = null;
   @Input() includeApocrypha: boolean = false;
   @Input() isLoading: boolean = false;
   @Input() isSavingBulk: boolean = false;

--- a/frontend/src/app/bible-tracker/components/bible-tracker-verse-grid/bible-tracker-verse-grid.component.ts
+++ b/frontend/src/app/bible-tracker/components/bible-tracker-verse-grid/bible-tracker-verse-grid.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { BibleBook, BibleChapter, BibleVerse } from '../../../core/models/bible';
+import { BookProgress, BibleChapter, BibleVerse } from '../../../core/models/bible';
 
 @Component({
   selector: 'app-bible-tracker-verse-grid',
@@ -11,7 +11,7 @@ import { BibleBook, BibleChapter, BibleVerse } from '../../../core/models/bible'
   styleUrls: ['./bible-tracker-verse-grid.component.scss']
 })
 export class BibleTrackerVerseGridComponent {
-  @Input() selectedBook: BibleBook | null = null;
+  @Input() selectedBook: BookProgress | null = null;
   @Input() selectedChapter: BibleChapter | null = null;
   @Input() isLoading: boolean = false;
   @Input() isSavingBulk: boolean = false;

--- a/frontend/src/app/core/models/bible/bible-book.model.ts
+++ b/frontend/src/app/core/models/bible/bible-book.model.ts
@@ -31,7 +31,7 @@ const BOOK_ID_MAP: Record<string, number> = {
 /**
  * Model class representing a Bible book
  */
-export class BibleBook {
+export class BookProgress {
     public readonly chapters: BibleChapter[];
     public readonly id: number; // Changed to number
 

--- a/frontend/src/app/core/models/bible/bible-chapter.model.ts
+++ b/frontend/src/app/core/models/bible/bible-chapter.model.ts
@@ -1,5 +1,5 @@
 import { BibleVerse } from './bible-verse.model';
-import { BibleBook } from './bible-book.model';
+import { BookProgress } from './bible-book.model';
 
 /**
  * Model class representing a Bible chapter
@@ -12,7 +12,7 @@ export class BibleChapter {
     public readonly chapterNumber: number,
     totalVerses: number,
     memorizedVerses: number[] = [],
-    private readonly parentBook?: BibleBook,
+    private readonly parentBook?: BookProgress,
     versesApocryphalStatus: boolean[] = []
   ) {
     // Create verses with proper parent references
@@ -36,7 +36,7 @@ export class BibleChapter {
   }
 
   // Getter for parent book
-  get book(): BibleBook | undefined {
+  get book(): BookProgress | undefined {
     return this.parentBook;
   }
 

--- a/frontend/src/app/core/models/bible/bible-data.model.ts
+++ b/frontend/src/app/core/models/bible/bible-data.model.ts
@@ -1,5 +1,5 @@
 // frontend/src/app/models/bible/bible-data.model.ts (key changes only)
-import { BibleBook } from './bible-book.model';
+import { BookProgress } from './bible-book.model';
 import { BibleTestament } from './bible-testament.model';
 import { UserVerseDetail } from './interfaces';
 import { TestamentType } from './enums';
@@ -8,20 +8,20 @@ import { BibleGroup } from './bible-group.modle';
 
 export class BibleData {
   private readonly testamentMap: Map<string, BibleTestament> = new Map();
-  private readonly bookMap: Map<string, BibleBook> = new Map();
-  private readonly bookIdMap: Map<number, BibleBook> = new Map(); // Changed to number key
+  private readonly bookMap: Map<string, BookProgress> = new Map();
+  private readonly bookIdMap: Map<number, BookProgress> = new Map(); // Changed to number key
 
   // Store all books regardless of filter status
-  private readonly _allBooks: BibleBook[] = [];
+  private readonly _allBooks: BookProgress[] = [];
 
   // Visible books after filtering (when not showing apocrypha)
-  public readonly visibleBooks: BibleBook[] = [];
+  public readonly visibleBooks: BookProgress[] = [];
 
   // Property to track apocrypha preference 
   private _includeApocrypha: boolean = false;
 
   // Getter to provide the appropriate book list based on preferences
-  get books(): BibleBook[] {
+  get books(): BookProgress[] {
     if (this._includeApocrypha) {
       return this._allBooks;
     }
@@ -77,7 +77,7 @@ export class BibleData {
       const group = groupMap.get(bookData.bookGroup)!;
 
       // Create book
-      const book = new BibleBook(
+      const book = new BookProgress(
         bookData.name,
         testament,
         group,
@@ -182,7 +182,7 @@ export class BibleData {
       : 0;
   }
 
-  getBookByName(name: string): BibleBook {
+  getBookByName(name: string): BookProgress {
     const book = this.bookMap.get(name);
     if (!book) {
       throw new Error(`Book ${name} not found`);
@@ -190,7 +190,7 @@ export class BibleData {
     return book;
   }
 
-  getBookById(id: number): BibleBook | undefined {
+  getBookById(id: number): BookProgress | undefined {
     return this.bookIdMap.get(id);
   }
 

--- a/frontend/src/app/core/models/bible/bible-group.modle.ts
+++ b/frontend/src/app/core/models/bible/bible-group.modle.ts
@@ -1,5 +1,5 @@
 // src/app/models/bible/bible-group.model.ts
-import { BibleBook } from './bible-book.model';
+import { BookProgress } from './bible-book.model';
 
 /**
  * Model class representing a group of Bible books
@@ -7,7 +7,7 @@ import { BibleBook } from './bible-book.model';
 export class BibleGroup {
   constructor(
     public readonly name: string,
-    public books: BibleBook[] = []
+    public books: BookProgress[] = []
   ) { }
 
   get totalBooks(): number {
@@ -36,7 +36,7 @@ export class BibleGroup {
     return this.books.filter(book => book.percentComplete === 100).length;
   }
 
-  getBookByName(name: string): BibleBook {
+  getBookByName(name: string): BookProgress {
     const book = this.books.find(book => book.name === name);
     if (!book) {
       throw new Error(`Book ${name} not found in group ${this.name}`);

--- a/frontend/src/app/core/models/bible/bible-testament.model.ts
+++ b/frontend/src/app/core/models/bible/bible-testament.model.ts
@@ -1,5 +1,5 @@
 // src/app/models/bible/bible-testament.model.ts
-import { BibleBook } from './bible-book.model';
+import { BookProgress } from './bible-book.model';
 import { BibleGroup } from './bible-group.modle';
 import { TestamentType } from './enums';
 
@@ -7,7 +7,7 @@ import { TestamentType } from './enums';
  * Model class representing a Bible testament (Old or New)
  */
 export class BibleTestament {
-  public readonly books: BibleBook[] = [];
+  public readonly books: BookProgress[] = [];
   private readonly _groupsMap: Map<string, BibleGroup> = new Map();
 
   constructor(
@@ -15,7 +15,7 @@ export class BibleTestament {
     books: any[] = []
   ) { }
 
-  addBook(book: BibleBook): void {
+  addBook(book: BookProgress): void {
     this.books.push(book);
 
     // Add to group map if not exists
@@ -68,7 +68,7 @@ export class BibleTestament {
     return this._groupsMap.get(name);
   }
 
-  getBook(name: string): BibleBook | undefined {
+  getBook(name: string): BookProgress | undefined {
     return this.books.find(book => book.name === name);
   }
 

--- a/frontend/src/app/core/models/bible/bible-verse.model.ts
+++ b/frontend/src/app/core/models/bible/bible-verse.model.ts
@@ -1,6 +1,6 @@
 // src/app/models/bible/bible-verse.model.ts
 import { BibleChapter } from './bible-chapter.model';
-import { BibleBook } from './bible-book.model';
+import { BookProgress } from './bible-book.model';
 
 /**
  * Model class representing a single Bible verse
@@ -34,7 +34,7 @@ export class BibleVerse {
   }
 
   // Getter for parent book through chapter
-  get book(): BibleBook | undefined {
+  get book(): BookProgress | undefined {
     return this.parentChapter?.book;
   }
 

--- a/frontend/src/app/core/services/bible.service.ts
+++ b/frontend/src/app/core/services/bible.service.ts
@@ -3,10 +3,10 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { Observable, of, throwError, BehaviorSubject, Subject } from 'rxjs';
 import { tap, catchError, switchMap } from 'rxjs/operators';
 import { isPlatformBrowser } from '@angular/common';
-import { BibleData, UserVerseDetail, BibleBook } from '../models/bible';
+import { BibleData, UserVerseDetail, BookProgress } from '../models/bible';
 import { NotificationService } from './notification.service';
 import { environment } from '../../../environments/environment';
-import { BookProgress } from '../../state/bible-tracker/models/bible-tracker.model';
+import { BookProgress as TrackerBookProgress } from '../../state/bible-tracker/models/bible-tracker.model';
 
 // Bible version tracking for citations
 export interface BibleVersion {
@@ -59,8 +59,8 @@ export class BibleService {
     return this.bibleData;
   }
 
-  getBooks(): Observable<BibleBook[]> {
-    return this.http.get<BibleBook[]>(`${this.apiUrl}/books`);
+  getBooks(): Observable<BookProgress[]> {
+    return this.http.get<BookProgress[]>(`${this.apiUrl}/books`);
   }
 
   updateUserPreferences(includeApocrypha: boolean): void {
@@ -265,7 +265,7 @@ export class BibleService {
 
   // ----- Bible Tracker Progress Methods (stub implementations) -----
 
-  getUserReadingProgress(): Observable<{ [bookId: string]: BookProgress }> {
+  getUserReadingProgress(): Observable<{ [bookId: string]: TrackerBookProgress }> {
     // TODO: Replace with real HTTP call
     return of({});
   }
@@ -280,7 +280,7 @@ export class BibleService {
     return of(void 0);
   }
 
-  syncProgress(progress: { [bookId: string]: BookProgress }): Observable<void> {
+  syncProgress(progress: { [bookId: string]: TrackerBookProgress }): Observable<void> {
     // TODO: Replace with real HTTP call
     return of(void 0);
   }

--- a/frontend/src/app/features/stats/stats.component.ts
+++ b/frontend/src/app/features/stats/stats.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UserService } from '../../core/services/user.service';
 import { BibleService } from '../../core/services/bible.service';
-import { BibleBook, BibleData, BibleTestament, UserVerseDetail } from '../../core/models/bible';
+import { BookProgress, BibleData, BibleTestament, UserVerseDetail } from '../../core/models/bible';
 import { BibleGroup } from '../../core/models/bible/bible-group.modle';
 import Chart from 'chart.js/auto';
 import { User } from '../../core/models/user';

--- a/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
+++ b/frontend/src/app/shared/components/memorization-modal/memorization-modal.component.ts
@@ -12,7 +12,7 @@ import { Router } from '@angular/router';
 import { BibleService } from '../../../core/services/bible.service';
 import { UserService } from '../../../core/services/user.service';
 import { RecordingService } from '../../../core/services/recording.service';
-import { BibleBook } from '../../../core/models/bible';
+import { BookProgress } from '../../../core/models/bible';
 import { Subject, takeUntil } from 'rxjs';
 import { trigger, style, transition, animate, keyframes, state } from '@angular/animations';
 
@@ -227,7 +227,7 @@ export class MemorizationModalComponent implements OnInit, OnDestroy {
   async detectSingleChapterBook() {
     try {
       const books = await this.bibleService.getBooks().toPromise();
-      const currentBookInfo = books?.find((book: BibleBook) =>
+      const currentBookInfo = books?.find((book: BookProgress) =>
         book.name === this.currentBook || book.name === this.chapterName
       );
       if (currentBookInfo) {
@@ -594,7 +594,7 @@ buildAllStages() {
         const chapterNum = parseInt(match[2], 10);
         const bibleData = this.bibleService.getBibleData();
         if (bibleData && bibleData.books) {
-          const nextBook = bibleData.books.find((b: BibleBook) => b.name === bookName);
+          const nextBook = bibleData.books.find((b: BookProgress) => b.name === bookName);
           if (nextBook) {
             queryParams = { bookId: nextBook.id, chapter: chapterNum };
           }


### PR DESCRIPTION
## Summary
- rename `BibleBook` to `BookProgress`
- update all model and service imports
- avoid naming conflicts by aliasing the progress interface in `bible.service.ts`

## Testing
- `npm install` *(fails: not relevant? actually success)*
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881a77b47c08331883c600850f174b2