### PR TITLE
Implement NgRx bible memorization state

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -3,6 +3,8 @@ import { ApplicationConfig, isDevMode, provideAppInitializer, inject } from '@an
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { bibleMemorizationReducer } from "./state/bible-tracker/reducers/bible-memorization.reducer";
+import { BibleMemorizationEffects } from "./state/bible-tracker/effects/bible-memorization.effects";
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -10,8 +12,6 @@ import { provideStoreDevtools } from '@ngrx/store-devtools';
 import { provideRouterStore, routerReducer } from '@ngrx/router-store';
 import { routes } from './app.routes';
 import { metaReducers } from './state/core/helpers/dev.helpers';
-import { bibleTrackerReducer } from './state/bible-tracker/reducers/bible-tracker.reducer';
-import { BibleTrackerEffects } from './state/bible-tracker/effects/bible-tracker.effects';
 import { decksReducer } from './state/decks/reducers/deck.reducer';
 import { DeckEffects } from './state/decks/effects/deck.effects';
 import { practiceSessionReducer } from './state/practice-session/reducers/practice-session.reducer';
@@ -36,7 +36,7 @@ export const appConfig: ApplicationConfig = {
     provideStore(
       {
         router: routerReducer,
-        bibleTracker: bibleTrackerReducer,
+        bibleMemorization: bibleMemorizationReducer,
         decks: decksReducer,
         practiceSession: practiceSessionReducer,
         ui: uiReducer,
@@ -56,8 +56,8 @@ export const appConfig: ApplicationConfig = {
 
     // NgRx Effects
     provideEffects([
-      BibleTrackerEffects,
       DeckEffects,
+      BibleMemorizationEffects,
       PracticeSessionEffects,
     ]),
 

--- a/frontend/src/app/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.html
@@ -1,11 +1,11 @@
 <div class="bible-selector-container">
   <!-- Loading overlay -->
-  <div *ngIf="isLoading" class="global-loading-overlay">
+  <div *ngIf="isLoading$ | async" class="global-loading-overlay">
     <div class="loading-spinner"></div>
     <p>Loading Bible data...</p>
   </div>
 
-  <!-- Success Popup -->
+  <!-- Success Popup (kept for backward compatibility, though notifications should handle this) -->
   <div class="success-popup" [class.show]="showSuccessMessage">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="success-icon">
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
@@ -19,17 +19,17 @@
 
   <!-- Stats -->
   <app-bible-tracker-stats
-    [memorizedVerses]="memorizedVerses"
-    [percentComplete]="percentComplete"
-    [progressViewMode]="progressViewMode"
-    [progressSegments]="progressSegments"
+    [memorizedVerses]="(memorizedVerses$ | async) || 0"
+    [percentComplete]="(percentComplete$ | async) || 0"
+    [progressViewMode]="(progressViewMode$ | async) || 'testament'"
+    [progressSegments]="(progressSegments$ | async) || []"
     (toggleProgressView)="toggleProgressView()">
   </app-bible-tracker-stats>
 
   <!-- Testament Cards -->
   <div class="chart-grid">
     <app-bible-tracker-testament-card
-      *ngFor="let testament of testaments"
+      *ngFor="let testament of (testaments$ | async) || []"
       [testament]="testament"
       [isActive]="testament === selectedTestament"
       [groupColors]="groupColors"
@@ -56,8 +56,8 @@
   <app-bible-tracker-chapter-heatmap
     [selectedBook]="selectedBook"
     [includeApocrypha]="includeApocrypha"
-    [isLoading]="isLoading"
-    [isSavingBulk]="isSavingBulk"
+    [isLoading]="(isLoading$ | async) || false"
+    [isSavingBulk]="(isSavingBulk$ | async) || false"
     (chapterSelected)="setChapter($event)"
     (selectAllChapters)="selectAllChapters()"
     (clearAllChapters)="clearAllChapters()">
@@ -67,8 +67,8 @@
   <app-bible-tracker-verse-grid
     [selectedBook]="selectedBook"
     [selectedChapter]="selectedChapter"
-    [isLoading]="isLoading"
-    [isSavingBulk]="isSavingBulk"
+    [isLoading]="(isLoading$ | async) || false"
+    [isSavingBulk]="(isSavingBulk$ | async) || false"
     (verseToggled)="toggleAndSaveVerse($event)"
     (selectAllVerses)="selectAllVerses()"
     (clearAllVerses)="clearAllVerses()">

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -1,19 +1,30 @@
-import { Component, OnInit, ChangeDetectorRef, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
-import { DialogsModule } from '@progress/kendo-angular-dialog';
-import { ButtonsModule } from '@progress/kendo-angular-buttons';
-import { Subscription } from 'rxjs';
-import Chart from 'chart.js/auto';
+import { Store } from '@ngrx/store';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+// Import NgRx elements
+import { BibleMemorizationActions } from '../state/bible-tracker/actions/bible-memorization.actions';
+import {
+  selectBibleDataWithProgress,
+  selectTestaments,
+  selectMemorizedVersesCount,
+  selectOverallPercentComplete,
+  selectProgressSegments,
+  selectProgressViewMode,
+  selectIsLoading,
+  selectIsSavingBulk,
+  selectUserId
+} from '../state/bible-tracker/selectors/bible-memorization.selectors';
 
 // Import models
-import { BibleBook, BibleChapter, BibleData, BibleTestament, UserVerseDetail } from '../core/models/bible';
+import { BibleBook, BibleChapter, BibleTestament, BibleGroup, BibleData } from '../core/models/bible';
 import { BibleVerse } from '../core/models/bible/bible-verse.model';
-import { BibleGroup } from '../core/models/bible/bible-group.modle';
+import { ProgressSegment } from '../state/bible-tracker/models/bible-memorization.model';
 
-// Import services
-import { BibleService } from '../core/services/bible.service';
-import { UserService } from '../core/services/user.service';
+// Import services (only for modal, no more data services!)
 import { ModalService } from '../core/services/modal.service';
 
 // Import sub-components
@@ -32,8 +43,6 @@ import { BibleTrackerVerseGridComponent } from './components/bible-tracker-verse
   imports: [
     CommonModule,
     RouterModule,
-    DialogsModule,
-    ButtonsModule,
     BibleTrackerHeaderComponent,
     BibleTrackerStatsComponent,
     BibleTrackerTestamentCardComponent,
@@ -45,9 +54,25 @@ import { BibleTrackerVerseGridComponent } from './components/bible-tracker-verse
   styleUrls: ['./bible-tracker.component.scss'],
 })
 export class BibleTrackerComponent implements OnInit, OnDestroy {
-  private bibleData: BibleData;
-  private subscriptions: Subscription = new Subscription();
+  private destroy$ = new Subject<void>();
   
+  // Observables from store
+  bibleData$!: Observable<BibleData>;
+  testaments$!: Observable<BibleTestament[]>;
+  memorizedVerses$!: Observable<number>;
+  percentComplete$!: Observable<number>;
+  progressSegments$!: Observable<ProgressSegment[]>;
+  progressViewMode$!: Observable<'testament' | 'groups'>;
+  isLoading$!: Observable<boolean>;
+  isSavingBulk$!: Observable<boolean>;
+  
+  // Local UI state for navigation (not persisted)
+  selectedTestament: BibleTestament | null = null;
+  selectedGroup: BibleGroup | null = null;
+  selectedBook: BibleBook | null = null;
+  selectedChapter: BibleChapter | null = null;
+  
+  // Group colors configuration
   groupColors: { [key: string]: string } = {
     'Law': '#10b981',
     'History': '#3b82f6',
@@ -60,232 +85,72 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
     'General Epistles': '#f59e0b',
     'Revelation': '#ef4444'
   };
-
-  selectedTestament: BibleTestament | null = null;
-  selectedGroup: BibleGroup | null = null;
-  selectedBook: BibleBook | null = null;
-  selectedChapter: BibleChapter | null = null;
-
-  userVerses: UserVerseDetail[] = [];
-  isLoading = true;
-  isSavingBulk = false;
-  userId = 1;
-  includeApocrypha = false;
-
-  progressViewMode: 'testament' | 'groups' = 'testament';
-  progressSegments: any[] = [];
-
-  // Success popup state
+  
+  // Success popup state (purely UI)
   showSuccessMessage = false;
   successMessage = '';
+  
+  // Store current user ID for operations
+  private userId: number = 1;
+  
+  // Cache for current bible data and apocrypha setting
+  private currentBibleData: any = null;
+  includeApocrypha = false;
 
   constructor(
-    private bibleService: BibleService,
-    private userService: UserService,
+    private store: Store,
     private modalService: ModalService,
     private cdr: ChangeDetectorRef,
     private router: Router
   ) {
-    this.bibleData = this.bibleService.getBibleData();
-    this.selectedTestament = this.defaultTestament;
-    if (this.selectedTestament?.groups.length > 0) {
-      this.setGroup(this.defaultGroup);
-    }
+    this.bibleData$ = this.store.select(selectBibleDataWithProgress);
+    this.testaments$ = this.store.select(selectTestaments);
+    this.memorizedVerses$ = this.store.select(selectMemorizedVersesCount);
+    this.percentComplete$ = this.store.select(selectOverallPercentComplete);
+    this.progressSegments$ = this.store.select(selectProgressSegments);
+    this.progressViewMode$ = this.store.select(selectProgressViewMode);
+    this.isLoading$ = this.store.select(selectIsLoading);
+    this.isSavingBulk$ = this.store.select(selectIsSavingBulk);
   }
 
   ngOnInit() {
-    const userSub = this.userService.currentUser$.subscribe(user => {
-      if (user) {
-        const newSetting = user.includeApocrypha || false;
-        if (this.includeApocrypha !== newSetting) {
-          this.includeApocrypha = newSetting;
-          this.bibleService.updateUserPreferences(newSetting);
-          this.loadUserVerses();
-        } else if (!this.userVerses.length) {
-          this.bibleService.updateUserPreferences(newSetting);
-          this.loadUserVerses();
-        }
-      } else {
-        this.loadUserVerses();
+    // Initialize the feature
+    this.store.dispatch(BibleMemorizationActions.initialize());
+    
+    // Subscribe to bible data to set initial selections
+    this.bibleData$.pipe(takeUntil(this.destroy$)).subscribe(bibleData => {
+      this.currentBibleData = bibleData;
+      this.includeApocrypha = bibleData.includeApocrypha;
+      
+      // Set default selections if not already set
+      if (!this.selectedTestament && bibleData.testaments.length > 0) {
+        this.setTestament(bibleData.testaments[0]);
       }
     });
-
-    this.subscriptions.add(userSub);
-    this.userService.fetchCurrentUser();
+    
+    // Get current user ID
+    this.store.select(selectUserId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(userId => this.userId = userId);
   }
 
   ngOnDestroy() {
-    this.subscriptions.unsubscribe();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
-  loadUserVerses() {
-    this.isLoading = true;
-
-    this.bibleService.getUserVerses(this.userId, this.includeApocrypha).subscribe({
-      next: (verses: any) => {
-        this.userVerses = verses;
-        this.isLoading = false;
-        this.computeProgressSegments();
-        this.cdr.detectChanges();
-      },
-      error: (error: any) => {
-        console.error('Error loading verses:', error);
-        this.isLoading = false;
-        this.modalService.alert(
-          'Error Loading Verses',
-          'Unable to load your saved verses. Please check your connection and try again.',
-          'danger'
-        );
-        this.cdr.detectChanges();
-      }
-    });
-  }
-
-  toggleProgressView(): void {
-    this.progressViewMode = this.progressViewMode === 'testament' ? 'groups' : 'testament';
-    this.computeProgressSegments();
-    this.cdr.detectChanges();
-  }
-
-  private computeProgressSegments(): void {
-    if (this.progressViewMode === 'testament') {
-      const otVerses = this.oldTestament.memorizedVerses;
-      const ntVerses = this.newTestament.memorizedVerses;
-      const apoVerses = this.includeApocrypha ? this.apocryphaTestament.memorizedVerses : 0;
-      const totalVerses = this.totalVerses;
-      const otPercent = Math.round((otVerses / totalVerses) * 100);
-      const ntPercent = Math.round((ntVerses / totalVerses) * 100);
-      const apoPercent = this.includeApocrypha ? Math.round((apoVerses / totalVerses) * 100) : 0;
-      const remainingPercent = 100 - otPercent - ntPercent - apoPercent;
-
-      const segments = [
-        { name: 'Old Testament', shortName: 'OT', percent: otPercent, color: '#f59e0b', verses: otVerses },
-        { name: 'New Testament', shortName: 'NT', percent: ntPercent, color: '#6366f1', verses: ntVerses }
-      ];
-      if (this.includeApocrypha) {
-        segments.push({ name: 'Apocrypha', shortName: 'Apoc.', percent: apoPercent, color: '#8b5cf6', verses: apoVerses });
-      }
-      segments.push({ name: 'Remaining', shortName: '', percent: remainingPercent, color: '#e5e7eb', verses: totalVerses - otVerses - ntVerses - apoVerses });
-
-      this.progressSegments = segments;
-    } else {
-      const segments: any[] = [];
-      const totalVerses = this.totalVerses;
-      const allGroups = [...this.oldTestament.groups, ...this.newTestament.groups];
-      if (this.includeApocrypha) {
-        allGroups.push(...this.apocryphaTestament.groups);
-      }
-      let totalMemorized = 0;
-
-      allGroups.forEach(group => {
-        if (group.memorizedVerses > 0) {
-          const percent = Math.round((group.memorizedVerses / totalVerses) * 100);
-          segments.push({
-            name: group.name,
-            shortName: this.getGroupShortName(group.name),
-            percent,
-            color: this.getGroupColor(group.name),
-            verses: group.memorizedVerses
-          });
-          totalMemorized += group.memorizedVerses;
-        }
-      });
-
-      const remainingPercent = Math.round(((totalVerses - totalMemorized) / totalVerses) * 100);
-      if (remainingPercent > 0) {
-        segments.push({
-          name: 'Remaining',
-          shortName: '',
-          percent: remainingPercent,
-          color: '#e5e7eb',
-          verses: totalVerses - totalMemorized
-        });
-      }
-
-      this.progressSegments = segments;
-    }
-  }
-
-  toggleAndSaveVerse(verse: any): void {
-    // Toggle memorized state
-    verse.memorized = !verse.memorized;
-    this.saveVerse(verse);
-  }
-
-  saveVerse(verse: BibleVerse) {
-    // Get book and chapter from the current selection context
-    if (!this.selectedBook || !this.selectedChapter) {
-      console.error('No book or chapter selected');
-      return;
-    }
-
-    if (verse.memorized) {
-      const practiceCount = 1;
-      this.bibleService.saveVerse(
-        this.userId,
-        this.selectedBook.id,
-        this.selectedChapter.chapterNumber,
-        verse.verseNumber,
-        practiceCount
-      ).subscribe({
-        next: (response: any) => {
-          // Update verse properties if they exist
-          verse.practiceCount = practiceCount;
-          verse.lastPracticed = new Date();
-          this.computeProgressSegments();
-          this.cdr.detectChanges();
-        },
-        error: (error: any) => {
-          verse.memorized = !verse.memorized;
-          this.modalService.alert(
-            'Error Saving Verse',
-            'Unable to save this verse. Please try again.',
-            'danger'
-          );
-          this.cdr.detectChanges();
-        }
-      });
-    } else {
-      this.bibleService.deleteVerse(
-        this.userId,
-        this.selectedBook.id,
-        this.selectedChapter.chapterNumber,
-        verse.verseNumber
-      ).subscribe({
-        next: (response: any) => {
-          verse.practiceCount = 0;
-          verse.lastPracticed = undefined;
-          this.computeProgressSegments();
-          this.cdr.detectChanges();
-        },
-        error: (error: any) => {
-          verse.memorized = !verse.memorized;
-          this.modalService.alert(
-            'Error Removing Verse',
-            'Unable to remove this verse. Please try again.',
-            'danger'
-          );
-          this.cdr.detectChanges();
-        }
-      });
-    }
-  }
-
-  private showSuccessPopup(message: string): void {
-    this.successMessage = message;
-    this.showSuccessMessage = true;
-    
-    // Hide the popup after 3 seconds
-    setTimeout(() => {
-      this.showSuccessMessage = false;
-      this.cdr.detectChanges();
-    }, 3000);
-  }
-
+  // Navigation methods
   setTestament(testament: BibleTestament): void {
     this.selectedTestament = testament;
     if (testament.groups.length > 0) {
       this.setGroup(testament.groups[0]);
+    }
+    
+    // Also update in store for persistence
+    if (testament.books.length > 0) {
+      this.store.dispatch(BibleMemorizationActions.selectBook({ 
+        bookId: testament.books[0].id 
+      }));
     }
   }
 
@@ -302,166 +167,109 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
     if (visibleChapters.length > 0) {
       this.setChapter(visibleChapters[0]);
     }
+    
+    // Update store
+    this.store.dispatch(BibleMemorizationActions.selectBook({ bookId: book.id }));
   }
 
   setChapter(chapter: BibleChapter): void {
     this.selectedChapter = chapter;
+    
+    // Update store
+    this.store.dispatch(BibleMemorizationActions.selectChapter({ 
+      chapterNumber: chapter.chapterNumber 
+    }));
   }
 
+  // Verse operations
+  toggleAndSaveVerse(verse: BibleVerse): void {
+    if (!this.selectedBook || !this.selectedChapter) {
+      console.error('No book or chapter selected');
+      return;
+    }
+    
+    // Dispatch action to toggle verse
+    this.store.dispatch(BibleMemorizationActions.toggleVerseMemorization({
+      userId: this.userId,
+      bookId: this.selectedBook.id,
+      chapterNumber: this.selectedChapter.chapterNumber,
+      verseNumber: verse.verseNumber
+    }));
+  }
+
+  // Bulk operations
   selectAllVerses(): void {
     if (!this.selectedChapter || !this.selectedBook) return;
-
-    this.isSavingBulk = true;
-
-    this.bibleService.saveChapter(
-      this.userId,
-      this.selectedBook.id,
-      this.selectedChapter.chapterNumber
-    ).subscribe({
-      next: () => {
-        this.selectedChapter!.verses.forEach(verse => {
-          verse.memorized = true;
-          verse.practiceCount = 1;
-          verse.lastPracticed = new Date();
-        });
-        this.isSavingBulk = false;
-        this.computeProgressSegments();
-        // Show success popup instead of modal
-        this.showSuccessPopup(
-          `All verses in ${this.selectedBook!.name} ${this.selectedChapter!.chapterNumber} have been marked as memorized.`
-        );
-        this.cdr.detectChanges();
-      },
-      error: (error: any) => {
-        this.isSavingBulk = false;
-        this.modalService.alert(
-          'Error Saving Chapter',
-          'Unable to save all verses in this chapter. Please try again.',
-          'danger'
-        );
-      }
-    });
+    
+    this.store.dispatch(BibleMemorizationActions.memorizeAllChapterVerses({
+      userId: this.userId,
+      bookId: this.selectedBook.id,
+      chapterNumber: this.selectedChapter.chapterNumber,
+      operation: 'memorize'
+    }));
   }
 
   async clearAllVerses(): Promise<void> {
     if (!this.selectedChapter || !this.selectedBook) return;
-
+    
     const confirmed = await this.modalService.danger(
       'Clear All Verses?',
       `Are you sure you want to clear all memorized verses in ${this.selectedBook.name} ${this.selectedChapter.chapterNumber}? This action cannot be undone.`,
       'Clear Verses'
     );
-
+    
     if (!confirmed) return;
-
-    this.isSavingBulk = true;
-
-    this.bibleService.clearChapter(
-      this.userId,
-      this.selectedBook.id,
-      this.selectedChapter.chapterNumber
-    ).subscribe({
-      next: () => {
-        this.selectedChapter!.verses.forEach(verse => {
-          verse.memorized = false;
-          verse.practiceCount = 0;
-          verse.lastPracticed = undefined;
-        });
-        this.isSavingBulk = false;
-        this.computeProgressSegments();
-        // Show success popup instead of modal
-        this.showSuccessPopup(
-          `All verses in ${this.selectedBook!.name} ${this.selectedChapter!.chapterNumber} have been cleared.`
-        );
-        this.cdr.detectChanges();
-      },
-      error: (error: any) => {
-        this.isSavingBulk = false;
-        this.modalService.alert(
-          'Error Clearing Chapter',
-          'Unable to clear verses in this chapter. Please try again.',
-          'danger'
-        );
-      }
-    });
+    
+    this.store.dispatch(BibleMemorizationActions.clearAllChapterVerses({
+      userId: this.userId,
+      bookId: this.selectedBook.id,
+      chapterNumber: this.selectedChapter.chapterNumber,
+      operation: 'clear'
+    }));
   }
 
-async selectAllChapters(): Promise<void> {
-  if (!this.selectedBook) return;
+  async selectAllChapters(): Promise<void> {
+    if (!this.selectedBook) return;
+    
+    const confirmed = await this.modalService.danger(
+      'Memorize All Chapters?',
+      `Are you sure you want to mark all chapters in ${this.selectedBook.name} as memorized?`,
+      'Memorize All'
+    );
+    
+    if (!confirmed) return;
+    
+    this.store.dispatch(BibleMemorizationActions.memorizeAllBookVerses({
+      userId: this.userId,
+      bookId: this.selectedBook.id,
+      operation: 'memorize'
+    }));
+  }
 
-  // Using danger modal for confirmation since modalService.confirm requires 4 parameters
-  const confirmed = await this.modalService.danger(
-    'Memorize All Chapters?',
-    `Are you sure you want to mark all chapters in ${this.selectedBook.name} as memorized?`,
-    'Memorize All'
-  );
-
-  if (!confirmed) return;
-
-  this.isSavingBulk = true;
-
-  this.bibleService.saveBook(
-    this.userId,
-    this.selectedBook.id
-  ).subscribe({
-    next: () => {
-      this.selectedBook!.chapters.forEach(ch => ch.selectAllVerses());
-      this.isSavingBulk = false;
-      this.computeProgressSegments();
-      // Show success popup instead of modal
-      this.showSuccessPopup(
-        `${this.selectedBook!.name} has been marked as memorized.`
-      );
-      this.cdr.detectChanges();
-    },
-    error: (error: any) => {
-      this.isSavingBulk = false;
-      this.modalService.alert(
-        'Error Saving Book',
-        'Unable to save all chapters in this book. Please try again.',
-        'danger'
-      );
-    }
-  });
-}
   async clearAllChapters(): Promise<void> {
     if (!this.selectedBook) return;
-
+    
     const confirmed = await this.modalService.danger(
       'Clear All Chapters?',
       `Are you sure you want to clear all memorized verses in ${this.selectedBook.name}? This action cannot be undone.`,
       'Clear Chapters'
     );
-
+    
     if (!confirmed) return;
-
-    this.isSavingBulk = true;
-
-    this.bibleService.clearBook(
-      this.userId,
-      this.selectedBook.id
-    ).subscribe({
-      next: () => {
-        this.selectedBook!.chapters.forEach(ch => ch.clearAllVerses());
-        this.isSavingBulk = false;
-        this.computeProgressSegments();
-        // Show success popup instead of modal
-        this.showSuccessPopup(
-          `${this.selectedBook!.name} has been cleared.`
-        );
-        this.cdr.detectChanges();
-      },
-      error: (error: any) => {
-        this.isSavingBulk = false;
-        this.modalService.alert(
-          'Error Clearing Book',
-          'Unable to clear chapters in this book. Please try again.',
-          'danger'
-        );
-      }
-    });
+    
+    this.store.dispatch(BibleMemorizationActions.clearAllBookVerses({
+      userId: this.userId,
+      bookId: this.selectedBook.id,
+      operation: 'clear'
+    }));
   }
 
+  // UI methods
+  toggleProgressView(): void {
+    this.store.dispatch(BibleMemorizationActions.toggleProgressViewMode());
+  }
+
+  // Helper methods
   isChapterVisible(chapter: BibleChapter): boolean {
     return this.includeApocrypha || !chapter.isApocryphal;
   }
@@ -470,64 +278,14 @@ async selectAllChapters(): Promise<void> {
     return book.chapters.filter(chapter => this.isChapterVisible(chapter));
   }
 
-  getGroupShortName(groupName: string): string {
-    const shortNames: { [key: string]: string } = {
-      'Law': 'Law',
-      'History': 'History',
-      'Wisdom': 'Wisdom',
-      'Major Prophets': 'Major',
-      'Minor Prophets': 'Minor',
-      'Gospels': 'Gospels',
-      'Acts': 'Acts',
-      'Pauline Epistles': 'Pauline',
-      'General Epistles': 'General',
-      'Revelation': 'Rev'
-    };
-    return shortNames[groupName] || groupName;
-  }
-
-  getGroupColor(groupName: string): string {
-    return this.groupColors[groupName] || '#6b7280';
-  }
-
-  // Getters
-  get testaments(): BibleTestament[] {
-    return this.bibleData.testaments;
-  }
-
-  get oldTestament(): BibleTestament {
-    return this.bibleData.getTestamentByName('OLD');
-  }
-
-  get newTestament(): BibleTestament {
-    return this.bibleData.getTestamentByName('NEW');
-  }
-
-  get apocryphaTestament(): BibleTestament {
-    return this.bibleData.getTestamentByName('APOCRYPHA');
-  }
-
-  get defaultTestament(): BibleTestament {
-    return this.oldTestament;
-  }
-
-  get defaultGroup(): BibleGroup {
-    return this.defaultBook.group;
-  }
-
-  get defaultBook(): BibleBook {
-    return this.bibleData.getBookByName("Genesis");
-  }
-
-  get percentComplete(): number {
-    return this.bibleData.percentComplete;
-  }
-
-  get totalVerses(): number {
-    return this.bibleData.totalVerses;
-  }
-
-  get memorizedVerses(): number {
-    return this.bibleData.memorizedVerses;
+  // Local success popup (kept local as it's pure UI)
+  private showSuccessPopup(message: string): void {
+    this.successMessage = message;
+    this.showSuccessMessage = true;
+    
+    setTimeout(() => {
+      this.showSuccessMessage = false;
+      this.cdr.detectChanges();
+    }, 3000);
   }
 }

--- a/frontend/src/app/bible-tracker/bible-tracker.component.ts
+++ b/frontend/src/app/bible-tracker/bible-tracker.component.ts
@@ -121,11 +121,8 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
     this.bibleData$.pipe(takeUntil(this.destroy$)).subscribe(bibleData => {
       this.currentBibleData = bibleData;
       this.includeApocrypha = bibleData.includeApocrypha;
-      
-      // Set default selections if not already set
-      if (!this.selectedTestament && bibleData.testaments.length > 0) {
-        this.setTestament(bibleData.testaments[0]);
-      }
+
+      this.updateSelections(bibleData);
     });
     
     // Get current user ID
@@ -276,6 +273,41 @@ export class BibleTrackerComponent implements OnInit, OnDestroy {
 
   getVisibleChapters(book: BibleBook): BibleChapter[] {
     return book.chapters.filter(chapter => this.isChapterVisible(chapter));
+  }
+
+  private updateSelections(bibleData: BibleData): void {
+    if (!this.selectedTestament && bibleData.testaments.length > 0) {
+      this.setTestament(bibleData.testaments[0]);
+      return;
+    }
+
+    if (this.selectedTestament) {
+      const testament = bibleData.testaments.find(t => t.name === this.selectedTestament!.name);
+      if (testament) {
+        this.selectedTestament = testament;
+
+        if (this.selectedGroup) {
+          const group = testament.groups.find(g => g.name === this.selectedGroup!.name);
+          if (group) {
+            this.selectedGroup = group;
+
+            if (this.selectedBook) {
+              const book = group.books.find(b => b.id === this.selectedBook!.id);
+              if (book) {
+                this.selectedBook = book;
+
+                if (this.selectedChapter) {
+                  const chapter = book.chapters.find(c => c.chapterNumber === this.selectedChapter!.chapterNumber);
+                  if (chapter) {
+                    this.selectedChapter = chapter;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   // Local success popup (kept local as it's pure UI)

--- a/frontend/src/app/bible-tracker/components/bible-tracker-verse-grid/bible-tracker-verse-grid.component.ts
+++ b/frontend/src/app/bible-tracker/components/bible-tracker-verse-grid/bible-tracker-verse-grid.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { BibleBook, BibleChapter, BibleVerse } from '../../../core/models/bible';
+import { BibleBook, BibleChapter } from '../../../core/models/bible';
+import { BibleVerse } from '../../../core/models/bible/bible-verse.model';
 
 @Component({
   selector: 'app-bible-tracker-verse-grid',

--- a/frontend/src/app/core/models/bible/index.ts
+++ b/frontend/src/app/core/models/bible/index.ts
@@ -12,3 +12,4 @@ export * from './bible-chapter.model';
 export * from './bible-book.model';
 export * from './bible-testament.model';
 export * from './bible-data.model';
+export * from './bible-group.modle';

--- a/frontend/src/app/state/app.state.ts
+++ b/frontend/src/app/state/app.state.ts
@@ -1,4 +1,5 @@
 import { RouterReducerState } from '@ngrx/router-store';
+import { BibleMemorizationState } from "./bible-tracker/models/bible-memorization.model";
 import { BibleTrackerState } from './bible-tracker/models/bible-tracker.model';
 import { DecksState as DeckState } from './decks/models/deck.model';
 import { PracticeSessionState } from './practice-session/models/practice-session.model';
@@ -8,7 +9,7 @@ import { UIState } from './ui/ui.state';
 export interface AppState {
   router: RouterReducerState;
   auth: AuthState;
-  bibleTracker: BibleTrackerState;
+  bibleMemorization: BibleMemorizationState;
   decks: DeckState;
   practiceSession: PracticeSessionState;
   courses: CourseState;

--- a/frontend/src/app/state/bible-tracker/actions/bible-memorization.actions.ts
+++ b/frontend/src/app/state/bible-tracker/actions/bible-memorization.actions.ts
@@ -1,0 +1,84 @@
+import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import {
+  ToggleVerseRequest,
+  BulkVerseOperation,
+  UserVerseDetail,
+  ProgressSegment
+} from '../models/bible-memorization.model';
+
+export const BibleMemorizationActions = createActionGroup({
+  source: 'Bible Memorization',
+  events: {
+    // Initialization
+    'Initialize': emptyProps(),
+    'Initialize Success': emptyProps(),
+    'Initialize Failure': props<{ error: string }>(),
+    
+    // Load memorization data
+    'Load Memorization Progress': props<{ userId: number; forceRefresh?: boolean }>(),
+    'Load Memorization Progress Success': props<{ verses: UserVerseDetail[] }>(),
+    'Load Memorization Progress Failure': props<{ error: string }>(),
+    
+    // Single verse operations
+    'Toggle Verse Memorization': props<ToggleVerseRequest>(),
+    'Toggle Verse Memorization Success': props<{ request: ToggleVerseRequest }>(),
+    'Toggle Verse Memorization Failure': props<{ request: ToggleVerseRequest; error: string }>(),
+    
+    // Bulk operations
+    'Memorize All Chapter Verses': props<BulkVerseOperation>(),
+    'Memorize All Chapter Verses Success': props<{ 
+      operation: BulkVerseOperation; 
+      bookName: string; 
+      chapterNumber?: number 
+    }>(),
+    'Memorize All Chapter Verses Failure': props<{ error: string }>(),
+    
+    'Clear All Chapter Verses': props<BulkVerseOperation>(),
+    'Clear All Chapter Verses Success': props<{ 
+      operation: BulkVerseOperation; 
+      bookName: string; 
+      chapterNumber?: number 
+    }>(),
+    'Clear All Chapter Verses Failure': props<{ error: string }>(),
+    
+    'Memorize All Book Verses': props<BulkVerseOperation>(),
+    'Memorize All Book Verses Success': props<{ 
+      operation: BulkVerseOperation; 
+      bookName: string 
+    }>(),
+    'Memorize All Book Verses Failure': props<{ error: string }>(),
+    
+    'Clear All Book Verses': props<BulkVerseOperation>(),
+    'Clear All Book Verses Success': props<{ 
+      operation: BulkVerseOperation; 
+      bookName: string 
+    }>(),
+    'Clear All Book Verses Failure': props<{ error: string }>(),
+    
+    // Preferences
+    'Update Apocrypha Preference': props<{ includeApocrypha: boolean }>(),
+    'Toggle Progress View Mode': emptyProps(),
+    
+    // Statistics
+    'Calculate Statistics': emptyProps(),
+    'Calculate Statistics Success': props<{ 
+      totalVersesMemorized: number;
+      percentageComplete: number;
+      progressSegments: ProgressSegment[];
+    }>(),
+    
+    // UI State
+    'Select Book': props<{ bookId: number | null }>(),
+    'Select Chapter': props<{ chapterNumber: number | null }>(),
+    'Set View Mode': props<{ viewMode: 'grid' | 'list' }>(),
+    'Set Bulk Saving': props<{ isSaving: boolean }>(),
+    
+    // Sync
+    'Sync Memorization Data': emptyProps(),
+    'Sync Memorization Data Success': props<{ timestamp: string }>(),
+    'Sync Memorization Data Failure': props<{ error: string }>(),
+    
+    // Retry mechanism
+    'Retry Failed Operation': props<{ operation: any; attemptNumber: number }>(),
+  }
+});

--- a/frontend/src/app/state/bible-tracker/effects/bible-memorization.effects.ts
+++ b/frontend/src/app/state/bible-tracker/effects/bible-memorization.effects.ts
@@ -1,0 +1,346 @@
+import { Injectable, inject } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { of, timer, EMPTY } from 'rxjs';
+import {
+  map,
+  mergeMap,
+  catchError,
+  withLatestFrom,
+  tap,
+  filter,
+  debounceTime,
+  switchMap,
+  concatMap,
+  retry
+} from 'rxjs/operators';
+
+import { BibleMemorizationActions } from '../actions/bible-memorization.actions';
+import { BibleService } from '../../../core/services/bible.service';
+import { UserService } from '../../../core/services/user.service';
+import { NotificationService } from '../../../core/services/notification.service';
+import { 
+  selectUserId, 
+  selectIncludeApocrypha,
+  selectIsDataStale,
+  selectBibleDataWithProgress,
+  selectDetailedProgressSegments
+} from '../selectors/bible-memorization.selectors';
+import { BaseEffects } from '../../core/effects/base.effect';
+
+@Injectable()
+export class BibleMemorizationEffects extends BaseEffects {
+  private actions$ = inject(Actions);
+  protected override store = inject(Store);
+  private bibleService = inject(BibleService);
+  private userService = inject(UserService);
+  private notificationService = inject(NotificationService);
+
+  // Initialize the feature
+  initialize$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.initialize),
+      withLatestFrom(this.userService.currentUser$),
+      mergeMap(([_, user]) => {
+        if (!user) {
+          return of(BibleMemorizationActions.initializeFailure({ 
+            error: 'No user found' 
+          }));
+        }
+        
+        // Update preferences from user
+        const actions = [
+          BibleMemorizationActions.updateApocryphaPreference({ 
+            includeApocrypha: user.includeApocrypha || false 
+          }),
+          BibleMemorizationActions.loadMemorizationProgress({ 
+            userId: user.id as number 
+          })
+        ];
+        
+        return actions;
+      })
+    )
+  );
+
+  // Load memorization progress
+  loadMemorizationProgress$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.loadMemorizationProgress),
+      withLatestFrom(
+        this.store.select(selectIncludeApocrypha),
+        this.store.select(selectIsDataStale)
+      ),
+      filter(([action, _, isStale]) => action.forceRefresh || isStale),
+      switchMap(([action, includeApocrypha]) =>
+        this.bibleService.getUserVerses(action.userId, includeApocrypha).pipe(
+          map(verses => BibleMemorizationActions.loadMemorizationProgressSuccess({ verses })),
+          catchError(error => of(BibleMemorizationActions.loadMemorizationProgressFailure({ 
+            error: error.message || 'Failed to load memorization progress' 
+          })))
+        )
+      )
+    )
+  );
+
+  // Toggle verse memorization
+  toggleVerseMemorization$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.toggleVerseMemorization),
+      concatMap(request => {
+        // Determine if we're adding or removing the verse
+        // This is handled optimistically in the reducer, so we just need to sync with server
+        const practiceCount = 1; // For now, always 1 when memorizing
+        
+        return this.bibleService.saveVerse(
+          request.userId,
+          request.bookId,
+          request.chapterNumber,
+          request.verseNumber,
+          practiceCount
+        ).pipe(
+          map(() => BibleMemorizationActions.toggleVerseMemorizationSuccess({ request })),
+          catchError(error => of(BibleMemorizationActions.toggleVerseMemorizationFailure({ 
+            request,
+            error: error.message || 'Failed to save verse' 
+          })))
+        );
+      })
+    )
+  );
+
+  // Memorize all chapter verses
+  memorizeAllChapterVerses$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.memorizeAllChapterVerses),
+      withLatestFrom(this.store.select(selectBibleDataWithProgress)),
+      concatMap(([operation, bibleData]) => {
+        const book = bibleData.getBookById(operation.bookId);
+        const bookName = book?.name || 'Book';
+        
+        return this.bibleService.saveChapter(
+          operation.userId,
+          operation.bookId,
+          operation.chapterNumber!
+        ).pipe(
+          map(() => BibleMemorizationActions.memorizeAllChapterVersesSuccess({ 
+            operation,
+            bookName,
+            chapterNumber: operation.chapterNumber
+          })),
+          catchError(error => of(BibleMemorizationActions.memorizeAllChapterVersesFailure({ 
+            error: error.message || 'Failed to memorize chapter' 
+          })))
+        );
+      })
+    )
+  );
+
+  // Clear all chapter verses
+  clearAllChapterVerses$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.clearAllChapterVerses),
+      withLatestFrom(this.store.select(selectBibleDataWithProgress)),
+      concatMap(([operation, bibleData]) => {
+        const book = bibleData.getBookById(operation.bookId);
+        const bookName = book?.name || 'Book';
+        
+        return this.bibleService.clearChapter(
+          operation.userId,
+          operation.bookId,
+          operation.chapterNumber!
+        ).pipe(
+          map(() => BibleMemorizationActions.clearAllChapterVersesSuccess({ 
+            operation,
+            bookName,
+            chapterNumber: operation.chapterNumber
+          })),
+          catchError(error => of(BibleMemorizationActions.clearAllChapterVersesFailure({ 
+            error: error.message || 'Failed to clear chapter' 
+          })))
+        );
+      })
+    )
+  );
+
+  // Memorize all book verses
+  memorizeAllBookVerses$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.memorizeAllBookVerses),
+      withLatestFrom(this.store.select(selectBibleDataWithProgress)),
+      concatMap(([operation, bibleData]) => {
+        const book = bibleData.getBookById(operation.bookId);
+        const bookName = book?.name || 'Book';
+        
+        return this.bibleService.saveBook(
+          operation.userId,
+          operation.bookId
+        ).pipe(
+          map(() => BibleMemorizationActions.memorizeAllBookVersesSuccess({ 
+            operation,
+            bookName
+          })),
+          catchError(error => of(BibleMemorizationActions.memorizeAllBookVersesFailure({ 
+            error: error.message || 'Failed to memorize book' 
+          })))
+        );
+      })
+    )
+  );
+
+  // Clear all book verses
+  clearAllBookVerses$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.clearAllBookVerses),
+      withLatestFrom(this.store.select(selectBibleDataWithProgress)),
+      concatMap(([operation, bibleData]) => {
+        const book = bibleData.getBookById(operation.bookId);
+        const bookName = book?.name || 'Book';
+        
+        return this.bibleService.clearBook(
+          operation.userId,
+          operation.bookId
+        ).pipe(
+          map(() => BibleMemorizationActions.clearAllBookVersesSuccess({ 
+            operation,
+            bookName
+          })),
+          catchError(error => of(BibleMemorizationActions.clearAllBookVersesFailure({ 
+            error: error.message || 'Failed to clear book' 
+          })))
+        );
+      })
+    )
+  );
+
+  // Update preferences
+  updateApocryphaPreference$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.updateApocryphaPreference),
+      withLatestFrom(this.store.select(selectUserId)),
+      tap(([action, userId]) => {
+        // Update user preference in service
+        this.userService.updateUser({ 
+          includeApocrypha: action.includeApocrypha 
+        }).subscribe();
+      }),
+      // Reload data with new preference
+      map(([_, userId]) => BibleMemorizationActions.loadMemorizationProgress({ 
+        userId, 
+        forceRefresh: true 
+      }))
+    )
+  );
+
+  // Calculate statistics after data changes
+  calculateStatistics$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        BibleMemorizationActions.loadMemorizationProgressSuccess,
+        BibleMemorizationActions.toggleVerseMemorizationSuccess,
+        BibleMemorizationActions.memorizeAllChapterVersesSuccess,
+        BibleMemorizationActions.clearAllChapterVersesSuccess,
+        BibleMemorizationActions.memorizeAllBookVersesSuccess,
+        BibleMemorizationActions.clearAllBookVersesSuccess,
+        BibleMemorizationActions.toggleProgressViewMode
+      ),
+      debounceTime(300), // Debounce rapid changes
+      withLatestFrom(
+        this.store.select(selectBibleDataWithProgress),
+        this.store.select(selectDetailedProgressSegments)
+      ),
+      map(([_, bibleData, progressSegments]) => {
+        return BibleMemorizationActions.calculateStatisticsSuccess({
+          totalVersesMemorized: bibleData.memorizedVerses,
+          percentageComplete: bibleData.percentComplete,
+          progressSegments
+        });
+      })
+    )
+  );
+
+  // Reload data after successful bulk operations
+  reloadAfterBulkOperation$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        BibleMemorizationActions.memorizeAllChapterVersesSuccess,
+        BibleMemorizationActions.clearAllChapterVersesSuccess,
+        BibleMemorizationActions.memorizeAllBookVersesSuccess,
+        BibleMemorizationActions.clearAllBookVersesSuccess
+      ),
+      withLatestFrom(this.store.select(selectUserId)),
+      map(([_, userId]) => BibleMemorizationActions.loadMemorizationProgress({ 
+        userId, 
+        forceRefresh: true 
+      }))
+    )
+  );
+
+  // Success notifications
+  showSuccessNotifications$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        BibleMemorizationActions.memorizeAllChapterVersesSuccess,
+        BibleMemorizationActions.clearAllChapterVersesSuccess,
+        BibleMemorizationActions.memorizeAllBookVersesSuccess,
+        BibleMemorizationActions.clearAllBookVersesSuccess
+      ),
+      tap(action => {
+        let message = '';
+        
+        switch (action.type) {
+          case BibleMemorizationActions.memorizeAllChapterVersesSuccess.type:
+            message = `All verses in ${action.bookName} ${action.chapterNumber} have been marked as memorized.`;
+            break;
+          case BibleMemorizationActions.clearAllChapterVersesSuccess.type:
+            message = `All verses in ${action.bookName} ${action.chapterNumber} have been cleared.`;
+            break;
+          case BibleMemorizationActions.memorizeAllBookVersesSuccess.type:
+            message = `${action.bookName} has been marked as memorized.`;
+            break;
+          case BibleMemorizationActions.clearAllBookVersesSuccess.type:
+            message = `${action.bookName} has been cleared.`;
+            break;
+        }
+        
+        this.notificationService.success(message, 3000);
+      })
+    ),
+    { dispatch: false }
+  );
+
+  // Error notifications
+  showErrorNotifications$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        BibleMemorizationActions.loadMemorizationProgressFailure,
+        BibleMemorizationActions.toggleVerseMemorizationFailure,
+        BibleMemorizationActions.memorizeAllChapterVersesFailure,
+        BibleMemorizationActions.clearAllChapterVersesFailure,
+        BibleMemorizationActions.memorizeAllBookVersesFailure,
+        BibleMemorizationActions.clearAllBookVersesFailure
+      ),
+      tap(action => {
+        this.notificationService.error(action.error, 5000);
+      })
+    ),
+    { dispatch: false }
+  );
+
+  // Retry failed operations
+  retryFailedOperations$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(BibleMemorizationActions.retryFailedOperation),
+      filter(action => action.attemptNumber < 3), // Max 3 retries
+      mergeMap(action => 
+        timer(1000 * Math.pow(2, action.attemptNumber)).pipe( // Exponential backoff
+          map(() => action.operation)
+        )
+      )
+    )
+  );
+
+  constructor() {
+    super();
+  }
+}

