### PR TITLE
Add Practice Session ComponentStore

### DIFF
--- a/frontend/src/app/features/memorize/practice/store/practice-session.effects.ts
+++ b/frontend/src/app/features/memorize/practice/store/practice-session.effects.ts
@@ -1,0 +1,248 @@
+import { ComponentStore } from '@ngrx/component-store';
+import { tapResponse } from '@ngrx/operators';
+import { Observable, timer, filter, tap, switchMap, withLatestFrom, takeUntil, map } from 'rxjs';
+import { PracticeSessionStoreState } from './practice-session.state';
+import { practiceSelectors } from './practice-session.selectors';
+import { 
+  StartSessionRequest,
+  ResponseQuality,
+  SessionState,
+  StudyCard
+} from '../../../../state/practice-session/models/practice-session.model';
+import { PracticeService } from '../../../../core/services/practice.service';
+import { NotificationService } from '../../../../core/services/notification.service';
+import { AudioService } from '../../../../core/services/audio.service';
+
+export function createPracticeEffects(
+  store: ComponentStore<PracticeSessionStoreState>,
+  practiceService: PracticeService,
+  notificationService: NotificationService,
+  audioService: AudioService
+) {
+  const setLoading = store.updater((state, loading: boolean) => ({
+    ...state,
+    loading,
+    error: loading ? null : state.error
+  }));
+
+  const setError = store.updater((state, error: string) => ({
+    ...state,
+    error,
+    loading: false
+  }));
+
+  const startSession = store.effect((request$: Observable<StartSessionRequest>) =>
+    request$.pipe(
+      tap(() => setLoading(true)),
+      switchMap(request =>
+        practiceService.startSession(request).pipe(
+          tapResponse(
+            (session: any) => {
+              store.patchState({
+                sessionId: session.id,
+                deckId: session.deckId,
+                deckName: session.deckName,
+                cards: session.cards,
+                currentIndex: 0,
+                responses: [],
+                startTime: session.startTime,
+                sessionState: SessionState.IN_PROGRESS,
+                settings: { ...(store as any).get().settings, ...session.settings },
+                cardFlipped: false,
+                showingHint: false,
+                currentStreak: 0,
+                loading: false,
+                error: null
+              });
+              
+              notificationService.info('Session started! Good luck! 🎯');
+              startTimeLimitTimer(store, notificationService);
+            },
+            (error: unknown) => {
+              setError('Failed to start session');
+              notificationService.error('Failed to start session');
+            }
+          )
+        )
+      )
+    )
+  );
+
+  const submitResponse = store.effect((response$: Observable<{
+    quality: ResponseQuality;
+    timeSpent?: number;
+  }>) =>
+    response$.pipe(
+      withLatestFrom(
+        store.select((state: PracticeSessionStoreState) => ({
+          sessionId: state.sessionId,
+          currentCard: practiceSelectors.currentCard(state),
+          startTime: state.startTime,
+          hintsUsed: state.showingHint ? 1 : 0,
+          settings: state.settings
+        }))
+      ),
+      filter(([_, data]) => !!data.sessionId && !!data.currentCard),
+      switchMap(([response, data]) => {
+        const responseTime = response.timeSpent || 
+          (Date.now() - (data.startTime?.getTime() || Date.now()));
+
+        return practiceService.submitResponse({
+          sessionId: data.sessionId!,
+          cardId: data.currentCard!.id,
+          quality: response.quality,
+          responseTime,
+          hintsUsed: data.hintsUsed
+        }).pipe(
+          tapResponse(
+            (cardResponse: any) => {
+              // Update state with response
+              store.patchState((state: PracticeSessionStoreState) => {
+                const newResponses = [...state.responses, cardResponse];
+                const isCorrect = cardResponse.correct;
+                const newStreak = isCorrect ? state.currentStreak + 1 : 0;
+                
+                return {
+                  responses: newResponses,
+                  currentStreak: newStreak,
+                  longestStreak: Math.max(newStreak, state.longestStreak),
+                  cards: state.cards.map(card =>
+                    card.id === cardResponse.cardId
+                      ? { ...card, seen: true }
+                      : card
+                  )
+                };
+              });
+
+              // Show feedback
+              if (cardResponse.correct) {
+                notificationService.success('Correct! 🎉', 1000);
+              } else {
+                notificationService.info('Keep practicing! 💪', 1000);
+              }
+
+              // Auto-advance if enabled
+              if (data.settings.immediateAnswerFeedback) {
+                timer(1500).subscribe(() => {
+                  const state = (store as any).get();
+                  if (state.currentIndex < state.cards.length - 1) {
+                    store.updater((s: PracticeSessionStoreState) => ({
+                      ...s,
+                      currentIndex: s.currentIndex + 1,
+                      cardFlipped: false,
+                      showingHint: false
+                    }))();
+                  } else {
+                    completeSession();
+                  }
+                });
+              }
+            },
+            (error: unknown) => {
+              notificationService.error('Failed to submit response');
+            }
+          )
+        );
+      })
+    )
+  );
+
+  const completeSession = store.effect((trigger$: Observable<void>) =>
+    trigger$.pipe(
+      withLatestFrom(store.select((state: PracticeSessionStoreState) => state.sessionId)),
+      filter(([_, sessionId]) => !!sessionId),
+      switchMap(([_, sessionId]) =>
+        practiceService.completeSession(sessionId!).pipe(
+          tapResponse(
+            (summary: any) => {
+              const { accuracy, correctCount, cardsStudied } = summary.session;
+              
+              notificationService.success(
+                `Session complete! ${correctCount}/${cardsStudied} correct (${Math.round(accuracy)}%)`,
+                5000
+              );
+              
+              // Play completion sound
+              audioService.playSound('session-complete');
+              
+              // Show achievements
+              summary.achievements.forEach((achievement: any) => {
+                setTimeout(() => {
+                  notificationService.info(
+                    `🏆 ${achievement.title}: ${achievement.description}`,
+                    5000
+                  );
+                }, 1000);
+              });
+              
+              // Reset to initial state
+              store.setState((state: PracticeSessionStoreState) => ({
+                ...state,
+                sessionId: null,
+                deckId: null,
+                deckName: '',
+                cards: [],
+                currentIndex: 0,
+                responses: [],
+                startTime: null,
+                sessionState: SessionState.COMPLETED,
+                cardFlipped: false,
+                showingHint: false,
+                currentStreak: 0,
+                loading: false,
+                error: null
+              }));
+            },
+            (error: unknown) => {
+              notificationService.error('Failed to complete session');
+            }
+          )
+        )
+      )
+    )
+  );
+
+  const setupAutoPlayAudio = () => {
+    store
+      .select((state: PracticeSessionStoreState) => ({
+        flipped: state.cardFlipped,
+        autoPlay: state.settings.autoPlayAudio,
+        card: practiceSelectors.currentCard(state),
+      }))
+      .pipe(
+        filter(({ flipped, autoPlay, card }) => flipped && autoPlay && !!card?.audioUrl),
+        tap(({ card }) => {
+          audioService.play(card!.audioUrl!);
+        })
+      )
+      .subscribe();
+  };
+
+  return {
+    startSession,
+    submitResponse,
+    completeSession,
+    setupAutoPlayAudio
+  };
+}
+
+function startTimeLimitTimer(
+  store: ComponentStore<PracticeSessionStoreState>,
+  notificationService: NotificationService
+): void {
+  const timeLimit = (store as any).get().settings.timeLimit;
+  if (!timeLimit) return;
+
+  timer(timeLimit * 60 * 1000)
+    .pipe(
+      takeUntil(
+        store.select((state: PracticeSessionStoreState) => state.sessionState).pipe(
+          filter((state: SessionState) => state !== SessionState.IN_PROGRESS)
+        )
+      )
+    )
+    .subscribe(() => {
+      notificationService.warning('Time limit reached! ⏰');
+      store.effect(() => (store as any).get())(); // Trigger complete session
+    });
+}

