### PR TITLE
Add playback tracking with timer and keyboard controls

### DIFF
--- a/frontend/src/app/features/flow-memorization/memorization-modal/components/navigation-controls/navigation-controls.component.css
+++ b/frontend/src/app/features/flow-memorization/memorization-modal/components/navigation-controls/navigation-controls.component.css
@@ -76,9 +76,26 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+
 .play-btn {
   background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
   color: white;
+  position: relative;
+  overflow: visible;
+}
+
+.play-btn.playing {
+  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  animation: playPulse 2s ease-in-out infinite;
+}
+
+@keyframes playPulse {
+  0%, 100% {
+    box-shadow: 0 4px 12px -2px rgba(139, 92, 246, 0.3);
+  }
+  50% {
+    box-shadow: 0 8px 20px -4px rgba(139, 92, 246, 0.5);
+  }
 }
 
 .play-btn:hover:not(:disabled) {
@@ -90,6 +107,66 @@
   opacity: 0.5;
   cursor: not-allowed;
   background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 100%);
+}
+
+.progress-ring {
+  position: absolute;
+  top: -7px;
+  left: -7px;
+  pointer-events: none;
+  transform: rotate(-90deg);
+}
+
+.progress-ring-circle {
+  transition: stroke-dashoffset 0.1s linear;
+}
+
+.playback-timer {
+  position: absolute;
+  bottom: -24px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #3b82f6;
+  white-space: nowrap;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 2px 8px;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+}
+
+.playback-timer.ending {
+  color: #ef4444;
+  animation: timerPulse 0.5s ease-in-out infinite;
+}
+
+@keyframes timerPulse {
+  0%, 100% {
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    transform: translateX(-50%) scale(1.05);
+  }
+}
+
+.play-btn.completion-flash {
+  animation: completionFlash 0.5s ease-out;
+}
+
+@keyframes completionFlash {
+  0% {
+    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+    transform: scale(1);
+  }
 }
 
 .prev-btn,

--- a/frontend/src/app/features/flow-memorization/memorization-modal/components/navigation-controls/navigation-controls.component.html
+++ b/frontend/src/app/features/flow-memorization/memorization-modal/components/navigation-controls/navigation-controls.component.html
@@ -27,9 +27,10 @@
     <!-- Play Button -->
     <button 
       class="play-btn"
-      [disabled]="!recordingState.audioUrl || isPlaying"
+      [disabled]="!recordingState.audioUrl || recordingState.isRecording"
+      [class.playing]="isPlaying"
       (click)="onPlayClick()"
-      title="Play recording"
+      [title]="getPlayTooltip()"
     >
       <svg *ngIf="!isPlaying" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
         <path d="M8 5v14l11-7z"/>
@@ -38,6 +39,31 @@
         <rect x="6" y="4" width="4" height="16"/>
         <rect x="14" y="4" width="4" height="16"/>
       </svg>
+      
+      <!-- Circular Progress Indicator -->
+      <svg class="progress-ring" *ngIf="isPlaying" width="56" height="56">
+        <circle
+          class="progress-ring-circle"
+          stroke="#3b82f6"
+          stroke-width="3"
+          fill="transparent"
+          r="25"
+          cx="28"
+          cy="28"
+          [style.stroke-dasharray]="'157 157'"
+          [style.stroke-dashoffset]="157 - (157 * (playbackDuration / audioDuration))"
+        />
+      </svg>
+      
+      <!-- Playback Timer -->
+      <span class="playback-timer" *ngIf="recordingState.audioUrl">
+        <span *ngIf="!isPlaying && recordingState.duration > 0">
+          {{ formatDuration(recordingState.duration) }}
+        </span>
+        <span *ngIf="isPlaying" [class.ending]="playbackRemaining < 3">
+          {{ formatRemaining(playbackRemaining) }}
+        </span>
+      </span>
     </button>
   </div>
 


### PR DESCRIPTION
## Summary
- track playback progress with timer and circular progress indicator
- add completion animation and dynamic tooltips
- handle spacebar to toggle playback

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_688fe77814d48331a0e18cac6df8bb5d