--- a/frontend/src/app/state/bible-tracker/models/bible-memorization.model.ts
+++ b/frontend/src/app/state/bible-tracker/models/bible-memorization.model.ts
@@ -1,0 +1,81 @@
+import { BibleBook, BibleTestament, BibleGroup } from '../../../core/models/bible';
+
+// Main state structure
+export interface BibleMemorizationState {
+  memorization: MemorizationProgressState;
+  statistics: MemorizationStatisticsState;
+  preferences: UserPreferencesState;
+  ui: BibleTrackerUIState;
+}
+
+// Memorization data from API
+export interface MemorizationProgressState {
+  verses: UserVerseDetail[];  // Raw data from API
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
+  lastFetch: string | null;
+  staleTime: number;  // milliseconds before data is considered stale
+}
+
+// User preferences that affect data display
+export interface UserPreferencesState {
+  includeApocrypha: boolean;
+  progressViewMode: 'testament' | 'groups';
+  userId: number;  // Current user ID
+}
+
+// Statistics calculated from memorization data
+export interface MemorizationStatisticsState {
+  totalVersesMemorized: number;
+  percentageComplete: number;
+  progressSegments: ProgressSegment[];
+  lastCalculated: string | null;
+}
+
+// UI state for navigation and display
+export interface BibleTrackerUIState {
+  selectedBookId: number | null;
+  selectedChapter: number | null;
+  viewMode: 'grid' | 'list';
+  isSavingBulk: boolean;  // Shows loading state for bulk operations
+}
+
+// Progress segment for visual display
+export interface ProgressSegment {
+  name: string;
+  shortName: string;
+  percent: number;
+  color: string;
+  verses: number;
+}
+
+// API request/response types
+export interface ToggleVerseRequest {
+  userId: number;
+  bookId: number;
+  chapterNumber: number;
+  verseNumber: number;
+}
+
+export interface BulkVerseOperation {
+  userId: number;
+  bookId: number;
+  chapterNumber?: number;  // If not provided, applies to whole book
+  operation: 'memorize' | 'clear';
+}
+
+// For verse details from API
+export interface UserVerseDetail {
+  verse: {
+    verse_id: string;
+    book_id: number;
+    chapter_number: number;
+    verse_number: number;
+    isApocryphal: boolean;
+  };
+  practice_count: number;
+  last_practiced?: Date;
+  created_at: Date;
+  updated_at?: Date;
+}