--- a/frontend/src/app/features/memorize/practice/store/practice-session.selectors.ts
+++ b/frontend/src/app/features/memorize/practice/store/practice-session.selectors.ts
@@ -1,0 +1,62 @@
+import { PracticeSessionStoreState } from './practice-session.state';
+import { SessionState } from '../../../../state/practice-session/models/practice-session.model';
+
+export const practiceSelectors = {
+  currentCard: (state: PracticeSessionStoreState) => 
+    state.cards[state.currentIndex] || null,
+
+  progress: (state: PracticeSessionStoreState) => ({
+    current: state.currentIndex + 1,
+    total: state.cards.length,
+    percent: state.cards.length > 0 
+      ? Math.round(((state.currentIndex + 1) / state.cards.length) * 100)
+      : 0,
+    cardsRemaining: state.cards.length - (state.currentIndex + 1)
+  }),
+
+  sessionStats: (state: PracticeSessionStoreState) => {
+    const correctResponses = state.responses.filter(r => r.correct).length;
+    const totalResponses = state.responses.length;
+    
+    return {
+      correct: correctResponses,
+      incorrect: totalResponses - correctResponses,
+      accuracy: totalResponses > 0 
+        ? Math.round((correctResponses / totalResponses) * 100)
+        : 0,
+      averageTime: totalResponses > 0
+        ? Math.round(
+            state.responses.reduce((sum, r) => sum + r.responseTime, 0) / 
+            totalResponses / 1000
+          )
+        : 0,
+      hintsUsed: state.responses.reduce((sum, r) => sum + r.hintsUsed, 0)
+    };
+  },
+
+  isSessionActive: (state: PracticeSessionStoreState) => 
+    state.sessionState === SessionState.IN_PROGRESS,
+
+  canFlipCard: (state: PracticeSessionStoreState) => 
+    state.sessionState === SessionState.IN_PROGRESS && state.cards.length > 0,
+
+  isCardFlipped: (state: PracticeSessionStoreState) => state.cardFlipped,
+
+  isShowingHint: (state: PracticeSessionStoreState) => state.showingHint,
+
+  currentSessionTime: (state: PracticeSessionStoreState) => 
+    state.startTime ? Date.now() - state.startTime.getTime() : 0,
+
+  sessionSummary: (state: PracticeSessionStoreState) => {
+    const stats = practiceSelectors.sessionStats(state);
+    const progress = practiceSelectors.progress(state);
+    
+    return {
+      deckName: state.deckName,
+      sessionType: state.settings.sessionType,
+      duration: practiceSelectors.currentSessionTime(state),
+      ...stats,
+      ...progress
+    };
+  }
+};

