### PR TITLE
Flow: Compact Neon Glow header for FLOW Memorization

### DIFF
--- a/docs/demos/neon-flow/FlowPage.jsx
+++ b/docs/demos/neon-flow/FlowPage.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export default function FlowPage() {
+  const radius = 45;
+  const circumference = 2 * Math.PI * radius;
+  return (
+    <div className="flow-header-glass">
+      <div className="header-glass-container">
+        <div className="header-left-section">
+          <div className="book-selector-glass">
+            <span className="book-icon">📚</span>
+            <span className="book-title">Genesis</span>
+          </div>
+          <div className="progress-ring-large">
+            <svg width="120" height="120">
+              <defs>
+                <linearGradient id="gradient-neon" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stopColor="#22d3ee" />
+                  <stop offset="100%" stopColor="#a855f7" />
+                </linearGradient>
+              </defs>
+              <circle cx="60" cy="60" r={radius} className="ring-bg" />
+              <circle
+                cx="60"
+                cy="60"
+                r={radius}
+                className="ring-fill"
+                stroke="url(#gradient-neon)"
+                strokeWidth="8"
+                strokeDasharray={circumference}
+                strokeDashoffset={circumference * 0.25}
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="ring-percentage">75%</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.html
@@ -1,7 +1,4 @@
 <div class="flow-header-glass">
-  <!-- Subtle animated mesh background -->
-  <div class="animated-mesh"></div>
-  
   <!-- Main header content -->
   <div class="header-glass-container">
     
@@ -111,14 +108,15 @@
         <div class="progress-ring-large">
           <svg width="120" height="120">
             <defs>
-              <linearGradient id="gradient-ring" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#34d399" />
-                <stop offset="100%" stop-color="#10b981" />
+              <linearGradient id="gradient-neon" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#22d3ee" />
+                <stop offset="100%" stop-color="#a855f7" />
               </linearGradient>
             </defs>
-            <circle cx="60" cy="60" r="54" class="ring-bg"></circle>
-            <circle cx="60" cy="60" r="54" class="ring-fill" 
-                    [attr.stroke-dasharray]="progressCircumference" 
+            <circle cx="60" cy="60" r="45" class="ring-bg"></circle>
+            <circle cx="60" cy="60" r="45" class="ring-fill"
+                    [attr.stroke]="'url(#gradient-neon)'"
+                    [attr.stroke-dasharray]="progressCircumference"
                     [attr.stroke-dashoffset]="progressOffset"></circle>
           </svg>
           <div class="ring-percentage">{{ progressPercentage }}%</div>
@@ -218,8 +216,8 @@
             <svg width="40" height="40">
               <defs>
                 <linearGradient [id]="'ch-gradient-' + chapter.number" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" [attr.stop-color]="chapter.isCurrent ? '#fff' : '#667eea'" />
-                  <stop offset="100%" [attr.stop-color]="chapter.isCurrent ? '#fff' : '#764ba2'" />
+                  <stop offset="0%" [attr.stop-color]="chapter.isCurrent ? '#fff' : '#22d3ee'" />
+                  <stop offset="100%" [attr.stop-color]="chapter.isCurrent ? '#fff' : '#a855f7'" />
                 </linearGradient>
               </defs>
               <circle cx="20" cy="20" r="18" class="pie-bg"></circle>

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.scss
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.scss
@@ -1,28 +1,36 @@
 .flow-header-glass {
-  // Subtle glass effect instead of bold gradient
-  background: linear-gradient(135deg, rgba(243, 244, 246, 0.95) 0%, rgba(229, 231, 235, 0.95) 100%);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(229, 231, 235, 0.6);
   position: relative;
   overflow: visible;
-  padding: 20px;
-  
-  // Subtle animated mesh
-  .animated-mesh {
+  padding: 16px;
+
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  backdrop-filter: blur(14px);
+
+  &::before,
+  &::after {
+    content: "";
     position: absolute;
-    top: -50%;
-    left: -50%;
-    width: 200%;
-    height: 200%;
-    background: radial-gradient(circle, rgba(102, 126, 234, 0.03) 1px, transparent 1px);
-    background-size: 20px 20px;
-    animation: drift 20s linear infinite;
+    filter: blur(60px);
     pointer-events: none;
   }
-  
-  @keyframes drift {
-    0% { transform: translate(0, 0); }
-    100% { transform: translate(20px, 20px); }
+
+  &::before {
+    left: 10%;
+    top: 20%;
+    width: 300px;
+    height: 300px;
+    border-radius: 50%;
+    background: rgba(34,211,238,0.30);
+  }
+
+  &::after {
+    right: 10%;
+    bottom: 20%;
+    width: 250px;
+    height: 250px;
+    border-radius: 50%;
+    background: rgba(168,85,247,0.30);
   }
 }
 
@@ -30,8 +38,8 @@
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: 340px 1fr;
-  gap: 24px;
+  grid-template-columns: 300px 1fr;
+  gap: 16px;
   
   @media (max-width: 1024px) {
     grid-template-columns: 1fr;
@@ -42,7 +50,7 @@
 .header-left-section {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 12px;
 }
 
 .book-selector-wrapper {
@@ -55,10 +63,10 @@
 .testament-filter {
   display: flex;
   gap: 2px;
-  background: rgba(243, 244, 246, 0.8);
+  background: rgba(255, 255, 255, 0.05);
   padding: 2px;
   border-radius: 10px;
-  
+
   button {
     padding: 6px 10px;
     background: transparent;
@@ -66,18 +74,17 @@
     border-radius: 8px;
     font-size: 11px;
     font-weight: 600;
-    color: #6b7280;
+    color: rgba(255, 255, 255, 0.7);
     cursor: pointer;
     transition: all 0.2s;
-    
+
     &:hover {
-      background: rgba(255, 255, 255, 0.5);
+      background: rgba(255, 255, 255, 0.1);
     }
-    
+
     &.active {
-      background: white;
-      color: #667eea;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+      background: rgba(34,211,238,0.3);
+      color: #fff;
     }
   }
 }
@@ -87,39 +94,46 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 16px;
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
-  border-radius: 14px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(34,211,238,0.10), rgba(168,85,247,0.10));
+  border: 1px solid rgba(34,211,238,0.30);
+  position: relative;
+  overflow: hidden;
+  color: #fff;
   cursor: pointer;
-  transition: all 0.3s;
-  border: 1px solid rgba(102, 126, 234, 0.2);
-  
-  &:hover {
-    background: rgba(255, 255, 255, 0.85);
-    transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.1);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(34,211,238,0.20), transparent);
+    transform: translateX(-100%);
+    animation: shine 3s linear infinite;
   }
-  
+
   .book-icon {
     font-size: 20px;
   }
-  
+
   .book-title {
     font-size: 18px;
     font-weight: 600;
     flex: 1;
-    color: #374151;
   }
-  
+
   .dropdown-arrow {
-    color: #6b7280;
     transition: transform 0.3s;
-    
+
     &.open {
       transform: rotate(180deg);
     }
   }
+}
+
+@keyframes shine {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(200%); }
 }
 
 // Book Dropdown
@@ -128,50 +142,50 @@
   top: calc(100% + 8px);
   left: 0;
   right: 0;
-  background: white;
+  background: #1e293b;
   border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-  border: 1px solid rgba(229, 231, 235, 0.6);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   max-height: 500px;
   overflow-y: auto;
   z-index: 100;
-  
+
   &::-webkit-scrollbar {
     width: 8px;
   }
-  
+
   &::-webkit-scrollbar-track {
-    background: #f3f4f6;
+    background: rgba(255,255,255,0.05);
     border-radius: 8px;
   }
-  
+
   &::-webkit-scrollbar-thumb {
-    background: #d1d5db;
+    background: rgba(255,255,255,0.2);
     border-radius: 8px;
-    
+
     &:hover {
-      background: #9ca3af;
+      background: rgba(255,255,255,0.3);
     }
   }
 }
 
 .dropdown-section {
   padding: 12px;
-  border-bottom: 1px solid #f3f4f6;
-  
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+
   &:last-child {
     border-bottom: none;
   }
-  
+
   &.recently-studied {
-    background: #fafafa;
+    background: rgba(255,255,255,0.02);
   }
 }
 
 .dropdown-header {
   font-size: 12px;
   font-weight: 600;
-  color: #9ca3af;
+  color: rgba(255,255,255,0.6);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 8px;
@@ -192,28 +206,28 @@
   border-radius: 10px;
   cursor: pointer;
   transition: all 0.2s;
-  
+
   &:hover {
-    background: #f3f4f6;
+    background: rgba(255,255,255,0.05);
   }
-  
+
   &.current {
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
-    
+    background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(168,85,247,0.2));
+
     .book-name {
-      color: #2563eb;
+      color: #fff;
       font-weight: 600;
     }
   }
