### PR TITLE
feat: remember last selected chapter

### DIFF
--- a/frontend/src/app/features/flow-memorization/flow.component.ts
+++ b/frontend/src/app/features/flow-memorization/flow.component.ts
@@ -206,14 +206,22 @@ export class FlowComponent implements OnInit, OnDestroy {
         console.log('Route params:', params);
         const bookId = params['bookId'] ? parseInt(params['bookId']) : null;
         const chapter = params['chapter'] ? parseInt(params['chapter']) : null;
-        
+
         if (bookId && chapter) {
           console.log('Loading chapter from params:', bookId, chapter);
           this.loadChapter(bookId, chapter);
         } else {
-          // Load default chapter if no params
-          console.log('No params, loading default chapter');
-          this.loadChapter(16, 9); // Nehemiah book ID and chapter 9
+          // Check for last selected chapter
+          const lastChapter = this.flowStateService.getLastChapter();
+
+          if (lastChapter) {
+            console.log('Loading last selected chapter:', lastChapter);
+            this.loadChapter(lastChapter.bookId, lastChapter.chapter);
+          } else {
+            // Default to Genesis 1
+            console.log('No last chapter, loading Genesis 1');
+            this.loadChapter(1, 1); // Genesis book ID is 1, chapter 1
+          }
         }
       });
   }
@@ -250,7 +258,10 @@ export class FlowComponent implements OnInit, OnDestroy {
     try {
       this.isLoading = true;
       this.currentChapter = chapterNum;
-      
+
+      // Save this as the last selected chapter
+      this.flowStateService.saveLastChapter(bookId, chapterNum);
+
       // Get book from Bible data
       const bibleData = this.bibleService.getBibleData();
       this.currentBook = bibleData.getBookById(bookId) || null;

--- a/frontend/src/app/features/flow-memorization/models/flow.models.ts
+++ b/frontend/src/app/features/flow-memorization/models/flow.models.ts
@@ -53,6 +53,8 @@ export interface ModalVerse {
 export interface FlowState {
   bookId?: number;
   chapter?: number;
+  lastBookId?: number;
+  lastChapter?: number;
   layoutMode: 'grid' | 'single';
   isTextMode: boolean;
   highlightFifthVerse: boolean;

--- a/frontend/src/app/features/flow-memorization/services/flow-state.service.ts
+++ b/frontend/src/app/features/flow-memorization/services/flow-state.service.ts
@@ -23,7 +23,9 @@ export class FlowStateService {
       isTextMode: false,
       highlightFifthVerse: true,
       showVerseNumbers: true,
-      fontSize: 16
+      fontSize: 16,
+      lastBookId: undefined,
+      lastChapter: undefined
     };
   }
 
@@ -53,6 +55,18 @@ export class FlowStateService {
     const updated = { ...current, ...state };
     this.stateSubject.next(updated);
     this.saveState();
+  }
+
+  saveLastChapter(bookId: number, chapter: number) {
+    this.updateState({ lastBookId: bookId, lastChapter: chapter });
+  }
+
+  getLastChapter(): { bookId: number; chapter: number } | null {
+    const state = this.getState();
+    if (state.lastBookId && state.lastChapter) {
+      return { bookId: state.lastBookId, chapter: state.lastChapter };
+    }
+    return null;
   }
 
   saveState() {


### PR DESCRIPTION
## Summary
- persist last selected book/chapter in flow state
- load flow page from query params, saved chapter, or default to Genesis 1
- save last selected chapter when loading a chapter

## Testing
- `npm run test:headless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68929e49f5408331bcea2fe4887536f8