--- a/frontend/src/app/features/memorize/practice/store/practice-session.state.ts
+++ b/frontend/src/app/features/memorize/practice/store/practice-session.state.ts
@@ -1,0 +1,75 @@
+import { 
+  StudyCard, 
+  PracticeSettings, 
+  SessionState,
+  CardResponse,
+  SessionType,
+  ReviewOrder
+} from '../../../../state/practice-session/models/practice-session.model';
+
+export interface PracticeSessionStoreState {
+  // Session data
+  sessionId: string | null;
+  deckId: number | null;
+  deckName: string;
+  cards: StudyCard[];
+  currentIndex: number;
+  responses: CardResponse[];
+  startTime: Date | null;
+  sessionState: SessionState;
+  
+  // Settings
+  settings: PracticeSettings;
+  
+  // UI State
+  cardFlipped: boolean;
+  showingHint: boolean;
+  
+  // Performance
+  currentStreak: number;
+  longestStreak: number;
+  
+  // Loading states
+  loading: boolean;
+  error: string | null;
+}
+
+export const initialState: PracticeSessionStoreState = {
+  sessionId: null,
+  deckId: null,
+  deckName: '',
+  cards: [],
+  currentIndex: 0,
+  responses: [],
+  startTime: null,
+  sessionState: SessionState.NOT_STARTED,
+  
+  settings: {
+    sessionType: SessionType.REVIEW,
+    cardLimit: 20,
+    timeLimit: null,
+    newCardsPerSession: 5,
+    reviewOrder: ReviewOrder.DUE_DATE,
+    prioritizeDue: true,
+    includeNewCards: true,
+    showHints: true,
+    autoPlayAudio: false,
+    flipAnimation: true,
+    fontSize: 'medium',
+    immediateAnswerFeedback: true,
+    requireTypedAnswer: false,
+    caseSensitive: false,
+    showProgress: true,
+    easyBonus: 1.3,
+    intervalModifier: 1.0,
+    lapseMultiplier: 0.5,
+    minimumInterval: 1
+  },
+  
+  cardFlipped: false,
+  showingHint: false,
+  currentStreak: 0,
+  longestStreak: 0,
+  loading: false,
+  error: null
+};