-  
+
   .book-name {
     font-size: 14px;
-    color: #374151;
+    color: #fff;
   }
-  
+
   .book-progress {
     font-size: 12px;
-    color: #9ca3af;
+    color: rgba(255,255,255,0.6);
     font-weight: 500;
   }
 }
@@ -229,19 +243,19 @@
   justify-content: space-between;
   padding: 8px 12px;
   border-radius: 8px;
-  
+
   &:hover {
-    background: white;
+    background: rgba(255,255,255,0.05);
   }
-  
+
   .recent-book {
     font-size: 13px;
-    color: #4b5563;
+    color: #fff;
   }
-  
+
   .recent-time {
     font-size: 12px;
-    color: #9ca3af;
+    color: rgba(255,255,255,0.6);
   }
 }
 
@@ -249,41 +263,41 @@
 .progress-stats-container {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
 
   .progress-ring-large {
     position: relative;
-    width: 120px;  // Increased from 80px
-    height: 120px; // Increased from 80px
+    width: 120px;
+    height: 120px;
     flex-shrink: 0;
 
     svg {
       transform: rotate(-90deg);
-      filter: drop-shadow(0 6px 20px rgba(16, 185, 129, 0.2));
     }
 
     .ring-bg {
       fill: none;
-      stroke: rgba(16, 185, 129, 0.1);
-      stroke-width: 10; // Increased from 8
+      stroke: rgba(255, 255, 255, 0.15);
+      stroke-width: 8;
     }
 
     .ring-fill {
       fill: none;
-      stroke: url(#gradient-ring);
-      stroke-width: 10; // Increased from 8
+      stroke-width: 8;
       stroke-linecap: round;
-      transition: stroke-dashoffset 0.5s ease;
+      filter: drop-shadow(0 0 20px rgba(34,211,238,0.5));
+      transition: stroke-dashoffset 0.6s ease;
     }
 
     .ring-percentage {
       position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      font-size: 28px; // Increased from 22px
+      inset: 0;
+      display: grid;
+      place-items: center;
+      color: #fff;
       font-weight: 700;
-      color: #059669;
+      font-size: 24px;
+      text-shadow: 0 2px 8px rgba(0,0,0,.2);
     }
   }
 
@@ -291,37 +305,35 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 14px; // Increased gap
-    justify-content: center; // Center vertically since we have fewer items
+    gap: 8px;
+    justify-content: center;
   }
 }
 
 .stat-card-glass {
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.10);
   border-radius: 10px;
