### PR TITLE
Add state actions/selectors

### DIFF
--- a/frontend/src/app/state/bible-tracker/actions/bible-tracker.actions.ts
+++ b/frontend/src/app/state/bible-tracker/actions/bible-tracker.actions.ts
@@ -54,6 +54,17 @@ export const BibleTrackerActions = createActionGroup({
     'Reset Progress Success': emptyProps(),
     'Reset Progress Failure': props<{ error: string }>(),
 
+    // Additional UI actions
+    'Toggle Apocrypha': emptyProps(),
+    'Set Progress View Mode': props<{ viewMode: 'testament' | 'groups' }>(),
+
+    // Additional clear actions
+    'Clear Chapter': props<{ bookId: string; chapter: number }>(),
+    'Clear Book': props<{ bookId: string }>(),
+
+    // Reset specific verses
+    'Reset Progress': props<{ bookId: string; chapter: number; verses: number[] }>(),
+  
     // UI Actions
     'Select Book': props<{ bookId: string | null }>(),
     'Select Chapter': props<{ chapter: number | null }>(),

--- a/frontend/src/app/state/bible-tracker/models/bible-tracker.model.ts
+++ b/frontend/src/app/state/bible-tracker/models/bible-tracker.model.ts
@@ -49,8 +49,10 @@ export interface BibleTrackerUIState {
   selectedBook: string | null;
   selectedChapter: number | null;
   viewMode: 'grid' | 'list' | 'reading';
+  progressViewMode: 'testament' | 'groups';
   showCompletedOnly: boolean;
   highlightToday: boolean;
+  includeApocrypha: boolean;
 }
 
 // API Models


### PR DESCRIPTION
## Summary
- add extra bible tracker actions for apocrypha toggling and clearing progress
- extend UI state with progress view options
- update reducer for new actions
- calculate progress segments and filtered books with new selectors

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822d8c560c8331950d8835784a0d10