### PR TITLE
Enable scrolling on Bible tracker page

### DIFF
--- a/frontend/src/app/features/bible-tracker/bible-tracker.component.html
+++ b/frontend/src/app/features/bible-tracker/bible-tracker.component.html
@@ -1,76 +1,78 @@
-<div class="bible-selector-container">
-  <!-- Loading overlay -->
-  <div *ngIf="isLoading$ | async" class="global-loading-overlay">
-    <div class="loading-spinner"></div>
-    <p>Loading Bible data...</p>
-  </div>
+<div class="scroll-container">
+  <div class="bible-selector-container">
+    <!-- Loading overlay -->
+    <div *ngIf="isLoading$ | async" class="global-loading-overlay">
+      <div class="loading-spinner"></div>
+      <p>Loading Bible data...</p>
+    </div>
 
-  <!-- Success Popup (kept for backward compatibility, though notifications should handle this) -->
-  <div class="success-popup" [class.show]="showSuccessMessage">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="success-icon">
-      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-      <polyline points="22 4 12 14.01 9 11.01"></polyline>
-    </svg>
-    <span>{{ successMessage }}</span>
-  </div>
+    <!-- Success Popup (kept for backward compatibility, though notifications should handle this) -->
+    <div class="success-popup" [class.show]="showSuccessMessage">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="success-icon">
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+        <polyline points="22 4 12 14.01 9 11.01"></polyline>
+      </svg>
+      <span>{{ successMessage }}</span>
+    </div>
 
-  <!-- Header -->
-  <app-bible-tracker-header></app-bible-tracker-header>
+    <!-- Header -->
+    <app-bible-tracker-header></app-bible-tracker-header>
 
-  <!-- Stats -->
-  <app-bible-tracker-stats
-    [memorizedVerses]="(memorizedVerses$ | async) || 0"
-    [percentComplete]="(percentComplete$ | async) || 0"
-    [progressViewMode]="(progressViewMode$ | async) || 'testament'"
-    [progressSegments]="(progressSegments$ | async) || []"
-    (toggleProgressView)="toggleProgressView()">
-  </app-bible-tracker-stats>
+    <!-- Stats -->
+    <app-bible-tracker-stats
+      [memorizedVerses]="(memorizedVerses$ | async) || 0"
+      [percentComplete]="(percentComplete$ | async) || 0"
+      [progressViewMode]="(progressViewMode$ | async) || 'testament'"
+      [progressSegments]="(progressSegments$ | async) || []"
+      (toggleProgressView)="toggleProgressView()">
+    </app-bible-tracker-stats>
 
-  <!-- Testament Cards -->
-  <div class="chart-grid">
-    <app-bible-tracker-testament-card
-      *ngFor="let testament of (testaments$ | async) || []"
-      [testament]="testament"
-      [isActive]="testament === selectedTestament"
+    <!-- Testament Cards -->
+    <div class="chart-grid">
+      <app-bible-tracker-testament-card
+        *ngFor="let testament of (testaments$ | async) || []"
+        [testament]="testament"
+        [isActive]="testament === selectedTestament"
+        [groupColors]="groupColors"
+        (testamentSelected)="setTestament($event)">
+      </app-bible-tracker-testament-card>
+    </div>
+
+    <!-- Book Groups -->
+    <app-bible-tracker-book-groups
+      [selectedTestament]="selectedTestament"
+      [selectedGroup]="selectedGroup"
       [groupColors]="groupColors"