-  padding: 10px 14px;
+  padding: 10px 12px;
+  color: #fff;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  transition: all 0.3s;
-  border: 1px solid rgba(102, 126, 234, 0.1);
-  
-  &:hover {
-    background: rgba(255, 255, 255, 0.85);
-    transform: translateX(4px);
-    border-color: rgba(102, 126, 234, 0.2);
-  }
-  
+
   .stat-label {
-    font-size: 13px;
-    color: #6b7280;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    opacity: .7;
   }
-  
+
   .stat-value {
-    font-size: 15px;
-    font-weight: 600;
-    color: #374151;
+    font-size: 18px;
+    font-weight: 800;
+    background: linear-gradient(135deg,#22d3ee,#a855f7);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
   }
 }
 
@@ -329,41 +341,35 @@
 .action-buttons-glass {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
 }
 
 .btn-glass-action {
-  padding: 12px;
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(102, 126, 234, 0.2);
+  padding: 10px 12px;
   border-radius: 10px;
-  color: #374151;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  color: #fff;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: 0.2s;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  
+
   &:hover {
-    background: rgba(255, 255, 255, 0.9);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.1);
+    border-color: rgba(34,211,238,0.30);
+    transform: translateY(-1px);
   }
-  
+
   &.primary {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    border-color: transparent;
-    color: white;
-    
-    &:hover {
-      box-shadow: 0 12px 24px rgba(102, 126, 234, 0.25);
-    }
+    background: linear-gradient(135deg, rgba(34,211,238,0.20), rgba(168,85,247,0.20));
+    border-color: rgba(168,85,247,0.50);
+    box-shadow: 0 0 24px rgba(34,211,238,0.35);
   }
