### PR TITLE
fix progress marker distribution and visibility

### DIFF
--- a/frontend/src/app/features/flow-memorization/memorization-modal/components/progress-journey/progress-journey.component.html
+++ b/frontend/src/app/features/flow-memorization/memorization-modal/components/progress-journey/progress-journey.component.html
@@ -16,11 +16,13 @@
         fill="none"
         [style.stroke-dasharray]="'100'"
         [style.stroke-dashoffset]="100 - progressPercentage"
+        [style.opacity]="progressPercentage > 0 ? 1 : 0"
         @progressPath
       />
     </svg>
     <div
       class="progress-shimmer"
+      *ngIf="progressPercentage > 0"
       [style.width.%]="progressPercentage"
     ></div>
   </div>

--- a/frontend/src/app/features/flow-memorization/memorization-modal/memorization-modal.component.ts
+++ b/frontend/src/app/features/flow-memorization/memorization-modal/memorization-modal.component.ts
@@ -342,7 +342,7 @@ buildAllStages() {
       const stage = this.allStages[stageIdx];
       const isLastStage = stageIdx === this.allStages.length - 1;
       for (let groupIdx = 0; groupIdx < stage.groups.length; groupIdx++) {
-        stepCount += 3;
+        stepCount += 4;
         const position = (stepCount / this.totalSteps) * 100;
         const isFinalMarker = isLastStage && groupIdx === stage.groups.length - 1;
         if (isFinalMarker) {
@@ -383,7 +383,7 @@ buildAllStages() {
       const stage = this.allStages[stageIdx];
       const isLastStage = stageIdx === this.allStages.length - 1;
       for (let groupIdx = 0; groupIdx < stage.groups.length; groupIdx++) {
-        stepCount += 3;
+        stepCount += 4;
         const markerId = isLastStage && groupIdx === stage.groups.length - 1
           ? 'finish-goal'
           : `star-${stageIdx}-${groupIdx}`;


### PR DESCRIPTION
## Summary
- align progress marker increments with total step count
- hide progress path and shimmer when progress is zero

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688fdc7f5cb0833183373935f1ef2ab8