### PR TITLE
feat: modernize deck list layout and theme

### DIFF
--- a/frontend/src/app/features/decks/components/deck-card/deck-card.component.html
+++ b/frontend/src/app/features/decks/components/deck-card/deck-card.component.html
@@ -1,210 +1,133 @@
-<!-- frontend/src/app/features/decks/components/deck-card/deck-card.component.html -->
-<div 
-  class="deck-card compact" 
-  [style.animation-delay.ms]="animationDelay">
+<div class="deck-card-modern" [style.animation-delay.ms]="animationDelay">
+  <!-- Hover gradient bar -->
+  <div class="hover-gradient"></div>
   
-  <!-- Gradient Header Bar -->
-  <div class="deck-header-gradient"></div>
-  
-  <div class="deck-content">
-    <!-- Header Section with badges -->
-    <div class="deck-header-wrapper">
-      <div class="deck-header">
-        <h3 class="deck-name">{{ deck.name }}</h3>
-      </div>
-      <div class="deck-badges">
-        <div class="deck-privacy-badge" [class.public]="deck.is_public">
-          <svg *ngIf="deck.is_public" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <circle cx="12" cy="12" r="10"/>
-            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
-          </svg>
-          <svg *ngIf="!deck.is_public" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-            <circle cx="12" cy="16" r="1"/>
-            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-          </svg>
-          {{ deck.is_public ? 'Public' : 'Private' }}
-        </div>
-        <div class="save-count-badge" *ngIf="deck.is_public">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M21 8.5c0 2.485-2.239 5.318-5.443 7.667C13.478 17.654 12 18.897 12 18.897s-1.478-1.243-3.557-2.73C5.239 13.818 3 10.985 3 8.5 3 5.462 5.462 3 8.5 3c1.352 0 2.59.49 3.5 1.3.91-.81 2.148-1.3 3.5-1.3C18.538 3 21 5.462 21 8.5z"/>
-          </svg>
-          <span>{{ deck.save_count || 0 }}</span>
-        </div>
-      </div>
+  <!-- Header with title and badges -->
+  <div class="card-header">
+    <h3 class="card-title">{{ deck.name }}</h3>
+    <div class="header-badges">
+      <span class="privacy-badge" [class.public]="deck.is_public">
+        <svg *ngIf="!deck.is_public" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2z"/>
+        </svg>
+        <svg *ngIf="deck.is_public" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm7.5-6.923c-.67.204-1.335.82-1.887 1.855A7.97 7.97 0 0 0 5.145 4H7.5V1.077zM4.09 4a9.267 9.267 0 0 1 .64-1.539 6.7 6.7 0 0 1 .597-.933A7.025 7.025 0 0 0 2.255 4H4.09zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a6.958 6.958 0 0 0-.656 2.5h2.49zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5H4.847zM8.5 5v2.5h2.99a12.495 12.495 0 0 0-.337-2.5H8.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5H4.51zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5H8.5zM5.145 12c.138.386.295.744.468 1.068.552 1.035 1.218 1.65 1.887 1.855V12H5.145zm.182 2.472a6.696 6.696 0 0 1-.597-.933A9.268 9.268 0 0 1 4.09 12H2.255a7.024 7.024 0 0 0 3.072 2.472zM3.82 11a13.652 13.652 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5H3.82zm6.853 3.472A7.024 7.024 0 0 0 13.745 12H11.91a9.27 9.27 0 0 1-.64 1.539 6.688 6.688 0 0 1-.597.933zM8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855.173-.324.33-.682.468-1.068H8.5zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.65 13.65 0 0 1-.312 2.5zm2.802-3.5a6.959 6.959 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5h2.49zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7.024 7.024 0 0 0-3.072-2.472c.218.284.418.598.597.933zM10.855 4a7.966 7.966 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4h2.355z"/>
+        </svg>
+      </span>
+      <span class="save-badge" *ngIf="deck.is_public && deck.save_count">
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z"/>
+        </svg>
+        {{ deck.save_count }}
+      </span>
+    </div>
+  </div>
+
+  <!-- Description -->
+  <p class="card-description">
+    {{ deck.description || 'No description provided' }}
+  </p>
+
+  <!-- Stats with circular progress -->
+  <div class="stats-container">
+    <div class="progress-ring-container">
+      <svg class="progress-ring" viewBox="0 0 36 36">
+        <defs>
+          <linearGradient [id]="'gradient-' + deck.deck_id" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#10b981;stop-opacity:1" />
+          </linearGradient>
+        </defs>
+        <path class="circle-bg"
+          stroke="#e5e7eb"
+          stroke-width="2.5"
+          fill="none"
+          d="M18 2.0845
+            a 15.9155 15.9155 0 0 1 0 31.831
+            a 15.9155 15.9155 0 0 1 0 -31.831"
+        />
+        <path class="circle-progress"
+          [attr.stroke]="'url(#gradient-' + deck.deck_id)'
+          stroke-width="2.5"
+          stroke-linecap="round"
+          fill="none"
+          [style.stroke-dasharray]="getProgressDashArray()"
+          d="M18 2.0845
+            a 15.9155 15.9155 0 0 1 0 31.831
+            a 15.9155 15.9155 0 0 1 0 -31.831"
+        />
+        <text x="18" y="20.35" class="percentage-text">{{ getMemorizationPercentage() }}%</text>
+      </svg>
     </div>
     