-  
+
   svg {
     width: 18px;
     height: 18px;
@@ -372,22 +378,24 @@
 
 // Chapters Section
 .chapters-section {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 16px;
-  padding: 20px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   max-height: 280px;
   overflow: hidden;
+  color: #fff;
 }
 
 .chapters-controls-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 16px;
-  border-bottom: 2px solid rgba(102, 126, 234, 0.1);
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .filter-pills {
@@ -397,26 +405,23 @@
 
 .filter-pill {
   padding: 6px 14px;
-  background: white;
-  border: 2px solid #e5e7eb;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 20px;
   font-size: 13px;
-  color: #6b7280;
+  color: #fff;
   cursor: pointer;
   transition: all 0.3s;
   font-weight: 500;
-  
+
   &:hover {
-    border-color: #667eea;
-    color: #667eea;
+    border-color: rgba(34,211,238,0.3);
     transform: translateY(-1px);
   }
-  
+
   &.active {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    border-color: transparent;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+    background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(168,85,247,0.2));
+    border-color: rgba(34,211,238,0.5);
   }
 }
 
@@ -424,25 +429,25 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  
+
   .chapter-count {
     font-size: 13px;
-    color: #6b7280;
+    color: rgba(255,255,255,0.7);
     font-weight: 500;
   }
-  
+
   .view-toggle-btn {
     padding: 6px 10px;
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
     border-radius: 8px;
     font-size: 14px;
     cursor: pointer;
     transition: all 0.2s;
-    
+    color: #fff;
+
     &:hover {
-      background: #f3f4f6;
-      border-color: #667eea;
+      border-color: rgba(34,211,238,0.3);
     }
   }
 }
@@ -451,7 +456,7 @@
 .chapters-grid-glass {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(85px, 1fr));
-  gap: 10px;
+  gap: 12px;
   overflow-y: auto;
   flex: 1;
   padding-right: 8px;
@@ -476,59 +481,31 @@
 }
 
 .chapter-card-glass {
-  background: white;
-  border: 2px solid #e5e7eb;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.10);
   border-radius: 12px;
-  padding: 10px 6px;
+  padding: 12px 10px;
   text-align: center;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: 0.2s;
   position: relative;
   overflow: hidden;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, #667eea, #764ba2);
-    transform: scaleX(0);
-    transition: transform 0.3s;
-  }
+  color: #fff;
 
   &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 16px rgba(102, 126, 234, 0.12);