--- a/frontend/src/app/state/bible-tracker/reducers/bible-memorization.reducer.ts
+++ b/frontend/src/app/state/bible-tracker/reducers/bible-memorization.reducer.ts
@@ -1,0 +1,249 @@
+import { createReducer, on } from '@ngrx/store';
+import { BibleMemorizationState } from '../models/bible-memorization.model';
+import { BibleMemorizationActions } from '../actions/bible-memorization.actions';
+
+export const initialState: BibleMemorizationState = {
+  memorization: {
+    verses: [],
+    loading: false,
+    loaded: false,
+    error: null,
+    lastFetch: null,
+    staleTime: 5 * 60 * 1000 // 5 minutes
+  },
+  statistics: {
+    totalVersesMemorized: 0,
+    percentageComplete: 0,
+    progressSegments: [],
+    lastCalculated: null
+  },
+  preferences: {
+    includeApocrypha: false,
+    progressViewMode: 'testament',
+    userId: 1 // Default, should be set from auth
+  },
+  ui: {
+    selectedBookId: null,
+    selectedChapter: null,
+    viewMode: 'grid',
+    isSavingBulk: false
+  }
+};
+
+export const bibleMemorizationReducer = createReducer(
+  initialState,
+  
+  // Initialization
+  on(BibleMemorizationActions.initialize, state => ({
+    ...state,
+    memorization: {
+      ...state.memorization,
+      loading: true,
+      error: null
+    }
+  })),
+  
+  // Load memorization progress
+  on(BibleMemorizationActions.loadMemorizationProgress, state => ({
+    ...state,
+    memorization: {
+      ...state.memorization,
+      loading: true,
+      error: null
+    }
+  })),
+  
+  on(BibleMemorizationActions.loadMemorizationProgressSuccess, (state, { verses }) => ({
+    ...state,
+    memorization: {
+      ...state.memorization,
+      verses,
+      loading: false,
+      loaded: true,
+      error: null,
+      lastFetch: new Date().toISOString()
+    }
+  })),
+  
+  on(BibleMemorizationActions.loadMemorizationProgressFailure, (state, { error }) => ({
+    ...state,
+    memorization: {
+      ...state.memorization,
+      loading: false,
+      error
+    }
+  })),
+  
+  // Toggle verse memorization - optimistic update
+  on(BibleMemorizationActions.toggleVerseMemorization, (state, request) => {
+    // Find and toggle the verse in our local state
+    const updatedVerses = state.memorization.verses.map(verseDetail => {
+      if (verseDetail.verse.book_id === request.bookId &&
+          verseDetail.verse.chapter_number === request.chapterNumber &&
+          verseDetail.verse.verse_number === request.verseNumber) {
+        // Toggle the memorization status
+        return {
+          ...verseDetail,
+          practice_count: verseDetail.practice_count > 0 ? 0 : 1,
+          last_practiced: verseDetail.practice_count > 0 ? undefined : new Date()
+        };
+      }
+      return verseDetail;
+    });
+    
+    // If verse doesn't exist, add it
+    const verseExists = updatedVerses.some(v => 
+      v.verse.book_id === request.bookId &&
+      v.verse.chapter_number === request.chapterNumber &&
+      v.verse.verse_number === request.verseNumber
+    );
+    
+    if (!verseExists) {
+      updatedVerses.push({
+        verse: {
+          verse_id: `${request.bookId}-${request.chapterNumber}-${request.verseNumber}`,
+          book_id: request.bookId,
+          chapter_number: request.chapterNumber,
+          verse_number: request.verseNumber,
+          isApocryphal: false // Will be updated from server response
+        },
+        practice_count: 1,
+        last_practiced: new Date(),
+        created_at: new Date(),
+        updated_at: new Date()
+      });
+    }
+    
+    return {
+      ...state,
+      memorization: {
+        ...state.memorization,
+        verses: updatedVerses
+      }
+    };
+  }),
+  
+  // Revert on failure
+  on(BibleMemorizationActions.toggleVerseMemorizationFailure, (state, { request }) => {
+    // Revert the optimistic update
+    const revertedVerses = state.memorization.verses.map(verseDetail => {
+      if (verseDetail.verse.book_id === request.bookId &&
+          verseDetail.verse.chapter_number === request.chapterNumber &&
+          verseDetail.verse.verse_number === request.verseNumber) {
+        // Toggle back
+        return {
+          ...verseDetail,
+          practice_count: verseDetail.practice_count > 0 ? 0 : 1,
+          last_practiced: verseDetail.practice_count > 0 ? undefined : new Date()
+        };
+      }
+      return verseDetail;
+    });
+    
+    return {
+      ...state,
+      memorization: {
+        ...state.memorization,
+        verses: revertedVerses,
+        error: 'Failed to save verse. Please try again.'
+      }
+    };
+  }),
+  
+  // Bulk operations
+  on(BibleMemorizationActions.memorizeAllChapterVerses, 
+     BibleMemorizationActions.clearAllChapterVerses,
+     BibleMemorizationActions.memorizeAllBookVerses,
+     BibleMemorizationActions.clearAllBookVerses,
+     state => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      isSavingBulk: true
+    }
+  })),
+  
+  on(BibleMemorizationActions.memorizeAllChapterVersesSuccess,
+     BibleMemorizationActions.clearAllChapterVersesSuccess,
+     BibleMemorizationActions.memorizeAllBookVersesSuccess,
+     BibleMemorizationActions.clearAllBookVersesSuccess,
+     state => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      isSavingBulk: false
+    }
+  })),
+  
+  on(BibleMemorizationActions.memorizeAllChapterVersesFailure,
+     BibleMemorizationActions.clearAllChapterVersesFailure,
+     BibleMemorizationActions.memorizeAllBookVersesFailure,
+     BibleMemorizationActions.clearAllBookVersesFailure,
+     (state, { error }) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      isSavingBulk: false
+    },
+    memorization: {
+      ...state.memorization,
+      error
+    }
+  })),
+  
+  // Preferences
+  on(BibleMemorizationActions.updateApocryphaPreference, (state, { includeApocrypha }) => ({
+    ...state,
+    preferences: {
+      ...state.preferences,
+      includeApocrypha
+    }
+  })),
+  
+  on(BibleMemorizationActions.toggleProgressViewMode, state => ({
+    ...state,
+    preferences: {
+      ...state.preferences,
+      progressViewMode: state.preferences.progressViewMode === 'testament'
+        ? ('groups' as const)
+        : ('testament' as const)
+    }
+  })),
+  
+  // Statistics
+  on(BibleMemorizationActions.calculateStatisticsSuccess, (state, { totalVersesMemorized, percentageComplete, progressSegments }) => ({
+    ...state,
+    statistics: {
+      totalVersesMemorized,
+      percentageComplete,
+      progressSegments,
+      lastCalculated: new Date().toISOString()
+    }
+  })),
+  
+  // UI State
+  on(BibleMemorizationActions.selectBook, (state, { bookId }) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      selectedBookId: bookId,
+      selectedChapter: null // Reset chapter when book changes
+    }
+  })),
+  
+  on(BibleMemorizationActions.selectChapter, (state, { chapterNumber }) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      selectedChapter: chapterNumber
+    }
+  })),
+  
+  on(BibleMemorizationActions.setViewMode, (state, { viewMode }) => ({
+    ...state,
+    ui: {
+      ...state.ui,
+      viewMode
+    }
+  }))
+);