--- a/frontend/src/app/features/memorize/practice/store/practice-session.store.spec.ts
+++ b/frontend/src/app/features/memorize/practice/store/practice-session.store.spec.ts
@@ -1,0 +1,427 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { PracticeSessionStore } from './practice-session.store';
+import { PracticeService } from '../../../../core/services/practice.service';
+import { NotificationService } from '../../../../core/services/notification.service';
+import { AudioService } from '../../../../core/services/audio.service';
+import { 
+  SessionType, 
+  ResponseQuality, 
+  SessionState 
+} from '../../../../state/practice-session/models/practice-session.model';
+
+describe('PracticeSessionStore', () => {
+  let store: PracticeSessionStore;
+  let practiceService: jasmine.SpyObj<PracticeService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+  let audioService: jasmine.SpyObj<AudioService>;
+
+  const mockSession = {
+    id: 'session-123',
+    deckId: 1,
+    deckName: 'Test Deck',
+    type: SessionType.REVIEW,
+    cards: [
+      {
+        id: 1,
+        deckId: 1,
+        front: 'Question 1',
+        back: 'Answer 1',
+        hint: 'Hint 1',
+        audioUrl: 'audio1.mp3',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 0,
+        seen: false
+      },
+      {
+        id: 2,
+        deckId: 1,
+        front: 'Question 2',
+        back: 'Answer 2',
+        easeFactor: 2.5,
+        interval: 1,
+        repetitions: 0,
+        order: 1,
+        seen: false
+      }
+    ],
+    currentIndex: 0,
+    responses: [],
+    startTime: new Date(),
+    settings: {
+      sessionType: SessionType.REVIEW,
+      cardLimit: 20,
+      timeLimit: null,
+      autoPlayAudio: false,
+      immediateAnswerFeedback: true
+    },
+    state: SessionState.IN_PROGRESS
+  };
+
+  beforeEach(() => {
+    const practiceServiceSpy = jasmine.createSpyObj('PracticeService', [
+      'startSession',
+      'submitResponse',
+      'completeSession'
+    ]);
+    const notificationServiceSpy = jasmine.createSpyObj('NotificationService', [
+      'success',
+      'error',
+      'info',
+      'warning'
+    ]);
+    const audioServiceSpy = jasmine.createSpyObj('AudioService', [
+      'play',
+      'playSound'
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        PracticeSessionStore,
+        { provide: PracticeService, useValue: practiceServiceSpy },
+        { provide: NotificationService, useValue: notificationServiceSpy },
+        { provide: AudioService, useValue: audioServiceSpy }
+      ]
+    });
+
+    store = TestBed.inject(PracticeSessionStore);
+    practiceService = TestBed.inject(PracticeService) as jasmine.SpyObj<PracticeService>;
+    notificationService = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
+    audioService = TestBed.inject(AudioService) as jasmine.SpyObj<AudioService>;
+  });
+
+  describe('Initial State', () => {
+    it('should have correct initial state', (done) => {
+      store.state$.subscribe(state => {
+        expect(state.sessionId).toBeNull();
+        expect(state.cards).toEqual([]);
+        expect(state.currentIndex).toBe(0);
+        expect(state.sessionState).toBe(SessionState.NOT_STARTED);
+        expect(state.cardFlipped).toBe(false);
+        expect(state.loading).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe('Selectors', () => {
+    it('should select current card', (done) => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 0
+      });
+
+      store.currentCard$.subscribe(card => {
+        expect(card).toEqual(mockSession.cards[0]);
+        done();
+      });
+    });
+
+    it('should calculate progress correctly', (done) => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 1
+      });
+
+      store.progress$.subscribe(progress => {
+        expect(progress.current).toBe(2);
+        expect(progress.total).toBe(2);
+        expect(progress.percent).toBe(100);
+        expect(progress.cardsRemaining).toBe(0);
+        done();
+      });
+    });
+
+    it('should calculate session stats', (done) => {
+      const responses = [
+        { cardId: 1, correct: true, responseTime: 3000, hintsUsed: 0 },
+        { cardId: 2, correct: false, responseTime: 5000, hintsUsed: 1 }
+      ];
+
+      store.patchState({
+        responses: responses as any
+      });
+
+      store.sessionStats$.subscribe(stats => {
+        expect(stats.correct).toBe(1);
+        expect(stats.incorrect).toBe(1);
+        expect(stats.accuracy).toBe(50);
+        expect(stats.averageTime).toBe(4); // (3000 + 5000) / 2 / 1000
+        expect(stats.hintsUsed).toBe(1);
+        done();
+      });
+    });
+
+    it('should provide complete view model', (done) => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 0,
+        sessionState: SessionState.IN_PROGRESS,
+        cardFlipped: true,
+        showingHint: false,
+        loading: false,
+        error: null
+      });
+
+      store.vm$.subscribe(vm => {
+        expect(vm.currentCard).toBeDefined();
+        expect(vm.progress).toBeDefined();
+        expect(vm.stats).toBeDefined();
+        expect(vm.cardFlipped).toBe(true);
+        expect(vm.showingHint).toBe(false);
+        expect(vm.loading).toBe(false);
+        expect(vm.error).toBeNull();
+        expect(vm.sessionState).toBe(SessionState.IN_PROGRESS);
+        expect(vm.settings).toBeDefined();
+        done();
+      });
+    });
+  });
+
+  describe('Updaters', () => {
+    it('should flip card', (done) => {
+      store.flipCard();
+      
+      store.state$.subscribe(state => {
+        expect(state.cardFlipped).toBe(true);
+        done();
+      });
+    });
+
+    it('should show hint', (done) => {
+      store.showHint();
+      
+      store.state$.subscribe(state => {
+        expect(state.showingHint).toBe(true);
+        done();
+      });
+    });
+
+    it('should navigate to next card', (done) => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 0,
+        cardFlipped: true,
+        showingHint: true
+      });
+
+      store.nextCard();
+      
+      store.state$.subscribe(state => {
+        expect(state.currentIndex).toBe(1);
+        expect(state.cardFlipped).toBe(false);
+        expect(state.showingHint).toBe(false);
+        done();
+      });
+    });
+
+    it('should not exceed card bounds when navigating', (done) => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 1 // Last card
+      });
+
+      store.nextCard();
+      
+      store.state$.subscribe(state => {
+        expect(state.currentIndex).toBe(1); // Should stay at last card
+        done();
+      });
+    });
+
+    it('should update settings', (done) => {
+      const newSettings = { autoPlayAudio: true, fontSize: 'large' as const };
+      
+      store.updateSettings(newSettings);
+      
+      store.state$.subscribe(state => {
+        expect(state.settings.autoPlayAudio).toBe(true);
+        expect(state.settings.fontSize).toBe('large');
+        done();
+      });
+    });
+
+    it('should reset session', (done) => {
+      store.patchState({
+        sessionId: 'test-123',
+        cards: mockSession.cards,
+        currentIndex: 1
+      });
+
+      store.resetSession();
+      
+      store.state$.subscribe(state => {
+        expect(state.sessionId).toBeNull();
+        expect(state.cards).toEqual([]);
+        expect(state.currentIndex).toBe(0);
+        done();
+      });
+    });
+  });
+
+  describe('Effects', () => {
+    it('should start session successfully', (done) => {
+      practiceService.startSession.and.returnValue(of(mockSession as any));
+
+      store.startSession({ 
+        deckId: 1, 
+        settings: { cardLimit: 10 } 
+      });
+
+      setTimeout(() => {
+        store.state$.subscribe(state => {
+          expect(state.sessionId).toBe('session-123');
+          expect(state.deckName).toBe('Test Deck');
+          expect(state.cards.length).toBe(2);
+          expect(state.sessionState).toBe(SessionState.IN_PROGRESS);
+          expect(state.loading).toBe(false);
+          expect(notificationService.info).toHaveBeenCalledWith('Session started! Good luck! 🎯');
+          done();
+        });
+      }, 100);
+    });
+
+    it('should handle start session error', (done) => {
+      practiceService.startSession.and.returnValue(
+        throwError(() => new Error('Network error'))
+      );
+
+      store.startSession({ deckId: 1, settings: {} });
+
+      setTimeout(() => {
+        store.state$.subscribe(state => {
+          expect(state.loading).toBe(false);
+          expect(state.error).toBe('Failed to start session');
+          expect(notificationService.error).toHaveBeenCalledWith('Failed to start session');
+          done();
+        });
+      }, 100);
+    });
+
+    it('should submit response and update state', (done) => {
+      const mockResponse = {
+        cardId: 1,
+        quality: ResponseQuality.GOOD,
+        responseTime: 3000,
+        hintsUsed: 0,
+        audioPlayed: false,
+        timestamp: new Date(),
+        correct: true,
+        newInterval: 2,
+        newEaseFactor: 2.6
+      };
+
+      practiceService.submitResponse.and.returnValue(of(mockResponse));
+
+      store.patchState({
+        sessionId: 'session-123',
+        cards: mockSession.cards,
+        currentIndex: 0,
+        startTime: new Date(),
+        showingHint: false
+      });
+
+      store.submitResponse({ quality: ResponseQuality.GOOD });
+
+      setTimeout(() => {
+        store.state$.subscribe(state => {
+          expect(state.responses.length).toBe(1);
+          expect(state.currentStreak).toBe(1);
+          expect(state.cards[0].seen).toBe(true);
+          expect(notificationService.success).toHaveBeenCalledWith('Correct! 🎉', 1000);
+          done();
+        });
+      }, 100);
+    });
+  });
+
+  describe('Key Press Handling', () => {
+    beforeEach(() => {
+      store.patchState({
+        sessionState: SessionState.IN_PROGRESS,
+        cards: mockSession.cards,
+        currentIndex: 0
+      });
+    });
+
+    it('should flip card on space key', () => {
+      store.handleKeyPress(' ');
+      
+      expect(store.get().cardFlipped).toBe(true);
+    });
+
+    it('should show hint on h key', () => {
+      store.handleKeyPress('h');
+      
+      expect(store.get().showingHint).toBe(true);
+    });
+
+    it('should submit response on number keys when card is flipped', () => {
+      practiceService.submitResponse.and.returnValue(of({} as any));
+      store.patchState({ cardFlipped: true });
+      
+      store.handleKeyPress('1');
+      
+      expect(practiceService.submitResponse).toHaveBeenCalled();
+    });
+
+    it('should not submit response on number keys when card is not flipped', () => {
+      store.patchState({ cardFlipped: false });
+      
+      store.handleKeyPress('1');
+      
+      expect(practiceService.submitResponse).not.toHaveBeenCalled();
+    });
+
+    it('should navigate with arrow keys', () => {
+      store.patchState({ currentIndex: 1 });
+      
+      store.handleKeyPress('ArrowLeft');
+      expect(store.get().currentIndex).toBe(0);
+      
+      store.handleKeyPress('ArrowRight');
+      expect(store.get().currentIndex).toBe(1);
+    });
+
+    it('should handle Enter key properly', () => {
+      // Should flip card if not flipped
+      store.handleKeyPress('Enter');
+      expect(store.get().cardFlipped).toBe(true);
+      
+      // Should submit response if flipped and card not seen
+      practiceService.submitResponse.and.returnValue(of({} as any));
+      store.handleKeyPress('Enter');
+      expect(practiceService.submitResponse).toHaveBeenCalled();
+    });
+  });
+
+  describe('Helper Methods', () => {
+    it('should return loading state', () => {
+      store.setLoading(true);
+      expect(store.isLoading()).toBe(true);
+      
+      store.setLoading(false);
+      expect(store.isLoading()).toBe(false);
+    });
+
+    it('should return error state', () => {
+      expect(store.hasError()).toBe(false);
+      expect(store.getError()).toBeNull();
+      
+      store.setError('Test error');
+      expect(store.hasError()).toBe(true);
+      expect(store.getError()).toBe('Test error');
+    });
+
+    it('should return current progress percentage', () => {
+      store.patchState({
+        cards: mockSession.cards,
+        currentIndex: 0
+      });
+      
+      expect(store.getCurrentProgress()).toBe(50);
+    });
+  });
+});