-    border-color: #667eea;
-
-    &::before {
-      transform: scaleX(1);
-    }
+    transform: translateY(-2px);
+    border-color: rgba(34,211,238,0.4);
   }
 
   &.current {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    border-color: transparent;
-    box-shadow: 0 6px 16px rgba(102, 126, 234, 0.25);
-    animation: pulse-glow 2s infinite;
-
-    .ch-verses,
-    .ch-last-studied {
-      color: white;
-      opacity: 0.9;
-    }
+    background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(168,85,247,0.2));
+    border-color: rgba(34,211,238,0.5);
+    box-shadow: 0 0 28px rgba(34,211,238,0.35);
   }
 
   &.completed {
-    background: linear-gradient(135deg, #d1fae5, #a7f3d0);
-    border-color: #10b981;
-
-    .ch-verses {
-      color: #059669;
-    }
+    background: rgba(34,211,238,0.1);
+    border-color: rgba(34,211,238,0.4);
   }
 
   .completed-icon {
@@ -552,7 +529,7 @@
     font-size: 14px;
     font-weight: 700;
     margin-bottom: 4px;
-    color: #374151;
+    color: #fff;
   }
 
   .chapter-pie-chart {
@@ -567,7 +544,7 @@
 
     .pie-bg {
       fill: none;
-      stroke: rgba(229, 231, 235, 0.5);
+      stroke: rgba(255, 255, 255, 0.15);
       stroke-width: 4;
     }
 
@@ -585,7 +562,7 @@
       transform: translate(-50%, -50%);
       font-size: 10px;
       font-weight: 700;
-      color: #374151;
+      color: #fff;
     }
   }
 
@@ -605,13 +582,13 @@
 
   .ch-verses {
     font-size: 10px;
-    color: #6b7280;
+    color: rgba(255, 255, 255, 0.7);
     margin-bottom: 2px;
   }
 
   .ch-last-studied {
     font-size: 9px;
-    color: #9ca3af;
+    color: rgba(255, 255, 255, 0.5);
     font-style: italic;
   }
 }
@@ -644,74 +621,74 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 14px;
-  background: white;
-  border: 1px solid #e5e7eb;
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.10);
   border-radius: 10px;
   cursor: pointer;
-  transition: all 0.2s;
-  
+  transition: 0.2s;
+
   &:hover {
-    border-color: #667eea;
+    border-color: rgba(34,211,238,0.4);
     transform: translateX(4px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.1);
   }
-  
+
   &.current {
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
-    border-color: #3b82f6;
+    background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(168,85,247,0.2));
+    border-color: rgba(34,211,238,0.5);
+    box-shadow: 0 0 28px rgba(34,211,238,0.35);
   }
-  
+
   &.completed {
-    background: #f0fdf4;
-    border-color: #10b981;
+    background: rgba(34,211,238,0.1);
+    border-color: rgba(34,211,238,0.4);
   }
-  
+
   .row-number {
     font-weight: 600;
     font-size: 14px;
     min-width: 45px;
-    color: #374151;
+    color: #fff;
   }
