### PR TITLE
Use native dropdown for book selection

### DIFF
--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
@@ -38,71 +38,13 @@
           </button>
         </div>
         
-        <!-- Book Selector -->
-        <div class="book-selector-glass" (click)="toggleBookDropdown()">
-          <span class="book-icon">📚</span>
-          <span class="book-title">{{ currentBook?.name || 'Select Book' }}</span>
-          <span class="dropdown-arrow" [class.open]="showBookDropdown">▼</span>
+          <!-- Book Selector Dropdown -->
+          <select class="book-select" (change)="onBookSelect(parseInt($any($event.target).value))">
+            <option *ngFor="let book of filteredBooks" [value]="book.id" [selected]="book.id === currentBook?.id">
+              {{ book.name }}
+            </option>
+          </select>
         </div>
-        
-        <!-- Book Dropdown -->
-        <div class="book-dropdown" *ngIf="showBookDropdown">
-          <div class="dropdown-section" *ngIf="booksByTestament.OT.length > 0">
-            <div class="dropdown-header">Old Testament</div>
-            <div class="book-list">
-              <div 
-                *ngFor="let book of booksByTestament.OT"
-                class="book-item"
-                [class.current]="book.id === currentBook?.id"
-                (click)="onBookSelect(book.id)"
-              >
-                <span class="book-name">{{ book.name }}</span>
-                <span class="book-progress">{{ book.progressPercentage }}%</span>
-              </div>
-            </div>
-          </div>
-          
-          <div class="dropdown-section" *ngIf="booksByTestament.NT.length > 0">
-            <div class="dropdown-header">New Testament</div>
-            <div class="book-list">
-              <div 
-                *ngFor="let book of booksByTestament.NT"
-                class="book-item"
-                [class.current]="book.id === currentBook?.id"
-                (click)="onBookSelect(book.id)"
-              >
-                <span class="book-name">{{ book.name }}</span>
-                <span class="book-progress">{{ book.progressPercentage }}%</span>
-              </div>
-            </div>
-          </div>
-          
-          <div class="dropdown-section" *ngIf="booksByTestament.APO.length > 0">
-            <div class="dropdown-header">Apocrypha</div>
-            <div class="book-list">
-              <div 
-                *ngFor="let book of booksByTestament.APO"
-                class="book-item"
-                [class.current]="book.id === currentBook?.id"
-                (click)="onBookSelect(book.id)"
-              >
-                <span class="book-name">{{ book.name }}</span>
-                <span class="book-progress">{{ book.progressPercentage }}%</span>
-              </div>
-            </div>
-          </div>
-          
-          <div class="dropdown-section recently-studied">
-            <div class="dropdown-header">Recently Studied</div>
-            <div class="recent-list">
-              <div *ngFor="let recent of recentlyStudied" class="recent-item">
-                <span class="recent-book">{{ recent.bookName }} Ch {{ recent.chapter }}</span>
-                <span class="recent-time">{{ recent.timeAgo }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
       
       <!-- Progress Container -->
       <div class="progress-stats-container">
@@ -124,16 +66,11 @@
           <div class="ring-percentage">{{ progressPercentage }}%</div>
         </div>
   
-        <!-- Stats Cards (removed Complete stat) -->
-        <div class="stats-cards">
-          <div class="stat-card-glass">
-            <span class="stat-label">Chapters</span>
-          </div>
-          <div class="stat-card-glass">
+          <!-- Verses statistic pill moved below the progress ring -->
+          <div class="verses-pill stat-card-glass">
             <span class="stat-label">Verses</span>
             <span class="stat-value">{{ memorizedBookVerses }} / {{ totalBookVerses }}</span>
           </div>
-        </div>
       </div>
       
       <!-- Action Buttons -->

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
@@ -39,7 +39,7 @@
         </div>
         
           <!-- Book Selector Dropdown -->
-          <select class="book-select" (change)="onBookSelect(parseInt($any($event.target).value))">
+          <select class="book-select" (change)="onBookSelect($any($event.target).value)">
             <option *ngFor="let book of filteredBooks" [value]="book.id" [selected]="book.id === currentBook?.id">
               {{ book.name }}
             </option>

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.scss
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.scss
@@ -52,6 +52,29 @@
   position: relative;
 }
 
+// Native select element to choose a book
+.book-select {
+  flex: 1;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(10px);
+  border-radius: 14px;
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  font-size: 16px;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.3s;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 4px 6px -1px rgba(102, 126, 234, 0.1);
+  }
+
+  option {
+    color: #374151;
+  }
+}
+
 .testament-filter {
   display: flex;
   gap: 2px;
@@ -247,9 +270,11 @@
 
 // Progress Stats Container
 .progress-stats-container {
+  // Stack the progress ring and the verses pill vertically
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 20px;
+  gap: 14px;
 
   .progress-ring-large {
     position: relative;
@@ -287,13 +312,19 @@
     }
   }
 
+  // Remove the old stats-cards styles as we no longer use the wrapper
   .stats-cards {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 14px; // Increased gap
-    justify-content: center; // Center vertically since we have fewer items
+    display: none;
   }
+}
+
+// Verses pill below the progress ring
+.verses-pill {
+  margin-top: 0.5rem;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .stat-card-glass {

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.ts
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.ts
@@ -215,8 +215,9 @@ export class FlowHeaderComponent {
     }
   }
 
-  onBookSelect(bookId: number): void {
-    this.changeBook.emit(bookId);
+  onBookSelect(bookId: string): void {
+    const parsedId = parseInt(bookId, 10);
+    this.changeBook.emit(parsedId);
     this.showBookDropdown = false;
   }
 

--- a/frontend/src/app/features/flow-memorization/flow.component.scss
+++ b/frontend/src/app/features/flow-memorization/flow.component.scss
@@ -158,13 +158,10 @@
     border-top-width: 4px;
   }
 
+  // Memorized verses no longer have a green background or border; they only show a checkmark.
   &.memorized {
-    background-color: #f0fdf4;
-    border-color: #10b981;
-
-    &:hover {
-      border-color: #059669;
-    }
+    background-color: white;
+    border-color: #e5e7eb;
   }
 
   &.memorized-needs-review {


### PR DESCRIPTION
## Summary
- Replace bespoke book picker with native `<select>` element
- Stack progress ring and verse stats vertically and add verse pill styling
- Remove green highlight from memorized verses

## Testing
- `npm test -- --watch=false` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6895467409c083318e082f287d863b06