--- a/frontend/src/app/state/bible-tracker/reducers/bible-memorization.reducer.ts
+++ b/frontend/src/app/state/bible-tracker/reducers/bible-memorization.reducer.ts
@@ -42,6 +42,15 @@ export const bibleMemorizationReducer = createReducer(
       error: null
     }
   })),
+
+  on(BibleMemorizationActions.initializeFailure, (state, { error }) => ({
+    ...state,
+    memorization: {
+      ...state.memorization,
+      loading: false,
+      error
+    }
+  })),
   
   // Load memorization progress
   on(BibleMemorizationActions.loadMemorizationProgress, state => ({

--- a/frontend/src/app/state/bible-tracker/selectors/bible-memorization.selectors.ts
+++ b/frontend/src/app/state/bible-tracker/selectors/bible-memorization.selectors.ts
@@ -1,0 +1,268 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { BibleMemorizationState } from '../models/bible-memorization.model';
+import { BibleData, BibleTestament, BibleGroup, BibleBook } from '../../../core/models/bible';
+
+import { ProgressSegment } from "../models/bible-memorization.model";
+// Feature selector
+export const selectBibleMemorizationState = 
+  createFeatureSelector<BibleMemorizationState>('bibleMemorization');
+
+// Sub-state selectors
+export const selectMemorizationProgress = createSelector(
+  selectBibleMemorizationState,
+  state => state.memorization
+);
+
+export const selectPreferences = createSelector(
+  selectBibleMemorizationState,
+  state => state.preferences
+);
+
+export const selectStatistics = createSelector(
+  selectBibleMemorizationState,
+  state => state.statistics
+);
+
+export const selectUI = createSelector(
+  selectBibleMemorizationState,
+  state => state.ui
+);
+
+// Specific preference selectors
+export const selectIncludeApocrypha = createSelector(
+  selectPreferences,
+  preferences => preferences.includeApocrypha
+);
+
+export const selectProgressViewMode = createSelector(
+  selectPreferences,
+  preferences => preferences.progressViewMode
+);
+
+export const selectUserId = createSelector(
+  selectPreferences,
+  preferences => preferences.userId
+);
+
+// Loading and error states
+export const selectIsLoading = createSelector(
+  selectMemorizationProgress,
+  progress => progress.loading
+);
+
+export const selectError = createSelector(
+  selectMemorizationProgress,
+  progress => progress.error
+);
+
+export const selectIsSavingBulk = createSelector(
+  selectUI,
+  ui => ui.isSavingBulk
+);
+
+// The main selector that builds the complete Bible structure with memorization data
+export const selectBibleDataWithProgress = createSelector(
+  selectMemorizationProgress,
+  selectIncludeApocrypha,
+  (progress, includeApocrypha) => {
+    // Create a new BibleData instance
+    const bibleData = new BibleData();
+    
+    // Apply user preferences
+    bibleData.includeApocrypha = includeApocrypha;
+    
+    // Map the flat verse data to the hierarchical structure
+    if (progress.verses && progress.verses.length > 0) {
+      bibleData.mapUserVersesToModel(progress.verses);
+    }
+    
+    return bibleData;
+  }
+);
+
+// Selector for testaments
+export const selectTestaments = createSelector(
+  selectBibleDataWithProgress,
+  bibleData => bibleData.testaments
+);
+
+// Selector for specific testament
+export const selectTestamentByName = (name: string) => createSelector(
+  selectBibleDataWithProgress,
+  bibleData => bibleData.getTestamentByName(name)
+);
+
+// Progress statistics selectors
+export const selectMemorizedVersesCount = createSelector(
+  selectBibleDataWithProgress,
+  bibleData => bibleData.memorizedVerses
+);
+
+export const selectOverallPercentComplete = createSelector(
+  selectBibleDataWithProgress,
+  bibleData => bibleData.percentComplete
+);
+
+// Progress segments for visualization
+export const selectProgressSegments = createSelector(
+  selectStatistics,
+  statistics => statistics.progressSegments
+);
+
+// Navigation selectors
+export const selectSelectedBookId = createSelector(
+  selectUI,
+  ui => ui.selectedBookId
+);
+
+export const selectSelectedChapter = createSelector(
+  selectUI,
+  ui => ui.selectedChapter
+);
+
+// Data freshness selector
+export const selectIsDataStale = createSelector(
+  selectMemorizationProgress,
+  progress => {
+    if (!progress.lastFetch) return true;
+    
+    const lastFetchTime = new Date(progress.lastFetch).getTime();
+    const now = Date.now();
+    const staleTime = progress.staleTime || 5 * 60 * 1000; // Default 5 minutes
+    
+    return (now - lastFetchTime) > staleTime;
+  }
+);
+
+// Memoized selector for expensive calculations
+export const selectDetailedProgressSegments = createSelector(
+  selectBibleDataWithProgress,
+  selectProgressViewMode,
+  (bibleData, viewMode) => {
+    // This expensive calculation only runs when inputs change
+    if (viewMode === 'testament') {
+      return calculateTestamentSegments(bibleData);
+    } else {
+      return calculateGroupSegments(bibleData);
+    }
+  }
+);
+
+// Helper functions for segment calculations
+function calculateTestamentSegments(bibleData: BibleData): ProgressSegment[] {
+  const segments: ProgressSegment[] = [];
+  const totalVerses = bibleData.totalVerses;
+  
+  bibleData.testaments.forEach(testament => {
+    if (testament.memorizedVerses > 0) {
+      segments.push({
+        name: testament.name,
+        shortName: getTestamentShortName(testament.name),
+        percent: Math.round((testament.memorizedVerses / totalVerses) * 100),
+        color: getTestamentColor(testament.name),
+        verses: testament.memorizedVerses
+      });
+    }
+  });
+  
+  // Add remaining segment
+  const memorizedTotal = segments.reduce((sum, seg) => sum + seg.verses, 0);
+  const remaining = totalVerses - memorizedTotal;
+  if (remaining > 0) {
+    segments.push({
+      name: 'Remaining',
+      shortName: '',
+      percent: Math.round((remaining / totalVerses) * 100),
+      color: '#e5e7eb',
+      verses: remaining
+    });
+  }
+  
+  return segments;
+}
+
+function calculateGroupSegments(bibleData: BibleData): ProgressSegment[] {
+  const segments: ProgressSegment[] = [];
+  const totalVerses = bibleData.totalVerses;
+  const groupColors: Record<string, string> = {
+    'Law': '#10b981',
+    'History': '#3b82f6',
+    'Wisdom': '#8b5cf6',
+    'Major Prophets': '#f59e0b',
+    'Minor Prophets': '#ef4444',
+    'Gospels': '#10b981',
+    'Acts': '#3b82f6',
+    'Pauline Epistles': '#8b5cf6',
+    'General Epistles': '#f59e0b',
+    'Revelation': '#ef4444'
+  };
+  
+  // Collect all groups from all testaments
+  const allGroups: BibleGroup[] = [];
+  bibleData.testaments.forEach(testament => {
+    allGroups.push(...testament.groups);
+  });
+  
+  // Create segments for groups with memorized verses
+  allGroups.forEach(group => {
+    if (group.memorizedVerses > 0) {
+      segments.push({
+        name: group.name,
+        shortName: getGroupShortName(group.name),
+        percent: Math.round((group.memorizedVerses / totalVerses) * 100),
+        color: groupColors[group.name] || '#6b7280',
+        verses: group.memorizedVerses
+      });
+    }
+  });
+  
+  // Add remaining segment
+  const memorizedTotal = segments.reduce((sum, seg) => sum + seg.verses, 0);
+  const remaining = totalVerses - memorizedTotal;
+  if (remaining > 0) {
+    segments.push({
+      name: 'Remaining',
+      shortName: '',
+      percent: Math.round((remaining / totalVerses) * 100),
+      color: '#e5e7eb',
+      verses: remaining
+    });
+  }
+  
+  return segments;
+}
+
+// Helper functions
+function getTestamentShortName(name: string): string {
+  const shortNames: Record<string, string> = {
+    'Old Testament': 'OT',
+    'New Testament': 'NT',
+    'Apocrypha': 'Apoc.'
+  };
+  return shortNames[name] || name;
+}
+
+function getTestamentColor(name: string): string {
+  const colors: Record<string, string> = {
+    'Old Testament': '#f59e0b',
+    'New Testament': '#6366f1',
+    'Apocrypha': '#8b5cf6'
+  };
+  return colors[name] || '#6b7280';
+}
+
+function getGroupShortName(groupName: string): string {
+  const shortNames: Record<string, string> = {
+    'Law': 'Law',
+    'History': 'History',
+    'Wisdom': 'Wisdom',
+    'Major Prophets': 'Major',
+    'Minor Prophets': 'Minor',
+    'Gospels': 'Gospels',
+    'Acts': 'Acts',
+    'Pauline Epistles': 'Pauline',
+    'General Epistles': 'General',
+    'Revelation': 'Rev'
+  };
+  return shortNames[groupName] || groupName;
+}


### PR DESCRIPTION
## Summary
- add bible memorization models, actions, selectors, reducer and effects
- refactor bible tracker component to use NgRx store
- register bibleMemorization feature in application config and root state
- update component template to use async data
- fix imports and make includeApocrypha public
- fix progress view mode type error
- ensure Chart.js canvases are destroyed when testament card components are removed

## Testing
- `npm run build` *(fails: ng not found)*
- `npm run test:headless --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68828772cfe48331b7ddf961ca0f0e9d