--- a/frontend/src/app/features/memorize/practice/store/practice-session.store.ts
+++ b/frontend/src/app/features/memorize/practice/store/practice-session.store.ts
@@ -1,0 +1,201 @@
+import { Injectable, inject } from '@angular/core';
+import { ComponentStore } from '@ngrx/component-store';
+import { initialState, PracticeSessionStoreState } from './practice-session.state';
+import { practiceSelectors } from './practice-session.selectors';
+import { createPracticeEffects } from './practice-session.effects';
+import { PracticeService } from '../../../../core/services/practice.service';
+import { NotificationService } from '../../../../core/services/notification.service';
+import { AudioService } from '../../../../core/services/audio.service';
+import { 
+  PracticeSettings, 
+  ResponseQuality,
+  StartSessionRequest 
+} from '../../../../state/practice-session/models/practice-session.model';
+
+@Injectable()
+export class PracticeSessionStore extends ComponentStore<PracticeSessionStoreState> {
+  private practiceService = inject(PracticeService);
+  private notificationService = inject(NotificationService);
+  private audioService = inject(AudioService);
+
+  // Expose get method publicly for testing and effects
+  override get(): PracticeSessionStoreState {
+    return super.get();
+  }
+
+  // Selectors
+  readonly currentCard$ = this.select(practiceSelectors.currentCard);
+  readonly progress$ = this.select(practiceSelectors.progress);
+  readonly sessionStats$ = this.select(practiceSelectors.sessionStats);
+  readonly isSessionActive$ = this.select(practiceSelectors.isSessionActive);
+  readonly canFlipCard$ = this.select(practiceSelectors.canFlipCard);
+  
+  // View model for components
+  readonly vm$ = this.select({
+    currentCard: this.currentCard$,
+    progress: this.progress$,
+    stats: this.sessionStats$,
+    cardFlipped: this.select(s => s.cardFlipped),
+    showingHint: this.select(s => s.showingHint),
+    loading: this.select(s => s.loading),
+    error: this.select(s => s.error),
+    sessionState: this.select(s => s.sessionState),
+    settings: this.select(s => s.settings)
+  });
+
+  // Effects
+  private effects = createPracticeEffects(
+    this,
+    this.practiceService,
+    this.notificationService,
+    this.audioService
+  );
+
+  // Public effect methods
+  readonly startSession = this.effects.startSession;
+  readonly submitResponse = this.effects.submitResponse;
+  readonly completeSession = this.effects.completeSession;
+
+  constructor() {
+    super(initialState);
+    
+    // Setup auto-play audio
+    this.effects.setupAutoPlayAudio();
+  }
+
+  // Simple updaters
+  readonly setLoading = this.updater((state, loading: boolean) => ({
+    ...state,
+    loading,
+    error: loading ? null : state.error
+  }));
+
+  readonly setError = this.updater((state, error: string) => ({
+    ...state,
+    error,
+    loading: false
+  }));
+
+  readonly flipCard = this.updater(state => ({
+    ...state,
+    cardFlipped: !state.cardFlipped
+  }));
+
+  readonly showHint = this.updater(state => ({
+    ...state,
+    showingHint: true
+  }));
+
+  readonly nextCard = this.updater(state => ({
+    ...state,
+    currentIndex: Math.min(state.currentIndex + 1, state.cards.length - 1),
+    cardFlipped: false,
+    showingHint: false
+  }));
+
+  readonly previousCard = this.updater(state => ({
+    ...state,
+    currentIndex: Math.max(state.currentIndex - 1, 0),
+    cardFlipped: false,
+    showingHint: false
+  }));
+
+  readonly updateSettings = this.updater(
+    (state, settings: Partial<PracticeSettings>) => ({
+      ...state,
+      settings: { ...state.settings, ...settings }
+    })
+  );
+
+  readonly resetSession = this.updater(() => initialState);
+
+  // Public API methods
+  handleKeyPress(key: string): void {
+    const state = this.get();
+    
+    switch (key) {
+      case ' ':  // Space
+        if (practiceSelectors.isSessionActive(state)) {
+          this.flipCard();
+        }
+        break;
+        
+      case 'Enter':
+        this.handleEnterKey();
+        break;
+        
+      case 'h':
+      case 'H':
+        if (!state.showingHint && practiceSelectors.isSessionActive(state)) {
+          this.showHint();
+        }
+        break;
+        
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+        this.handleNumberKey(key);
+        break;
+        
+      case 'ArrowLeft':
+        if (practiceSelectors.isSessionActive(state)) {
+          this.previousCard();
+        }
+        break;
+        
+      case 'ArrowRight':
+        if (practiceSelectors.isSessionActive(state)) {
+          this.nextCard();
+        }
+        break;
+    }
+  }
+
+  private handleEnterKey(): void {
+    const state = this.get();
+    const currentCard = practiceSelectors.currentCard(state);
+    
+    if (state.cardFlipped && currentCard && !currentCard.seen) {
+      this.submitResponse({ quality: ResponseQuality.GOOD });
+    } else if (currentCard?.seen) {
+      this.nextCard();
+    } else if (!state.cardFlipped && practiceSelectors.isSessionActive(state)) {
+      this.flipCard();
+    }
+  }
+
+  private handleNumberKey(key: string): void {
+    const state = this.get();
+    if (!state.cardFlipped || !practiceSelectors.isSessionActive(state)) return;
+
+    const qualityMap: Record<string, ResponseQuality> = {
+      '1': ResponseQuality.AGAIN,
+      '2': ResponseQuality.HARD,
+      '3': ResponseQuality.GOOD,
+      '4': ResponseQuality.EASY
+    };
+
+    const quality = qualityMap[key];
+    if (quality !== undefined) {
+      this.submitResponse({ quality });
+    }
+  }
+
+  // Helper methods
+  isLoading(): boolean {
+    return this.get().loading;
+  }
+
+  hasError(): boolean {
+    return !!this.get().error;
+  }
+
+  getError(): string | null {
+    return this.get().error;
+  }
+
+  getCurrentProgress(): number {
+    return practiceSelectors.progress(this.get()).percent;
+  }
+}


### PR DESCRIPTION
## Summary
- implement component store state/effects/store for practice session
- add selectors and unit tests

## Testing
- `npm run test:single -- --include='**/practice-session.store.spec.ts'` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68896f9780008331896758e8d14a1a3f