-    <!-- Description -->
-    <p class="deck-description">{{ deck.description || 'No description provided' }}</p>
-    
-    <!-- Stats Row -->
-    <div class="deck-stats-row" 
-         [class.show-tooltip]="showStatsTooltip"
-         (mouseenter)="viewMode === 'my-decks' && !isMobileView && (showStatsTooltip = true)"
-         (mouseleave)="showStatsTooltip = false"
-         (click)="onStatsClick($event)">
+    <div class="stats-list">
       <div class="stat-item">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <rect x="3" y="7" width="18" height="14" rx="2"/>
-          <path d="M3 7V5a2 2 0 012-2h14a2 2 0 012 2v2M7 11h10M7 15h7"/>
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1h-11zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6v7zm1.5.5A.5.5 0 0 1 1 13V6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5h-13z"/>
         </svg>
-        <span class="stat-value">{{ getCountDisplay().cards }}</span>
+        <span class="stat-value">{{ deck.card_count }}</span>
         <span class="stat-label">cards</span>
       </div>
       
       <div class="stat-item">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <path d="M19 14l-7 7m0 0l-7-7m7 7V3"/>
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"/>
         </svg>
         <span class="stat-value">{{ getCountDisplay().verses }}</span>
         <span class="stat-label">verses</span>
       </div>
       
-      <div class="stat-item memorized" *ngIf="viewMode === 'my-decks'">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <path d="M9 11l3 3L22 4"/>
-          <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+      <div class="stat-item" *ngIf="viewMode === 'my-decks'">
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"/>
         </svg>
         <span class="stat-value">{{ deck.memorized_count || 0 }}</span>
-        <span class="stat-label">memorized</span>
+        <span class="stat-label">done</span>
       </div>
