### PR TITLE
Add global NgRx foundation and UI state

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -16,6 +16,7 @@ import { decksReducer } from './state/decks/reducers/deck.reducer';
 import { DeckEffects } from './state/decks/effects/deck.effects';
 import { practiceSessionReducer } from './state/practice-session/reducers/practice-session.reducer';
 import { PracticeSessionEffects } from './state/practice-session/effects/practice-session.effects';
+import { uiReducer } from './state/ui/ui.reducer';
 import { ConfigService } from './core/services/config.service';
 
 export const appConfig: ApplicationConfig = {
@@ -38,6 +39,7 @@ export const appConfig: ApplicationConfig = {
         bibleTracker: bibleTrackerReducer,
         decks: decksReducer,
         practiceSession: practiceSessionReducer,
+        ui: uiReducer,
       },
       {
         metaReducers: isDevMode() ? metaReducers : [],

--- a/frontend/src/app/state/app.state.ts
+++ b/frontend/src/app/state/app.state.ts
@@ -1,14 +1,20 @@
 import { RouterReducerState } from '@ngrx/router-store';
 import { BibleTrackerState } from './bible-tracker/models/bible-tracker.model';
-import { DecksState } from './decks/models/deck.model';
+import { DecksState as DeckState } from './decks/models/deck.model';
 import { PracticeSessionState } from './practice-session/models/practice-session.model';
+import { UIState } from './ui/ui.state';
 
 // Root state interface - all feature states will be added here
 export interface AppState {
   router: RouterReducerState;
+  auth: AuthState;
   bibleTracker: BibleTrackerState;
-  decks: DecksState;
+  decks: DeckState;
   practiceSession: PracticeSessionState;
+  courses: CourseState;
+  atlas: AtlasState;
+  ui: UIState;
+  featureRequests: FeatureRequestState;
 }
 
 // Shared state interfaces used across features
@@ -26,3 +32,9 @@ export interface EntityLoadingState {
   error: string | null;
   lastFetch: Date | null;
 }
+
+// Placeholder interfaces for features to be migrated to NgRx
+export interface AuthState {}
+export interface CourseState {}
+export interface AtlasState {}
+export interface FeatureRequestState {}

--- a/frontend/src/app/state/bible-tracker/effects/bible-tracker.effects.ts
+++ b/frontend/src/app/state/bible-tracker/effects/bible-tracker.effects.ts
@@ -12,10 +12,10 @@ import {
 } from '../models/bible-tracker.model';
 import { BibleBook } from '../../../core/models/bible';
 import { selectBibleTrackerState } from '../selectors/bible-tracker.selectors';
-import { BaseEffect } from '../../core/effects/base.effect';
+import { BaseEffects } from '../../core/effects/base.effect';
 
 @Injectable()
-export class BibleTrackerEffects extends BaseEffect {
+export class BibleTrackerEffects extends BaseEffects {
   private actions$ = inject(Actions);
   private store = inject(Store<BibleTrackerState>);
   private bibleService = inject(BibleService);

--- a/frontend/src/app/state/core/effects/base.effect.ts
+++ b/frontend/src/app/state/core/effects/base.effect.ts
@@ -1,40 +1,22 @@
-import { Injectable } from '@angular/core';
-import { catchError, of, Observable } from 'rxjs';
-import { Action } from '@ngrx/store';
+import { inject } from '@angular/core';
+import { Action, Store } from '@ngrx/store';
+import { Observable, of } from 'rxjs';
+import { tap, finalize } from 'rxjs/operators';
+import { UIActions } from '../../ui/ui.actions';
 
-@Injectable()
-export abstract class BaseEffect {
-  protected handleError<T extends Action>(
-    action: (error: string) => T
-  ) {
-    return (error: any): Observable<T> => {
-      console.error('Effect Error:', error);
-      const errorMessage = error?.error?.message || error?.message || 'An error occurred';
-      return of(action(errorMessage));
+export abstract class BaseEffects {
+  protected store = inject(Store);
+
+  protected handleError = (source: string) =>
+    (error: Error, _caught: Observable<Action>) => {
+      console.error(`Error in ${source}:`, error);
+      return of(UIActions.setError({ key: source, error }));
     };
-  }
-  
-  protected handleHttpError<T extends Action>(
-    actionCreator: (error: string) => T
-  ) {
-    return catchError<any, Observable<T>>((error: any) => {
-      let errorMessage = 'An error occurred';
-      
-      if (error.status === 0) {
-        errorMessage = 'Unable to connect to server';
-      } else if (error.status === 401) {
-        errorMessage = 'Unauthorized. Please login again';
-      } else if (error.status === 403) {
-        errorMessage = 'You do not have permission to perform this action';
-      } else if (error.status === 404) {
-        errorMessage = 'Resource not found';
-      } else if (error.status >= 500) {
-        errorMessage = 'Server error. Please try again later';
-      } else if (error.error?.message) {
-        errorMessage = error.error.message;
-      }
-      
-      return of(actionCreator(errorMessage));
-    });
-  }
+
+  protected withLoadingState = (key: string) =>
+    (source: Observable<Action>) =>
+      source.pipe(
+        tap(() => this.store.dispatch(UIActions.setLoading({ key, loading: true }))),
+        finalize(() => this.store.dispatch(UIActions.setLoading({ key, loading: false })))
+      );
 }

--- a/frontend/src/app/state/decks/effects/deck.effects.ts
+++ b/frontend/src/app/state/decks/effects/deck.effects.ts
@@ -7,10 +7,10 @@ import { DeckService } from '../../../core/services/deck.service';
 import { NotificationService } from '../../../core/services/notification.service';
 import { DeckActions, CardActions } from '../actions/deck.actions';
 import { Deck } from '../models/deck.model';
-import { BaseEffect } from '../../core/effects/base.effect';
+import { BaseEffects } from '../../core/effects/base.effect';
 
 @Injectable()
-export class DeckEffects extends BaseEffect {
+export class DeckEffects extends BaseEffects {
   private actions$ = inject(Actions);
   private store = inject(Store);
   private deckService = inject(DeckService);

--- a/frontend/src/app/state/index.ts
+++ b/frontend/src/app/state/index.ts
@@ -1,20 +1,7 @@
-// Export all public state interfaces
 export * from './app.state';
-
-// Export shared models
-export * from './shared/models/action-types';
-
-// Export shared actions
-export * from './shared/actions/loading.actions';
-export * from './shared/actions/error.actions';
-
-// Export core helpers
-export * from './core/helpers/store.helpers';
-
-// Export router selectors
-export * from './core/reducers/router.reducer';
-
-// Bible Tracker feature exports
-export * from './bible-tracker';
-export * from './decks';
-export * from './practice-session';
+export * from './ui/ui.actions';
+export * from './ui/ui.reducer';
+export * from './ui/ui.selectors';
+export * from './shared/utils/action-factory';
+export * from './shared/utils/reducer-factory';
+export * from './core/effects/base.effect';

--- a/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
+++ b/frontend/src/app/state/practice-session/effects/practice-session.effects.ts
@@ -23,14 +23,14 @@ import {
   selectSettings,
   selectSessionProgress,
 } from '../selectors/practice-session.selectors';
-import { BaseEffect } from '../../core/effects/base.effect';
+import { BaseEffects } from '../../core/effects/base.effect';
 import { ResponseQuality } from '../models/practice-session.model';
 import { PracticeService } from '@app/app/core/services/practice.service';
 import { AudioService } from '@app/app/core/services/audio.service';
 import { NotificationService } from '@app/app/core/services/notification.service';
 
 @Injectable()
-export class PracticeSessionEffects extends BaseEffect {
+export class PracticeSessionEffects extends BaseEffects {
 
   private actions$ = inject(Actions);
   private store = inject(Store);

--- a/frontend/src/app/state/shared/utils/action-factory.ts
+++ b/frontend/src/app/state/shared/utils/action-factory.ts
@@ -1,0 +1,22 @@
+import { createAction, props } from '@ngrx/store';
+
+// Create a factory for async actions (API calls)
+export function createAsyncActions<TRequest extends object, TSuccess extends object, TFailure = Error>(
+  source: string,
+  event: string
+) {
+  return {
+    request: createAction(
+      `[${source}] ${event} Request`,
+      props<TRequest>()
+    ),
+    success: createAction(
+      `[${source}] ${event} Success`,
+      props<TSuccess>()
+    ),
+    failure: createAction(
+      `[${source}] ${event} Failure`,
+      props<{ error: TFailure }>()
+    )
+  };
+}

--- a/frontend/src/app/state/shared/utils/reducer-factory.ts
+++ b/frontend/src/app/state/shared/utils/reducer-factory.ts
@@ -1,0 +1,28 @@
+import { ActionCreator, createReducer, on } from '@ngrx/store';
+
+// Create a factory for handling loading states
+export function createLoadingReducer(
+  requestAction: ActionCreator,
+  successAction: ActionCreator,
+  failureAction: ActionCreator
+) {
+  return createReducer(
+    false,
+    on(requestAction, () => true),
+    on(successAction, failureAction, () => false)
+  );
+}
+
+// Create a factory for handling errors
+export function createErrorReducer(
+  requestAction: ActionCreator,
+  successAction: ActionCreator,
+  failureAction: ActionCreator
+) {
+  return createReducer<Error | null>(
+    null,
+    on(requestAction, () => null),
+    on(successAction, () => null),
+    on(failureAction, (_, { error }) => error)
+  );
+}

--- a/frontend/src/app/state/ui/ui.actions.ts
+++ b/frontend/src/app/state/ui/ui.actions.ts
@@ -1,0 +1,26 @@
+import { createAction, props } from '@ngrx/store';
+import { NotificationMessage } from '../../core/services/notification.service';
+
+export const UIActions = {
+  setLoading: createAction(
+    '[UI] Set Loading',
+    props<{ key: string; loading: boolean }>()
+  ),
+  setError: createAction(
+    '[UI] Set Error',
+    props<{ key: string; error: Error | null }>()
+  ),
+  openModal: createAction(
+    '[UI] Open Modal',
+    props<{ modalId: string; data?: any }>()
+  ),
+  closeModal: createAction('[UI] Close Modal'),
+  addNotification: createAction(
+    '[UI] Add Notification',
+    props<{ notification: NotificationMessage }>()
+  ),
+  removeNotification: createAction(
+    '[UI] Remove Notification',
+    props<{ id: string }>()
+  )
+};

--- a/frontend/src/app/state/ui/ui.reducer.ts
+++ b/frontend/src/app/state/ui/ui.reducer.ts
@@ -1,0 +1,33 @@
+import { createReducer, on } from '@ngrx/store';
+import { UIActions } from './ui.actions';
+import { UIState } from './ui.state';
+
+const initialState: UIState = {
+  loading: {},
+  errors: {},
+  modals: {
+    activeModal: null,
+    modalData: null
+  },
+  notifications: []
+};
+
+export const uiReducer = createReducer(
+  initialState,
+  on(UIActions.setLoading, (state, { key, loading }) => ({
+    ...state,
+    loading: { ...state.loading, [key]: loading }
+  })),
+  on(UIActions.setError, (state, { key, error }) => ({
+    ...state,
+    errors: { ...state.errors, [key]: error }
+  })),
+  on(UIActions.openModal, (state, { modalId, data }) => ({
+    ...state,
+    modals: { activeModal: modalId, modalData: data }
+  })),
+  on(UIActions.closeModal, (state) => ({
+    ...state,
+    modals: { activeModal: null, modalData: null }
+  }))
+);

--- a/frontend/src/app/state/ui/ui.selectors.ts
+++ b/frontend/src/app/state/ui/ui.selectors.ts
@@ -1,0 +1,25 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { UIState } from './ui.state';
+
+export const selectUIState = createFeatureSelector<UIState>('ui');
+
+export const selectLoading = (key: string) =>
+  createSelector(selectUIState, (state) => state.loading[key]);
+
+export const selectError = (key: string) =>
+  createSelector(selectUIState, (state) => state.errors[key]);
+
+export const selectActiveModal = createSelector(
+  selectUIState,
+  (state) => state.modals.activeModal
+);
+
+export const selectModalData = createSelector(
+  selectUIState,
+  (state) => state.modals.modalData
+);
+
+export const selectNotifications = createSelector(
+  selectUIState,
+  (state) => state.notifications
+);

--- a/frontend/src/app/state/ui/ui.state.ts
+++ b/frontend/src/app/state/ui/ui.state.ts
@@ -1,0 +1,11 @@
+import { NotificationMessage } from '../../core/services/notification.service';
+
+export interface UIState {
+  loading: Record<string, boolean>;
+  errors: Record<string, Error | null>;
+  modals: {
+    activeModal: string | null;
+    modalData: any;
+  };
+  notifications: NotificationMessage[];
+}


### PR DESCRIPTION
## Summary
- expand `AppState` to include all features
- add reusable action and reducer factories
- implement global UI state with actions, reducer and selectors
- introduce `BaseEffects` with loading and error helpers
- wire UI reducer into the NgRx store configuration
- update existing effects to extend `BaseEffects`

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882306c1c6c833187b1bc220b774cb7