### PR TITLE
Add initial course domain schemas

### DIFF
--- a/backend/domain/courses/exceptions.py
+++ b/backend/domain/courses/exceptions.py
@@ -1,0 +1,18 @@
+class CourseNotFoundError(Exception):
+    def __init__(self, course_id: int):
+        super().__init__(f"Course {course_id} not found")
+        self.course_id = course_id
+
+
+class CourseAccessDeniedError(Exception):
+    def __init__(self, user_id: int, course_id: int):
+        super().__init__(f"User {user_id} cannot access course {course_id}")
+        self.user_id = user_id
+        self.course_id = course_id
+
+
+class AlreadyEnrolledError(Exception):
+    def __init__(self, user_id: int, course_id: int):
+        super().__init__(f"User {user_id} is already enrolled in course {course_id}")
+        self.user_id = user_id
+        self.course_id = course_id

--- a/backend/domain/courses/schemas.py
+++ b/backend/domain/courses/schemas.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+
+class CourseCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    is_public: bool = False
+    tags: List[str] = Field(default_factory=list)
+
+
+class CourseUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    is_public: Optional[bool] = None
+    tags: Optional[List[str]] = None
+
+
+class CourseResponse(BaseModel):
+    id: int
+    creator_id: int
+    creator_name: str
+    name: str  # Not 'title' - keeping consistent with DB
+    description: Optional[str]
+    thumbnail_url: Optional[str]
+    is_public: bool
+    created_at: str
+    updated_at: str
+    lesson_count: int
+    enrolled_count: int
+    tags: List[str]
+
+
+class CourseEnrollment(BaseModel):
+    user_id: int
+    course_id: int
+    enrolled_at: str
+    current_lesson_position: int
+    lessons_completed: int
+    last_accessed: Optional[str]
+    completed_at: Optional[str]


### PR DESCRIPTION
## Summary
- define Course domain schemas
- add Course domain exceptions
- verify imports succeed

## Testing
- `python -c "from domain.courses.schemas import CourseCreate, CourseResponse; print('✓ Schemas import successfully')"`
- `python -c "from domain.courses.exceptions import CourseNotFoundError; print('✓ Exceptions import successfully')"`

------
https://chatgpt.com/codex/tasks/task_e_68868fd8431883318b685157322fb4ef