-      
-      <!-- Info icon for mobile -->
-      <div class="stats-info-icon" *ngIf="viewMode === 'my-decks' && isMobileView">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <circle cx="12" cy="12" r="10"/>
-          <line x1="12" y1="16" x2="12" y2="12"/>
-          <line x1="12" y1="8" x2="12.01" y2="8"/>
-        </svg>
-      </div>
-      
-      <!-- Stats Tooltip with Progress Chart -->
-      <div class="stats-tooltip" *ngIf="viewMode === 'my-decks' && showStatsTooltip">
-        <div class="tooltip-arrow"></div>
-        <div class="tooltip-content">
-          <h4>Memorization Progress</h4>
-          <div class="progress-chart">
-            <svg viewBox="0 0 36 36" class="circular-chart">
-              <path class="circle-bg"
-                d="M18 2.0845
-                  a 15.9155 15.9155 0 0 1 0 31.831
-                  a 15.9155 15.9155 0 0 1 0 -31.831"
-              />
-              <path class="circle"
-                [style.stroke-dasharray]="getProgressDashArray()"
-                [attr.stroke]="'url(#progress-gradient-' + deck.deck_id + ')'"
-                d="M18 2.0845
-                  a 15.9155 15.9155 0 0 1 0 31.831
-                  a 15.9155 15.9155 0 0 1 0 -31.831"
-              />
-              <text x="18" y="20.35" class="percentage">{{ getMemorizationPercentage() }}%</text>
-            </svg>
-          </div>
-          <div class="stats-details">
-            <div class="detail-row">
-              <span class="detail-label">Memorized:</span>
-              <span class="detail-value">{{ deck.memorized_count || 0 }} / {{ deck.card_count }}</span>
-            </div>
-            <div class="detail-row">
-              <span class="detail-label">Remaining:</span>
-              <span class="detail-value">{{ deck.card_count - (deck.memorized_count || 0) }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    
-    <!-- Tags and Meta Info -->
-    <div class="deck-meta-row">
-      <div class="deck-tags" *ngIf="deck.tags && deck.tags.length > 0">
-        <span 
-          class="deck-tag" 
-          *ngFor="let tag of deck.tags | slice:0:3"
-          (click)="onTagClick(tag, $event)">
-          #{{ formatTag(tag) }}
-        </span>
-        <span class="deck-tag more" *ngIf="deck.tags.length > 3">
-          +{{ deck.tags.length - 3 }}
-        </span>
-      </div>
-      
-      <div class="deck-footer-info">
-        <span *ngIf="viewMode !== 'my-decks' && deck.creator_name" class="deck-creator">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
-            <circle cx="12" cy="7" r="4"/>
-          </svg>
-          {{ deck.creator_name }}
-        </span>
-        <span class="deck-date">{{ deck.created_at | date:'MMM d' }}</span>
-      </div>
-    </div>
-
-    <!-- Actions Row -->
-    <div class="deck-actions-compact">
-      <!-- My Decks Actions -->
-      <ng-container *ngIf="viewMode === 'my-decks'">
-        <button class="action-button primary" [routerLink]="['/decks/study', deck.deck_id]">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <polygon points="5 3 19 12 5 21 5 3"/>
-          </svg>
-          Study
-        </button>
-        <div class="action-button-group">
-          <button class="action-button icon secondary" [routerLink]="['/deck-editor', deck.deck_id]" title="Edit">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-            </svg>
-          </button>
-          <button class="action-button icon danger" (click)="onDelete()" title="Delete">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <polyline points="3 6 5 6 21 6"/>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-            </svg>
-          </button>
-        </div>
-      </ng-container>
-
-      <!-- Public/Saved Decks Actions -->
-      <ng-container *ngIf="viewMode !== 'my-decks'">
-        <button class="action-button primary" [routerLink]="['/decks/study', deck.deck_id]">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <polygon points="5 3 19 12 5 21 5 3"/>
-          </svg>
-          Study
-        </button>
-        <button 
-          class="action-button secondary icon"
-          *ngIf="!deck.is_saved"
-          (click)="onSave()"
-          [disabled]="deck.saving"
-          [title]="deck.saving ? 'Saving...' : 'Save to collection'">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
-          </svg>
-        </button>
-        <button 
-          class="action-button danger icon"
-          *ngIf="deck.is_saved"
-          (click)="onUnsave()"
-          [disabled]="deck.saving"
-          [title]="deck.saving ? 'Removing...' : 'Remove from collection'">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
-          </svg>
-        </button>
-      </ng-container>
     </div>
   </div>
-  
-  <!-- SVG Definitions for Progress Gradient -->
-  <svg width="0" height="0">
-    <defs>
-      <linearGradient [id]="'progress-gradient-' + deck.deck_id" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
-        <stop offset="100%" style="stop-color:#10b981;stop-opacity:1" />
-      </linearGradient>
-    </defs>
-  </svg>
+
+  <!-- Tags -->
+  <div class="tags-row" *ngIf="deck.tags && deck.tags.length > 0">
+    <span class="tag-chip" *ngFor="let tag of deck.tags | slice:0:3" (click)="onTagClick(tag, $event)">
+      #{{ formatTag(tag) }}
+    </span>
+    <span class="tag-more" *ngIf="deck.tags.length > 3">+{{ deck.tags.length - 3 }}</span>
+  </div>
+
+  <!-- Actions -->
+  <div class="actions-row">
+    <button class="action-btn primary" [routerLink]="['/decks/study', deck.deck_id]">
+      <svg viewBox="0 0 16 16" fill="currentColor">
+        <path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z"/>
+      </svg>
+      Study
+    </button>
+    
+    <div class="action-group">
+      <button class="action-btn icon" *ngIf="viewMode === 'my-decks'" 
+              [routerLink]="['/deck-editor', deck.deck_id]" title="Edit">
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
+        </svg>
+      </button>
+      
+      <button class="action-btn icon" *ngIf="viewMode !== 'my-decks' && !deck.is_saved"
+              (click)="onSave()" [disabled]="deck.saving" title="Save">
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.777.416L8 13.101l-5.223 2.815A.5.5 0 0 1 2 15.5V2zm2-1a1 1 0 0 0-1 1v12.566l4.723-2.482a.5.5 0 0 1 .554 0L13 14.566V2a1 1 0 0 0-1-1H4z"/>
+        </svg>
+      </button>
+      
+      <button class="action-btn icon danger" 
+              (click)="viewMode === 'my-decks' ? onDelete() : onUnsave()"
+              [disabled]="deck.saving" 
+              [title]="viewMode === 'my-decks' ? 'Delete' : 'Remove'">
+        <svg viewBox="0 0 16 16" fill="currentColor">
+          <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+          <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
 </div>

--- a/frontend/src/app/features/decks/components/deck-card/deck-card.component.scss
+++ b/frontend/src/app/features/decks/components/deck-card/deck-card.component.scss
@@ -1,516 +1,313 @@
-// frontend/src/app/features/decks/components/deck-card/deck-card.component.scss
-
 @use '../../shared/styles/variables' as *;
 @use '../../shared/styles/animations' as *;
 
-// Deck Card
-.deck-card {
+.deck-card-modern {
   background: white;
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06), 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: $radius-xl;
+  padding: 1.25rem;
+  box-shadow: $shadow-card;
+  transition: all $transition-smooth;
   position: relative;
-  animation: slideUp 0.4s ease-out both;
+  overflow: hidden;
+  animation: slideUp 0.5s ease-out both;
 
   &:hover {
     transform: translateY(-4px);
-    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: $shadow-card-hover;
 
-    .deck-header-gradient {
+    .hover-gradient {
       opacity: 1;
     }
 
-    .deck-name {
-      color: #3b82f6;
+    .card-title {
+      color: $color-blue-600;
     }
   }
 }
 
-.deck-header-gradient {
+.hover-gradient {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, #3b82f6, #8b5cf6, #ec4899);
+  background: $gradient-primary;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity $transition-base;
 }
 
-// Save count badge (top right)
-.save-count-badge {
+// Header
+.card-header {
   display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+  gap: 0.5rem;
+}
+
+.card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: $text-primary;
+  margin: 0;
+  line-height: 1.3;
+  transition: color $transition-base;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.header-badges {
+  display: flex;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.privacy-badge {
+  display: inline-flex;
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: rgba(236, 72, 153, 0.1);
-  border-radius: 1rem;
-  font-size: 0.75rem;
+  border-radius: $radius-full;
+  font-size: 0.625rem;
   font-weight: 600;
+  background: #fee2e2;
+  color: #dc2626;
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  &.public {
+    background: $color-blue-50;
+    color: $color-blue-700;
+  }
+}
+
+.save-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: #fce7f3;
   color: #be185d;
-  animation: fadeIn 0.3s ease-out;
+  border-radius: $radius-full;
+  font-size: 0.625rem;
+  font-weight: 600;
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+}
+
+// Description
+.card-description {
+  color: $text-secondary;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0 0 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+// Stats Container with Progress Ring
+.stats-container {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid $border-light;
+  border-bottom: 1px solid $border-light;
+  margin-bottom: 0.75rem;
+}
+
+.progress-ring-container {
+  flex-shrink: 0;
+}
+
+.progress-ring {
+  width: 60px;
+  height: 60px;
+  transform: rotate(-90deg);
+}
+
+.circle-bg {
+  stroke: $color-slate-200;
+}
+
+.circle-progress {
+  transition: stroke-dasharray 0.6s ease;
+}
+
+.percentage-text {
+  fill: $text-primary;
+  font-size: 0.5em;
+  font-weight: 700;
+  text-anchor: middle;
+  transform: rotate(90deg);
+  transform-origin: center;
+}
+
+.stats-list {
+  display: flex;
+  gap: 1.25rem;
+  flex: 1;
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
 
   svg {
     width: 14px;
     height: 14px;
-    fill: #ec4899;
+    color: $text-muted;
+    flex-shrink: 0;
+  }
+
+  .stat-value {
+    font-weight: 700;
+    color: $text-primary;
+    font-size: 1rem;
+  }
+
+  .stat-label {
+    color: $text-muted;
+    font-size: 0.75rem;
   }
 }
 
-// Compact variant styles
-.deck-card.compact {
-  .deck-content {
+// Tags
+.tags-row {
+  display: flex;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  background: $color-blue-50;
+  color: $color-blue-700;
+  border-radius: $radius-full;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all $transition-base;
+
+  &:hover {
+    background: $color-blue-100;
+    transform: scale(1.05);
+  }
+}
+
+.tag-more {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  background: $color-slate-100;
+  color: $text-secondary;
+  border-radius: $radius-full;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+// Actions
+.actions-row {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: $radius-md;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all $transition-base;
+  text-decoration: none;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &.primary {
+    background: $gradient-primary;
+    color: white;
+    flex: 1;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba($color-blue-500, 0.3);
+    }
+  }
+
+  &.icon {
+    padding: 0.5rem;
+    background: $color-slate-50;
+    color: $text-secondary;
+
+    &:hover {
+      background: $color-slate-100;
+      color: $text-primary;
+    }
+  }
+
+  &.danger:hover {
+    background: #fef2f2;
+    color: #dc2626;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.action-group {
+  display: flex;
+  gap: 0.375rem;
+}
+
+// Responsive
+@media (max-width: 640px) {
+  .deck-card-modern {
     padding: 1rem;
   }
 
-  .deck-header-wrapper {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    margin-bottom: 0.5rem;
+  .card-title {
+    font-size: 1rem;
   }
 
-  .deck-header {
-    flex: 1;
-    margin-right: 0.5rem;
-  }
-
-  .deck-badges {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-shrink: 0;
-  }
-
-  .deck-name {
-    font-size: 1.125rem;
-    font-weight: 700;
-    color: #1e293b;
-    margin: 0;
-    line-height: 1.2;
-    transition: color 0.3s ease;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-  }
-
-  .deck-privacy-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.75rem;
-    font-size: 0.625rem;
-    font-weight: 600;
-    background: #fee2e2;
-    color: #dc2626;
-    white-space: nowrap;
-
-    svg {
-      width: 10px;
-      height: 10px;
-    }
-
-    &.public {
-      background: #dbeafe;
-      color: #1d4ed8;
-    }
-  }
-
-  .deck-description {
-    color: #64748b;
-    font-size: 0.75rem;
-    line-height: 1.4;
-    margin-bottom: 0.5rem;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    min-height: 2.1rem;
-  }
-
-  // Stats Row
-  .deck-stats-row {
-    display: flex;
-    gap: 1rem;
-    margin: 0.75rem 0;
-    padding: 0.625rem 0;
-    border-top: 1px solid #f1f5f9;
-    border-bottom: 1px solid #f1f5f9;
-    position: relative;
-    cursor: default;
-    transition: all 0.2s ease;
-
-    &.show-tooltip {
-      background: #f8fafc;
-      margin: 0.75rem -0.5rem;
-      padding: 0.625rem 0.5rem;
-      border-radius: 0.5rem;
-    }
+  .stats-list {
+    gap: 0.75rem;
   }
 
   .stat-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
-
-    svg {
-      width: 16px;
-      height: 16px;
-      color: #64748b;
-    }
-
     .stat-value {
-      font-weight: 700;
-      color: #1e293b;
-      font-size: 1.125rem;
-    }
-
-    .stat-label {
-      color: #64748b;
-      font-size: 0.8rem;
-    }
-
-    &.memorized {
-      svg {
-        color: #10b981;
-      }
-
-      .stat-value {
-        color: #059669;
-      }
+      font-size: 0.875rem;
     }
   }
 
-  // Stats Info Icon (mobile)
-  .stats-info-icon {
-    margin-left: auto;
-    color: #94a3b8;
-
-    svg {
-      width: 16px;
-      height: 16px;
-    }
-  }
-
-  // Stats Tooltip
-  .stats-tooltip {
-    position: absolute;
-    bottom: calc(100% + 0.75rem);
-    left: 50%;
-    transform: translateX(-50%);
-    background: white;
-    border-radius: 0.75rem;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
-    padding: 1.25rem;
-    min-width: 250px;
-    z-index: 100;
-    animation: fadeIn 0.2s ease-out;
-
-    .tooltip-arrow {
-      position: absolute;
-      bottom: -6px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 12px;
-      height: 12px;
-      background: white;
-      transform: translateX(-50%) rotate(45deg);
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.1);
-    }
-
-    .tooltip-content {
-      position: relative;
-      z-index: 1;
-
-      h4 {
-        font-size: 0.875rem;
-        font-weight: 600;
-        color: #334155;
-        margin: 0 0 1rem;
-        text-align: center;
-      }
-    }
-
-    .progress-chart {
-      width: 120px;
-      height: 120px;
-      margin: 0 auto 1rem;
-    }
-
-    .circular-chart {
-      display: block;
-      margin: 0 auto;
-      max-width: 100%;
-      max-height: 100%;
-    }
-
-    .circle-bg {
-      fill: none;
-      stroke: #e5e7eb;
-      stroke-width: 2.8;
-    }
-
-    .circle {
-      fill: none;
-      stroke-width: 2.8;
-      stroke-linecap: round;
-      animation: progress 1s ease-out forwards;
-      stroke-dasharray: 0 100;
-      transform: rotate(-90deg);
-      transform-origin: center;
-    }
-
-    .percentage {
-      fill: #1e293b;
-      font-size: 0.6em;
-      text-anchor: middle;
-      font-weight: 700;
-    }
-
-    .stats-details {
-      .detail-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.375rem 0;
-        font-size: 0.8rem;
-
-        &:not(:last-child) {
-          border-bottom: 1px solid #f1f5f9;
-        }
-
-        .detail-label {
-          color: #64748b;
-        }
-
-        .detail-value {
-          font-weight: 600;
-          color: #1e293b;
-        }
-      }
-    }
-  }
-
-  .deck-meta-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .deck-tags {
-    display: flex;
-    gap: 0.25rem;
-    flex: 1;
-    overflow: hidden;
-  }
-
-  .deck-tag {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.125rem 0.375rem;
-    background: #e0e7ff;
-    color: #4338ca;
-    border-radius: 0.375rem;
-    font-size: 0.625rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-
-    &:hover {
-      transform: scale(1.05);
-      background: #c7d2fe;
-    }
-
-    &.more {
-      background: #f3f4f6;
-      color: #6b7280;
-      cursor: default;
-
-      &:hover {
-        transform: none;
-      }
-    }
-  }
-
-  .deck-footer-info {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.625rem;
-    color: #94a3b8;
-    flex-shrink: 0;
-
-    span {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-      white-space: nowrap;
-    }
-
-    svg {
-      width: 10px;
-      height: 10px;
-    }
-  }
-
-  // Compact Actions at bottom
-  .deck-actions-compact {
-    display: flex;
-    gap: 0.375rem;
-    padding-top: 0.5rem;
-
-    .action-button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.25rem;
-      padding: 0.375rem 0.75rem;
-      border-radius: 0.5rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      text-decoration: none;
-      border: none;
-
-      svg {
-        width: 12px;
-        height: 12px;
-      }
-
-      &.primary {
-        background: $gradient-primary;
-        color: white;
-        box-shadow: 0 1px 3px rgba(59, 130, 246, 0.3);
-        flex: 1;
-
-        &:hover {
-          transform: translateY(-1px);
-          box-shadow: 0 2px 6px rgba(59, 130, 246, 0.4);
-        }
-      }
-
-      &.secondary {
-        background: white;
-        color: #64748b;
-        border: 1.5px solid #e2e8f0;
-
-        &:hover {
-          background: #f8fafc;
-          color: #334155;
-          border-color: #cbd5e1;
-        }
-      }
-
-      &.danger {
-        background: white;
-        color: #dc2626;
-        border: 1.5px solid #fecaca;
-
-        &:hover {
-          background: #fef2f2;
-          border-color: #fca5a5;
-        }
-      }
-
-      &.icon {
-        padding: 0.375rem;
-        min-width: auto;
-      }
-
-      &:disabled {
-        opacity: 0.6;
-        cursor: not-allowed;
-        transform: none !important;
-      }
-    }
-
-    .action-button-group {
-      display: flex;
-      gap: 0.25rem;
-    }
-  }
-}
-
-// Responsive Design
-@media (max-width: 640px) {
-  .deck-card.compact {
-    .deck-content {
-      padding: 0.875rem;
-    }
-
-    .deck-stats-row {
-      gap: 0.75rem;
-      cursor: pointer;
-      
-      &:hover {
-        background: #f8fafc;
-      }
-      
-      .stat-item {
-        font-size: 0.8rem;
-        
-        svg {
-          width: 14px;
-          height: 14px;
-        }
-        
-        .stat-value {
-          font-size: 1rem;
-        }
-      }
-    }
-
-    .stats-tooltip {
-      left: 0;
-      right: 0;
-      transform: none;
-      margin: 0 0.5rem;
-      width: auto;
-      min-width: unset;
-
-      .tooltip-arrow {
-        left: 25%;
-      }
-    }
-
-    .deck-meta-row {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.375rem;
-    }
-
-    .deck-tags {
-      width: 100%;
-    }
-
-    .deck-actions-compact {
-      .action-button {
-        font-size: 0.7rem;
-        padding: 0.375rem 0.5rem;
-        
-        &.secondary,
-        &.danger {
-          &:not(.icon) {
-            display: none;
-          }
-        }
-      }
-    }
-  }
-}
-
-// Animations
-@keyframes progress {
-  to {
-    stroke-dasharray: 100 100;
+  .progress-ring {
+    width: 50px;
+    height: 50px;
   }
 }

--- a/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.html
+++ b/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.html
@@ -1,0 +1,27 @@
+<div class="hero-card">
+  <div class="hero-gradient"></div>
+  <div class="hero-pattern"></div>
+  
+  <div class="hero-content">
+    <div class="streak-badge" *ngIf="streakDays > 0">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+              d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+      </svg>
+      <span>{{ streakDays }} day streak!</span>
+    </div>
+    
+    <h2 class="hero-title">Keep your momentum—pick up where you left off</h2>
+    
+    <p class="hero-subtitle" *ngIf="nextDeck">
+      Next up: <span class="deck-name">{{ nextDeck.name }}</span>
+    </p>
+    
+    <button class="continue-button" (click)="onContinueClick()" [disabled]="!nextDeck">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <polygon points="5 3 19 12 5 21 5 3"></polygon>
+      </svg>
+      Continue Studying
+    </button>
+  </div>
+</div>

--- a/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.scss
+++ b/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.scss
@@ -1,0 +1,129 @@
+@use '../../shared/styles/variables' as *;
+@use '../../shared/styles/animations' as *;
+
+.hero-card {
+  position: relative;
+  overflow: hidden;
+  background: white;
+  border-radius: $radius-2xl;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: $shadow-md;
+  animation: slideUp 0.6s ease-out;
+
+  @media (max-width: 768px) {
+    padding: 1.5rem;
+    border-radius: $radius-xl;
+  }
+}
+
+.hero-gradient {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: $gradient-hero;
+  opacity: 0.5;
+  animation: gentleFloat 20s ease-in-out infinite;
+}
+
+.hero-pattern {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+}
+
+.streak-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.875rem;
+  background: rgba(white, 0.7);
+  backdrop-filter: blur(10px);
+  border-radius: $radius-full;
+  color: $color-sky-700;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: $shadow-sm;
+  animation: scaleIn 0.4s ease-out 0.3s both;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    color: #f59e0b;
+    fill: #fbbf24;
+  }
+}
+
+.hero-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: $text-primary;
+  margin: 0.5rem 0;
+  line-height: 1.4;
+
+  @media (max-width: 768px) {
+    font-size: 1.25rem;
+  }
+}
+
+.hero-subtitle {
+  font-size: 1rem;
+  color: $text-secondary;
+  margin: 0;
+
+  .deck-name {
+    font-weight: 600;
+    color: $color-blue-600;
+  }
+}
+
+.continue-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.75rem 1.5rem;
+  background: $gradient-primary;
+  color: white;
+  border: none;
+  border-radius: $radius-lg;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba($color-blue-500, 0.3);
+  transition: all $transition-smooth;
+  margin-top: 0.5rem;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba($color-blue-500, 0.4);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.ts
+++ b/frontend/src/app/features/decks/components/deck-hero/deck-hero.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+interface NextDeck {
+  deck_id: number;
+  name: string;
+  progress: number;
+}
+
+@Component({
+  selector: 'app-deck-hero',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './deck-hero.component.html',
+  styleUrls: ['./deck-hero.component.scss']
+})
+export class DeckHeroComponent {
+  @Input() nextDeck: NextDeck | null = null;
+  @Input() streakDays: number = 0;
+  @Output() continueStudy = new EventEmitter<number>();
+
+  onContinueClick() {
+    if (this.nextDeck) {
+      this.continueStudy.emit(this.nextDeck.deck_id);
+    }
+  }
+}

--- a/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.html
+++ b/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.html
@@ -1,0 +1,8 @@
+<div class="metrics-grid">
+  <div class="metric-card" *ngFor="let metric of metrics; let i = index" 
+       [style.animation-delay.ms]="i * 100"
+       [attr.data-color]="metric.color">
+    <div class="metric-value">{{ metric.value }}</div>
+    <div class="metric-label">{{ metric.label }}</div>
+  </div>
+</div>

--- a/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.scss
+++ b/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.scss
@@ -1,0 +1,66 @@
+@use '../../shared/styles/variables' as *;
+@use '../../shared/styles/animations' as *;
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+
+  @media (max-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+}
+
+.metric-card {
+  background: white;
+  border-radius: $radius-xl;
+  padding: 1.25rem;
+  text-align: center;
+  box-shadow: $shadow-sm;
+  border: 1px solid $border-light;
+  transition: all $transition-smooth;
+  animation: slideUp 0.5s ease-out both;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: $shadow-md;
+  }
+
+  &[data-color="blue"] {
+    border-top: 3px solid $color-blue-500;
+  }
+
+  &[data-color="teal"] {
+    border-top: 3px solid $color-teal-500;
+  }
+
+  &[data-color="emerald"] {
+    border-top: 3px solid $color-emerald-500;
+  }
+
+  &[data-color="sky"] {
+    border-top: 3px solid $color-sky-500;
+  }
+}
+
+.metric-value {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: $text-primary;
+  line-height: 1;
+  margin-bottom: 0.25rem;
+
+  @media (max-width: 640px) {
+    font-size: 1.5rem;
+  }
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}

--- a/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.ts
+++ b/frontend/src/app/features/decks/components/deck-metrics/deck-metrics.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface Metric {
+  label: string;
+  value: number | string;
+  icon?: string;
+  color?: string;
+}
+
+@Component({
+  selector: 'app-deck-metrics',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './deck-metrics.component.html',
+  styleUrls: ['./deck-metrics.component.scss']
+})
+export class DeckMetricsComponent {
+  @Input() totalDecks: number = 0;
+  @Input() totalCards: number = 0;
+  @Input() totalMemorized: number = 0;
+  @Input() averageProgress: number = 0;
+
+  get metrics(): Metric[] {
+    return [
+      { label: 'Decks', value: this.totalDecks, color: 'blue' },
+      { label: 'Cards', value: this.totalCards, color: 'teal' },
+      { label: 'Memorized', value: this.totalMemorized, color: 'emerald' },
+      { label: 'Avg Progress', value: `${this.averageProgress}%`, color: 'sky' }
+    ];
+  }
+}

--- a/frontend/src/app/features/decks/deck-study/deck-study.component.scss
+++ b/frontend/src/app/features/decks/deck-study/deck-study.component.scss
@@ -4,7 +4,7 @@
 
 .study-container {
   min-height: 100vh;
-  background: $gradient-background;
+  background: $bg-primary;
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/app/features/decks/pages/deck-list-page/deck-list-page.component.html
+++ b/frontend/src/app/features/decks/pages/deck-list-page/deck-list-page.component.html
@@ -1,9 +1,25 @@
 <!-- frontend/src/app/features/decks/pages/deck-list-page/deck-list-page.component.html -->
 <div class="flashcard-container">
+  <!-- Add Hero Section -->
+  <app-deck-hero
+    [nextDeck]="getNextDeck()"
+    [streakDays]="userStreakDays"
+    (continueStudy)="onContinueStudy($event)">
+  </app-deck-hero>
+
+  <!-- Page Header -->
   <div class="page-header">
-    <h2 class="page-title">Flashcard Decks</h2>
+    <h1 class="page-title">Flashcard Decks</h1>
     <p class="page-subtitle">Organize and study your scripture verses with personalized flashcard decks</p>
   </div>
+
+  <!-- Add Metrics Section -->
+  <app-deck-metrics
+    [totalDecks]="getTotalDecks()"
+    [totalCards]="getTotalCards()"
+    [totalMemorized]="getTotalMemorized()"
+    [averageProgress]="getAverageProgress()">
+  </app-deck-metrics>
 
   <div class="content-wrapper">
     <!-- Tab Navigation -->

--- a/frontend/src/app/features/decks/pages/deck-list-page/deck-list-page.component.scss
+++ b/frontend/src/app/features/decks/pages/deck-list-page/deck-list-page.component.scss
@@ -6,36 +6,44 @@
 // Main Container
 .flashcard-container {
   min-height: 100vh;
-  background: $gradient-background;
+  background: $bg-primary;
+  padding: 2rem 1rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem 0.5rem;
+  }
 }
 
 .page-header {
   text-align: center;
-  margin-bottom: 1.5rem;
-}
+  margin: 2rem 0 1.5rem;
+  animation: fadeIn 0.6s ease-out 0.2s both;
 
-.page-title {
-  font-size: 1.75rem;
-  font-weight: 600;
-  color: #1f2937;
-  margin: 0 0 0.25rem 0;
-}
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    color: $text-primary;
+    margin: 0 0 0.5rem;
 
-.page-subtitle {
-  color: #6b7280;
-  margin: 0;
-  font-size: 1rem;
+    @media (max-width: 768px) {
+      font-size: 1.5rem;
+    }
+  }
+
+  .page-subtitle {
+    font-size: 1rem;
+    color: $text-secondary;
+    margin: 0;
+    max-width: 600px;
+    margin: 0 auto;
+  }
 }
 
 // Content Wrapper
 .content-wrapper {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 1.5rem 3rem;
-  
-  @media (max-width: 768px) {
-    padding: 0 1rem 2rem;
-  }
+  animation: fadeIn 0.6s ease-out 0.4s both;
 }
 
 // Tab Navigation
@@ -229,7 +237,8 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 1.25rem;
-  
+  margin-top: 1.5rem;
+
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
     gap: 1rem;

--- a/frontend/src/app/features/decks/shared/styles/_variables.scss
+++ b/frontend/src/app/features/decks/shared/styles/_variables.scss
@@ -1,71 +1,79 @@
 // frontend/src/app/features/decks/shared/styles/_variables.scss
-// Gradients
+
+// Light Theme Colors (matching React template)
+$color-sky-50: #f0f9ff;
+$color-sky-100: #e0f2fe;
+$color-sky-500: #0ea5e9;
+$color-sky-600: #0284c7;
+$color-sky-700: #0369a1;
+
+$color-teal-50: #f0fdfa;
+$color-teal-100: #ccfbf1;
+$color-teal-500: #14b8a6;
+$color-teal-600: #0d9488;
+
+$color-emerald-50: #ecfdf5;
+$color-emerald-500: #10b981;
+$color-emerald-600: #059669;
+
+$color-blue-50: #eff6ff;
+$color-blue-100: #dbeafe;
+$color-blue-500: #3b82f6;
+$color-blue-600: #2563eb;
+$color-blue-700: #1d4ed8;
+
+$color-slate-50: #f8fafc;
+$color-slate-100: #f1f5f9;
+$color-slate-200: #e2e8f0;
+$color-slate-300: #cbd5e1;
+$color-slate-400: #94a3b8;
+$color-slate-500: #64748b;
+$color-slate-600: #475569;
+$color-slate-700: #334155;
+$color-slate-800: #1e293b;
+
+// Gradients (React template style)
 $gradient-primary: linear-gradient(135deg, #3b82f6 0%, #10b981 100%);
-$gradient-secondary: linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%);
-$gradient-danger: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-$gradient-success: linear-gradient(135deg, #10b981 0%, #059669 100%);
-$gradient-background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+$gradient-hero: linear-gradient(135deg, 
+  rgba(14, 165, 233, 0.05) 0%, 
+  rgba(20, 184, 166, 0.05) 50%,
+  rgba(16, 185, 129, 0.05) 100%);
+$gradient-card-hover: linear-gradient(135deg, #f0f9ff 0%, #f0fdfa 100%);
+$gradient-progress: linear-gradient(135deg, #3b82f6 0%, #10b981 100%);
 
-// Colors
-$color-primary: #3b82f6;
-$color-secondary: #8b5cf6;
-$color-success: #10b981;
-$color-danger: #ef4444;
-$color-warning: #f59e0b;
+// Background
+$bg-primary: $color-slate-50;
+$bg-card: white;
+$bg-hover: $color-slate-50;
 
-// Text Colors
-$text-primary: #1e293b;
-$text-secondary: #64748b;
-$text-muted: #94a3b8;
+// Text
+$text-primary: $color-slate-800;
+$text-secondary: $color-slate-600;
+$text-muted: $color-slate-500;
+$text-light: $color-slate-400;
 
-// Border Colors
-$border-light: #e2e8f0;
-$border-medium: #cbd5e1;
-$border-dark: #94a3b8;
+// Borders
+$border-light: $color-slate-200;
+$border-medium: $color-slate-300;
 
-// Background Colors
-$bg-white: #ffffff;
-$bg-light: #f8fafc;
-$bg-medium: #f1f5f9;
-$bg-dark: #e2e8f0;
-
-// Shadows
-$shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-$shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-$shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-$shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
-$shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+// Shadows (softer, matching React)
+$shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+$shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+$shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+$shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1);
+$shadow-card: 0 2px 4px rgba(0, 0, 0, 0.06), 0 4px 6px rgba(0, 0, 0, 0.1);
+$shadow-card-hover: 0 12px 20px rgba(0, 0, 0, 0.1);
 
 // Border Radius
 $radius-sm: 0.375rem;
 $radius-md: 0.5rem;
 $radius-lg: 0.75rem;
 $radius-xl: 1rem;
-$radius-2xl: 1.25rem;
+$radius-2xl: 1.5rem;
 $radius-full: 9999px;
-
-// Spacing
-$space-1: 0.25rem;
-$space-2: 0.5rem;
-$space-3: 0.75rem;
-$space-4: 1rem;
-$space-5: 1.25rem;
-$space-6: 1.5rem;
-$space-8: 2rem;
-$space-10: 2.5rem;
-$space-12: 3rem;
-$space-16: 4rem;
 
 // Transitions
 $transition-fast: 0.15s ease;
 $transition-base: 0.2s ease;
-$transition-slow: 0.3s ease;
-$transition-slower: 0.5s ease;
+$transition-smooth: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
-// Z-index
-$z-base: 1;
-$z-dropdown: 10;
-$z-sticky: 50;
-$z-overlay: 100;
-$z-modal: 1000;
-$z-tooltip: 1100;


### PR DESCRIPTION
## Summary
- revamp deck cards with circular progress indicators and refreshed styling
- introduce hero banner and metrics summary components
- apply new light theme variables and update deck list layout

## Testing
- `npm test -- --watch=false` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee9349508331861d02fbde70ff72