-      (testamentSelected)="setTestament($event)">
-    </app-bible-tracker-testament-card>
+      (groupSelected)="setGroup($event)">
+    </app-bible-tracker-book-groups>
+
+    <!-- Book Grid -->
+    <app-bible-tracker-book-grid
+      [selectedGroup]="selectedGroup"
+      [selectedBook]="selectedBook"
+      (bookSelected)="setBook($event)">
+    </app-bible-tracker-book-grid>
+
+    <!-- Chapter Heatmap -->
+    <app-bible-tracker-chapter-heatmap
+      [selectedBook]="selectedBook"
+      [includeApocrypha]="includeApocrypha"
+      [isLoading]="(isLoading$ | async) || false"
+      [isSavingBulk]="(isSavingBulk$ | async) || false"
+      (chapterSelected)="setChapter($event)"
+      (selectAllChapters)="selectAllChapters()"
+      (clearAllChapters)="clearAllChapters()">
+    </app-bible-tracker-chapter-heatmap>
+
+    <!-- Verse Grid -->
+    <app-bible-tracker-verse-grid
+      [selectedBook]="selectedBook"
+      [selectedChapter]="selectedChapter"
+      [isLoading]="(isLoading$ | async) || false"
+      [isSavingBulk]="(isSavingBulk$ | async) || false"
+      (verseToggled)="toggleAndSaveVerse($event)"
+      (selectAllVerses)="selectAllVerses()"
+      (clearAllVerses)="clearAllVerses()">
+    </app-bible-tracker-verse-grid>
   </div>
-
-  <!-- Book Groups -->
-  <app-bible-tracker-book-groups
-    [selectedTestament]="selectedTestament"
-    [selectedGroup]="selectedGroup"
-    [groupColors]="groupColors"
-    (groupSelected)="setGroup($event)">
-  </app-bible-tracker-book-groups>
-
-  <!-- Book Grid -->
-  <app-bible-tracker-book-grid
-    [selectedGroup]="selectedGroup"
-    [selectedBook]="selectedBook"
-    (bookSelected)="setBook($event)">
-  </app-bible-tracker-book-grid>
-
-  <!-- Chapter Heatmap -->
-  <app-bible-tracker-chapter-heatmap
-    [selectedBook]="selectedBook"
-    [includeApocrypha]="includeApocrypha"
-    [isLoading]="(isLoading$ | async) || false"
-    [isSavingBulk]="(isSavingBulk$ | async) || false"
-    (chapterSelected)="setChapter($event)"
-    (selectAllChapters)="selectAllChapters()"
-    (clearAllChapters)="clearAllChapters()">
-  </app-bible-tracker-chapter-heatmap>
-
-  <!-- Verse Grid -->
-  <app-bible-tracker-verse-grid
-    [selectedBook]="selectedBook"
-    [selectedChapter]="selectedChapter"
-    [isLoading]="(isLoading$ | async) || false"
-    [isSavingBulk]="(isSavingBulk$ | async) || false"
-    (verseToggled)="toggleAndSaveVerse($event)"
-    (selectAllVerses)="selectAllVerses()"
-    (clearAllVerses)="clearAllVerses()">
-  </app-bible-tracker-verse-grid>
 </div>

--- a/frontend/src/app/features/bible-tracker/bible-tracker.component.scss
+++ b/frontend/src/app/features/bible-tracker/bible-tracker.component.scss
@@ -4,6 +4,13 @@
   box-sizing: border-box;
 }
 
+.scroll-container {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-bottom: 2rem;
+}
+
 .bible-selector-container {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   background: #f3f4f6;
@@ -11,6 +18,7 @@
   color: #1f2937;
   max-width: 1200px;
   margin: 0 auto;
+  height: 100%;
 }
 
 .chart-grid {

--- a/frontend/src/app/layout/main-layout/main-layout.component.scss
+++ b/frontend/src/app/layout/main-layout/main-layout.component.scss
@@ -11,7 +11,8 @@
 .app-content {
   flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding-top: 60px;
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -14,7 +14,8 @@ body {
   color: #1f2937;
   background-color: #f9fafb;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Utility classes */


### PR DESCRIPTION
## Summary
- Allow vertical scrolling globally by adjusting `html`/`body` styles
- Make `app-content` in the main layout scrollable
- Wrap Bible tracker content in a scroll container and add styles for it

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6895f2162194833191b8f68c47d674ad