-  
+
   .row-progress {
     flex: 1;
-    
+
     .progress-bar-row {
-      height: 8px;
-      background: #f3f4f6;
-      border-radius: 4px;
+      height: 6px;
+      background: rgba(255,255,255,0.1);
+      border-radius: 3px;
       overflow: hidden;
     }
-    
+
     .progress-fill-row {
       height: 100%;
-      background: linear-gradient(90deg, #667eea, #764ba2);
-      border-radius: 4px;
+      background: linear-gradient(90deg, #22d3ee, #a855f7);
+      border-radius: 3px;
       transition: width 0.5s ease;
     }
   }
-  
+
   .row-stats {
     display: flex;
     gap: 12px;
     align-items: center;
-    
+
     .verses-count {
       font-size: 12px;
-      color: #6b7280;
+      color: rgba(255,255,255,0.7);
     }
-    
+
     .percentage {
       font-size: 13px;
       font-weight: 600;
-      color: #374151;
+      color: #fff;
     }
   }
-  
+
   .row-last-studied {
     font-size: 11px;
-    color: #9ca3af;
+    color: rgba(255,255,255,0.5);
     font-style: italic;
     min-width: 80px;
     text-align: right;
@@ -743,40 +720,40 @@
 }
 
 .chapter-list-item {
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.10);
   border-radius: 12px;
   padding: 14px;
   cursor: pointer;
-  transition: all 0.2s;
-  
+  transition: 0.2s;
+
   &:hover {
-    border-color: #667eea;
-    box-shadow: 0 6px 16px rgba(102, 126, 234, 0.1);
+    border-color: rgba(34,211,238,0.4);
   }
-  
+
   &.current {
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
-    border-color: #3b82f6;
+    background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(168,85,247,0.2));
+    border-color: rgba(34,211,238,0.5);
+    box-shadow: 0 0 28px rgba(34,211,238,0.35);
   }
-  
+
   &.completed {
-    background: #f0fdf4;
-    border-color: #10b981;
+    background: rgba(34,211,238,0.1);
+    border-color: rgba(34,211,238,0.4);
   }
-  
+
   .list-header {
     display: flex;
     align-items: center;
     gap: 8px;
     margin-bottom: 8px;
-    
+
     .list-number {
       font-size: 15px;
       font-weight: 600;
-      color: #374151;
+      color: #fff;
     }
-    
+
     .list-badge {
       padding: 2px 8px;
       border-radius: 12px;
@@ -784,40 +761,40 @@
       font-weight: 600;
       background: #fbbf24;
       color: white;
-      
+
       &.completed {
         background: #10b981;
       }
     }
   }
-  
+
   .list-progress {
     margin-bottom: 8px;
-    
+
     .progress-bar-list {
-      height: 10px;
-      background: #f3f4f6;
-      border-radius: 5px;
+      height: 6px;
+      background: rgba(255,255,255,0.1);
+      border-radius: 3px;
       overflow: hidden;
     }
-    
+
     .progress-fill-list {
       height: 100%;
-      background: linear-gradient(90deg, #667eea, #764ba2);
-      border-radius: 5px;
+      background: linear-gradient(90deg, #22d3ee, #a855f7);
+      border-radius: 3px;
       transition: width 0.5s ease;
     }
   }
-  
+
   .list-footer {
     display: flex;
     justify-content: space-between;
     font-size: 12px;
-    color: #6b7280;
-    
+    color: rgba(255,255,255,0.7);
+
     .last-studied {
       font-style: italic;
-      color: #9ca3af;
+      color: rgba(255,255,255,0.5);
     }
   }
 }

--- a/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.ts
+++ b/frontend/src/app/features/flow-memorization/components/flow-header/flow-header.component.ts
@@ -77,7 +77,7 @@ export class FlowHeaderComponent {
 
   // LARGER Progress ring calculations for more prominent display
   get progressCircumference(): number {
-    return 2 * Math.PI * 54; // INCREASED radius from 36 to 54
+    return 2 * Math.PI * 45;
   }
 
   get progressOffset(): number {

--- a/frontend/src/app/features/flow-memorization/flow.component.scss
+++ b/frontend/src/app/features/flow-memorization/flow.component.scss
@@ -9,6 +9,10 @@
   width: 100%;        // Full width up to max-width
 }
 
+app-flow-header {
+  margin-bottom: 16px;
+}
+
 // Encouragement Message
 .encouragement-message {
   position: absolute;


### PR DESCRIPTION
## Summary
- restyle Flow header with Neon Glow glass aesthetic and tighter grid
- shrink progress ring and stats cards; update chapter cards and actions with neon gradients
- add optional React demo for Neon Flow styles

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*
- `apt-get update` *(failed: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68954ecae6a88331adeb81476144d522